### PR TITLE
Update for control of low-rank compression in RIRPA functionality.

### DIFF
--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -203,14 +203,20 @@ def build_se_moments_drpa_opt(
         Initial `a` value, see `Vayesta` for more details.  Default
         value is 10.
     compress : int, optional
-        How thoroughly to attempt compression of the low-rank representations of various matrices.
+        How thoroughly to attempt compression of the low-rank
+        representations of various matrices.
         Thresholds are:
-        - above 0: Compress representation of (A+B)(A-B) once constructed, prior to main calculation.
-        - above 3: Compress representations of A+B and A-B separately prior to constructing (A+B)(A-B) or (A+B)^{-1}
-        - above 5: Compress representation of (A+B)^{-1} prior to contracting. This is basically never worthwhile.
-        Note that in all cases these compressions will have computational cost O(N_{aux}^2 ov), the same as our later
-        computations, and so a tradeoff must be made between reducing the N_{aux} in later calculations vs the cost
-        of compression. Default value is 0.
+        - above 0: Compress representation of (A+B)(A-B) once
+          constructed, prior to main calculation.
+        - above 3: Compress representations of A+B and A-B separately
+          prior to constructing (A+B)(A-B) or (A+B)^{-1}
+        - above 5: Compress representation of (A+B)^{-1} prior to
+          contracting. This is basically never worthwhile.
+        Note that in all cases these compressions will have
+        computational cost O(N_{aux}^2 ov), the same as our later
+        computations, and so a tradeoff must be made between reducing
+        the N_{aux} in later calculations vs the cost of compression.
+        Default value is 0.
 
     Returns
     -------


### PR DESCRIPTION
This adds a parameter `compress` to `rpa.build_se_moments_drpa` which determines how many attempts will be made to compress the low-rank representation within RIRPA, bringing the optionality here in line with Vayesta after [this](https://github.com/BoothGroup/Vayesta/pull/77) PR.
This should reduce the overhead from attempted compression of the low-rank representation to basically nothing. I haven't got `dyson` set up on my current machine so haven't run the tests locally, though given the nature of it it's hopefully low-risk. Note that this will currently result in no compression attempts unless `compress` is passed as a kwarg to `GW.build_se_moments`, but that's optimal for current system sizes anyway.