### PR TITLE
k-space TDA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: python "3.10" on ubuntu-latest
+    name: python "3.11" on ubuntu-latest
     runs-on: ubuntu-latest
 
     strategy:
@@ -20,7 +20,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Upgrade pip
         run: |
           python -m pip install --upgrade pip

--- a/examples/03-qsgw.py
+++ b/examples/03-qsgw.py
@@ -34,3 +34,12 @@ gw.kernel(nmom_max=3)
 gw = qsGW(mf)
 gw.solver_options = dict(optimise_chempot=True, fock_loop=True)
 gw.kernel(nmom_max=3)
+
+# qsGW finds a self-consistent Green's function in the space defined
+# by the moment expansion, and via quasiparticle self-consistency
+# obtains a (different) set of single particle Koopmans states. Both
+# of these can be accessed via the `gw` object:
+print("QP energies:")
+print(gw.qp_energy)
+print("GF energies:")
+print(gw.gf.energy)

--- a/examples/11-srg_qsgw_s_parameter.py
+++ b/examples/11-srg_qsgw_s_parameter.py
@@ -40,7 +40,7 @@ else:
 
 # GW
 gw = GW(mf)
-_, gf, se = gw.kernel(nmom_max)
+_, gf, se, _ = gw.kernel(nmom_max)
 gf.remove_uncoupled(tol=0.8)
 if which == "ip":
     gw_eta = -gf.get_occupied().energy.max() * HARTREE2EV
@@ -50,7 +50,7 @@ else:
 # qsGW
 gw = qsGW(mf)
 gw.eta = 0.05
-_, gf, se = gw.kernel(nmom_max)
+_, gf, se, _ = gw.kernel(nmom_max)
 gf.remove_uncoupled(tol=0.8)
 if which == "ip":
     qsgw_eta = -np.max(gw.qp_energy[mf.mo_occ > 0]) * HARTREE2EV
@@ -72,7 +72,7 @@ for s in s_params:
     gw.diis_space = 10
     gw.conv_tol = 1e-5
     gw.conv_tol_moms = 1
-    conv, gf, se = gw.kernel(nmom_max, moments=moments)
+    conv, gf, se, _ = gw.kernel(nmom_max, moments=moments)
     moments = (
             se.get_occupied().moment(range(nmom_max+1)),
             se.get_virtual().moment(range(nmom_max+1)),

--- a/examples/11-srg_qsgw_s_parameter.py
+++ b/examples/11-srg_qsgw_s_parameter.py
@@ -53,9 +53,9 @@ gw.eta = 0.05
 _, gf, se = gw.kernel(nmom_max)
 gf.remove_uncoupled(tol=0.8)
 if which == "ip":
-    qsgw_eta = -gf.get_occupied().energy.max() * HARTREE2EV
+    qsgw_eta = -np.max(gw.qp_energy[mf.mo_occ > 0]) * HARTREE2EV
 else:
-    qsgw_eta = gf.get_virtual().energy.min() * HARTREE2EV
+    qsgw_eta = np.min(gw.qp_energy[mf.mo_occ == 0]) * HARTREE2EV
 
 # SRG-qsGW
 s_params = sorted(list(data.keys()))[::-1]
@@ -79,9 +79,9 @@ for s in s_params:
     )
     gf.remove_uncoupled(tol=0.8)
     if which == "ip":
-        qsgw_srg.append(-gf.get_occupied().energy.max() * HARTREE2EV)
+        qsgw_srg.append(-np.max(gw.qp_energy[mf.mo_occ > 0]) * HARTREE2EV)
     else:
-        qsgw_srg.append(gf.get_virtual().energy.min() * HARTREE2EV)
+        qsgw_srg.append(np.min(gw.qp_energy[mf.mo_occ == 0]) * HARTREE2EV)
 
 qsgw_srg = np.array(qsgw_srg)
 

--- a/examples/30-ktda.py
+++ b/examples/30-ktda.py
@@ -1,0 +1,44 @@
+"""Example of running k-space GW calculations with dTDA screening.
+"""
+
+import numpy as np
+from pyscf.pbc import gto, dft
+from momentGW.pbc.gw import KGW
+from momentGW.pbc.qsgw import qsKGW
+from momentGW.pbc.evgw import evKGW
+from momentGW.pbc.scgw import scKGW
+
+cell = gto.Cell()
+cell.atom = "He 0 0 0; He 1 1 1"
+cell.a = np.eye(3) * 3
+cell.basis = "6-31g"
+cell.verbose = 5
+cell.build()
+
+kpts = cell.make_kpts([2, 2, 2])
+
+mf = dft.KRKS(cell, kpts)
+mf = mf.density_fit()
+mf.xc = "hf"
+mf.kernel()
+
+# KGW
+gw = KGW(mf)
+gw.polarizability = "dtda"
+gw.kernel(nmom_max=5)
+
+# qsKGW
+gw = qsKGW(mf)
+gw.polarizability = "dtda"
+gw.srg = 100
+gw.kernel(nmom_max=1)
+
+# evKGW
+gw = evKGW(mf)
+gw.polarizability = "dtda"
+gw.kernel(nmom_max=1)
+
+# scKGW
+gw = scKGW(mf)
+gw.polarizability = "dtda"
+gw.kernel(nmom_max=1)

--- a/examples/31-kpt_interpolation.py
+++ b/examples/31-kpt_interpolation.py
@@ -1,0 +1,55 @@
+"""Example of interpolation of a GW calculation onto a new k-point mesh.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from pyscf.pbc import gto, dft
+from momentGW.pbc.gw import KGW
+
+cell = gto.Cell()
+cell.atom = "H 0 0 0; H 0 0 1"
+cell.a = np.array([[25, 0, 0], [0, 25, 0], [0, 0, 2]])
+cell.basis = "sto6g"
+cell.max_memory = 1e10
+cell.verbose = 5
+cell.build()
+
+kmesh1 = [1, 1, 3]
+kmesh2 = [1, 1, 9]
+kpts1 = cell.make_kpts(kmesh1)
+kpts2 = cell.make_kpts(kmesh2)
+
+mf1 = dft.KRKS(cell, kpts1, xc="hf")
+mf1 = mf1.density_fit(auxbasis="weigend")
+mf1.exxdiv = None
+mf1.conv_tol = 1e-10
+mf1.kernel()
+
+mf2 = dft.KRKS(cell, kpts2, xc="hf")
+mf2 = mf2.density_fit(mf1.with_df.auxbasis)
+mf2.exxdiv = mf1.exxdiv
+mf2.conv_tol = mf1.conv_tol
+mf2.kernel()
+
+gw1 = KGW(mf1)
+gw1.polarizability = "dtda"
+gw1.kernel(5)
+
+gw2 = gw1.interpolate(mf2, 5)
+
+e1 = gw1.qp_energy
+e2 = gw2.qp_energy
+
+
+def get_xy(kpts, e):
+    kpts = kpts.wrap_around(kpts._kpts)[:, 2]
+    arg = np.argsort(kpts)
+    return kpts[arg], np.array(e)[arg]
+
+plt.figure()
+plt.plot(*get_xy(gw1.kpts, e1), "C0.-", label="original")
+plt.plot(*get_xy(gw2.kpts, e2), "C2.-", label="interpolated")
+handles, labels = plt.gca().get_legend_handles_labels()
+by_label = dict(zip(labels, handles))
+plt.legend(by_label.values(), by_label.keys())
+plt.show()

--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -53,3 +53,4 @@ from momentGW.evgw import evGW
 from momentGW.scgw import scGW
 from momentGW.qsgw import qsGW
 from momentGW.pbc.gw import KGW
+from momentGW.pbc.evgw import evKGW

--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -52,3 +52,4 @@ from momentGW.gw import GW
 from momentGW.evgw import evGW
 from momentGW.scgw import scGW
 from momentGW.qsgw import qsGW
+from momentGW.pbc.gw import KGW

--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -54,3 +54,4 @@ from momentGW.scgw import scGW
 from momentGW.qsgw import qsGW
 from momentGW.pbc.gw import KGW
 from momentGW.pbc.evgw import evKGW
+from momentGW.pbc.qsgw import qsKGW

--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -55,3 +55,4 @@ from momentGW.qsgw import qsGW
 from momentGW.pbc.gw import KGW
 from momentGW.pbc.evgw import evKGW
 from momentGW.pbc.qsgw import qsKGW
+from momentGW.pbc.scgw import scKGW

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -3,6 +3,7 @@ Base class for moment-constrained GW solvers.
 """
 
 import warnings
+
 import numpy as np
 from pyscf import lib
 from pyscf.lib import logger

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -124,6 +124,53 @@ class BaseGW(lib.StreamObject):
     def solve_dyson(self, *args, **kwargs):
         raise NotImplementedError
 
+    def _kernel(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def kernel(
+        self,
+        nmom_max,
+        mo_energy=None,
+        mo_coeff=None,
+        moments=None,
+        integrals=None,
+    ):
+        if mo_coeff is None:
+            mo_coeff = self.mo_coeff
+        if mo_energy is None:
+            mo_energy = self.mo_energy
+
+        cput0 = (logger.process_clock(), logger.perf_counter())
+        self.dump_flags()
+        logger.info(self, "nmom_max = %d", nmom_max)
+
+        self.converged, self.gf, self.se, self._qp_energy = self._kernel(
+            nmom_max,
+            mo_energy,
+            mo_coeff,
+            integrals=integrals,
+        )
+
+        gf_occ = self.gf.get_occupied()
+        gf_occ.remove_uncoupled(tol=1e-1)
+        for n in range(min(5, gf_occ.naux)):
+            en = -gf_occ.energy[-(n + 1)]
+            vn = gf_occ.coupling[:, -(n + 1)]
+            qpwt = np.linalg.norm(vn) ** 2
+            logger.note(self, "IP energy level %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
+
+        gf_vir = self.gf.get_virtual()
+        gf_vir.remove_uncoupled(tol=1e-1)
+        for n in range(min(5, gf_vir.naux)):
+            en = gf_vir.energy[n]
+            vn = gf_vir.coupling[:, n]
+            qpwt = np.linalg.norm(vn) ** 2
+            logger.note(self, "EA energy level %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
+
+        logger.timer(self, self.name, *cput0)
+
+        return self.converged, self.gf, self.se, self.qp_energy
+
     @staticmethod
     def _moment_error(t, t_prev):
         """Compute scaled error between moments."""

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -2,6 +2,7 @@
 Base class for moment-constrained GW solvers.
 """
 
+import warnings
 import numpy as np
 from pyscf import lib
 from pyscf.lib import logger
@@ -21,9 +22,6 @@ class BaseGW(lib.StreamObject):
     polarizability : str, optional
         Type of polarizability to use, can be one of `("drpa",
         "drpa-exact", "dtda").  Default value is `"drpa"`.
-    vhf_df : bool, optional
-        If True, calculate the static self-energy directly from `Lpq`.
-        Default value is False.
     npoints : int, optional
         Number of numerical integration points.  Default value is `48`.
     optimise_chempot : bool, optional
@@ -53,7 +51,6 @@ class BaseGW(lib.StreamObject):
 
     diagonal_se = False
     polarizability = "drpa"
-    vhf_df = False
     npoints = 48
     optimise_chempot = False
     fock_loop = False
@@ -71,7 +68,6 @@ class BaseGW(lib.StreamObject):
     _opts = [
         "diagonal_se",
         "polarizability",
-        "vhf_df",
         "npoints",
         "optimise_chempot",
         "fock_loop",
@@ -85,6 +81,9 @@ class BaseGW(lib.StreamObject):
         self.verbose = self.mol.verbose
         self.stdout = self.mol.stdout
         self.max_memory = 1e10
+
+        if kwargs.pop("vhf_df", None) is not None:
+            warnings.warn("Keyword argument vhf_df is deprecated.", DeprecationWarning)
 
         for key, val in kwargs.items():
             if not hasattr(self, key):

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -197,6 +197,20 @@ class BaseGW(lib.StreamObject):
 
         return occ
 
+    @staticmethod
+    def _gf_to_energy(gf):
+        """Return the `energy` attribute of a `gf`. Allows hooking in
+        `pbc` methods to retain syntax.
+        """
+        return gf.energy
+
+    @staticmethod
+    def _gf_to_coupling(gf):
+        """Return the `coupling` attribute of a `gf`. Allows hooking in
+        `pbc` methods to retain syntax.
+        """
+        return gf.coupling
+
     def _gf_to_mo_energy(self, gf):
         """Find the poles of a GF which best overlap with the MOs.
 

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -127,6 +127,9 @@ class BaseGW(lib.StreamObject):
     def _moment_error(t, t_prev):
         """Compute scaled error between moments."""
 
+        if t_prev is None:
+            t_prev = np.zeros_like(t)
+
         error = 0
         for a, b in zip(t, t_prev):
             a = a / max(np.max(np.abs(a)), 1)

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -264,6 +264,17 @@ class BaseGW(lib.StreamObject):
             raise ValueError("GW solvers require density fitting.")
         return self._scf.with_df
 
+    @property
+    def has_fock_loop(self):
+        """
+        Returns a boolean indicating whether the solver requires a Fock
+        loop. For most GW methods, this is simply `self.fock_loop`. In
+        some methods such as qsGW, a Fock loop is required with or
+        without `self.fock_loop` for the quasiparticle self-consistency,
+        with this property acting as a hook to indicate this.
+        """
+        return self.fock_loop
+
     get_nmo = get_nmo
     get_nocc = get_nocc
     get_frozen_mask = get_frozen_mask

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -109,7 +109,7 @@ def kernel(
 
         # Update the MO energies
         mo_energy_prev = mo_energy.copy()
-        mo_energy = gw.update_mo_energy(gf)
+        mo_energy = gw._gf_to_mo_energy(gf)
 
         # Check for convergence
         conv = gw.check_convergence(mo_energy, mo_energy_prev, th, th_prev, tp, tp_prev)
@@ -177,22 +177,6 @@ class evGW(GW):
     @property
     def name(self):
         return "evG%sW%s" % ("0" if self.g0 else "", "0" if self.w0 else "")
-
-    def update_mo_energy(self, gf):
-        """Update the eigenvalues."""
-
-        check = set()
-        mo_energy = np.zeros_like(self.mo_energy)
-
-        for i in range(self.nmo):
-            arg = np.argmax(gf.coupling[i] ** 2)
-            mo_energy[i] = gf.energy[arg]
-            check.add(arg)
-
-        if len(check) != self.nmo:
-            logger.warn(self, "Inconsistent quasiparticle weights!")
-
-        return mo_energy
 
     def check_convergence(self, mo_energy, mo_energy_prev, th, th_prev, tp, tp_prev):
         """Check for convergence, and print a summary of changes."""

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -63,8 +63,6 @@ def kernel(
     if integrals is None:
         integrals = gw.ao2mo()
 
-    nmo = gw.nmo
-    nocc = gw.nocc
     mo_energy = mo_energy.copy()
     mo_energy_ref = mo_energy.copy()
 

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -58,7 +58,6 @@ def kernel(
 
     if integrals is None:
         integrals = gw.ao2mo(mo_coeff)
-    Lpq, Lia = integrals
 
     nmo = gw.nmo
     nocc = gw.nocc
@@ -70,7 +69,6 @@ def kernel(
 
     # Get the static part of the SE
     se_static = gw.build_se_static(
-        Lpq=Lpq,
         mo_energy=mo_energy,
         mo_coeff=mo_coeff,
     )
@@ -86,8 +84,7 @@ def kernel(
         else:
             th, tp = gw.build_se_moments(
                 nmom_max,
-                Lpq,
-                Lia,
+                *integrals,
                 mo_energy=(
                     mo_energy if not gw.g0 else mo_energy_ref,
                     mo_energy if not gw.w0 else mo_energy_ref,
@@ -106,7 +103,7 @@ def kernel(
             tp = gw.damping * tp_prev + (1.0 - gw.damping) * tp
 
         # Solve the Dyson equation
-        gf, se = gw.solve_dyson(th, tp, se_static, Lpq=Lpq)
+        gf, se = gw.solve_dyson(th, tp, se_static, Lpq=integrals[0])
 
         # Update the MO energies
         check = set()

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -256,6 +256,7 @@ class GW(BaseGW):
         gf.coupling = mpi_helper.bcast(gf.coupling, root=0)
 
         if self.fock_loop:
+            # TODO remove these try...except
             try:
                 gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
             except IndexError:

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -194,7 +194,7 @@ class GW(BaseGW):
             self.mo_occ,
             compression=self.compression,
             compression_tol=self.compression_tol,
-            store_full=self.fock_loop,
+            store_full=self.has_fock_loop,
         )
         integrals.transform()
 

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -185,7 +185,7 @@ class GW(BaseGW):
         else:
             raise NotImplementedError
 
-    def ao2mo(self):
+    def ao2mo(self, transform=True):
         """Get the integrals."""
 
         integrals = Integrals(
@@ -196,7 +196,8 @@ class GW(BaseGW):
             compression_tol=self.compression_tol,
             store_full=self.has_fock_loop,
         )
-        integrals.transform()
+        if transform:
+            integrals.transform()
 
         return integrals
 

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -43,8 +43,8 @@ class Integrals:
         compression_tol=1e-10,
         store_full=False,
     ):
-        self.verbose = with_df.mol.verbose
-        self.stdout = with_df.mol.stdout
+        self.verbose = with_df.verbose
+        self.stdout = with_df.stdout
 
         self.with_df = with_df
         self.mo_coeff = mo_coeff
@@ -60,12 +60,13 @@ class Integrals:
         self._rot = None
 
     def _parse_compression(self):
+        if not self.compression:
+            return None
         compression = self.compression.replace("vo", "ov")
         compression = set(x for x in compression.split(","))
-        if not compression:
-            return None
         if "ia" in compression and "ov" in compression:
             raise ValueError("`compression` cannot contain both `'ia'` and `'ov'` (or `'vo'`)")
+        return compression
 
     def get_compression_metric(self):
         """

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -404,7 +404,7 @@ class Integrals:
         compression.
         """
         if self._rot is None:
-            return [self.naux_full] * len(self.kpts)
+            return self.naux_full
         return self._rot.shape[1]
 
     @property

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -61,7 +61,7 @@ class Integrals:
 
     def _parse_compression(self):
         if not self.compression:
-            return None
+            return set()
         compression = self.compression.replace("vo", "ov")
         compression = set(x for x in compression.split(","))
         if "ia" in compression and "ov" in compression:
@@ -220,7 +220,7 @@ class Integrals:
         if mo_coeff_w is not None:
             self._mo_coeff_w = mo_coeff_w
             self._mo_occ_w = mo_occ_w
-            if "ia" in self.compression:
+            if "ia" in self._parse_compression():
                 self.rot = self.get_compression_metric()
 
         self.transform(

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -38,18 +38,20 @@ class Integrals:
         self._mo_occ_w = None
         self._rot = None
 
-    def get_compression_metric(self):
-        """
-        Return the compression metric.
-        """
-        # TODO cache this if needed
-
+    def _parse_compression(self):
         compression = self.compression.replace("vo", "ov")
         compression = set(x for x in compression.split(","))
         if not compression:
             return None
         if "ia" in compression and "ov" in compression:
             raise ValueError("`compression` cannot contain both `'ia'` and `'ov'` (or `'vo'`)")
+
+    def get_compression_metric(self):
+        """
+        Return the compression metric.
+        """
+
+        compression = self._parse_compression()
 
         cput0 = (logger.process_clock(), logger.perf_counter())
         logger.info(self, f"Computing compression metric for {self.__class__.__name__}")
@@ -146,9 +148,8 @@ class Integrals:
             # If needed, rotate the full (L|pq) array
             if do_Lpq:
                 logger.debug(self, f"(L|pq) size: ({self.naux_full}, {self.nmo}, {o1 - o0})")
-                Lpq[b0:b1] = lib.einsum(
-                    "Lpq,pi,qj->Lij", block, self.mo_coeff, self.mo_coeff[:, o0:o1]
-                )
+                coeffs = (self.mo_coeff, self.mo_coeff[:, o0:o1])
+                Lpq[b0:b1] = lib.einsum("Lpq,pi,qj->Lij", block, *coeffs)
 
             # Compress the block
             block = lib.einsum("L...,LQ->Q...", block, rot[b0:b1])
@@ -156,15 +157,16 @@ class Integrals:
             # Build the compressed (L|px) array
             if do_Lpx:
                 logger.debug(self, f"(L|px) size: ({self.naux}, {self.nmo}, {p1 - p0})")
-                Lpx += lib.einsum("Lpq,pi,qj->Lij", block, self.mo_coeff, self.mo_coeff_g[:, p0:p1])
+                coeffs = (self.mo_coeff, self.mo_coeff_g[:, p0:p1])
+                Lpx += lib.einsum("Lpq,pi,qj->Lij", block, *coeffs)
 
             # Build the compressed (L|ia) array
             if do_Lia:
                 logger.debug(self, f"(L|ia) size: ({self.naux}, {q1 - q0})")
                 i0, a0 = divmod(q0, self.nvir_w)
                 i1, a1 = divmod(q1, self.nvir_w)
-                coeffs = [self.mo_coeff_w[:, i0 : i1 + 1], self.mo_coeff_w[:, self.nocc_w :]]
-                tmp = lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0], coeffs[1])
+                coeffs = (self.mo_coeff_w[:, i0 : i1 + 1], self.mo_coeff_w[:, self.nocc_w :])
+                tmp = lib.einsum("Lpq,pi,qj->Lij", block, *coeffs)
                 tmp = tmp.reshape(self.naux, -1)
                 Lia += tmp[:, a0 : a0 + (q1 - q0)]
 

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -404,7 +404,7 @@ class Integrals:
         compression.
         """
         if self._rot is None:
-            return self.naux_full
+            return [self.naux_full] * len(self.kpts)
         return self._rot.shape[1]
 
     @property

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -74,6 +74,8 @@ class Integrals:
         """
 
         compression = self._parse_compression()
+        if not compression:
+            return None
 
         cput0 = (logger.process_clock(), logger.perf_counter())
         logger.info(self, f"Computing compression metric for {self.__class__.__name__}")

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -78,6 +78,7 @@ class BaseKGW(BaseGW):
         self.converged = None
         self.se = None
         self.gf = None
+        self._qp_energy = None
 
         self._keys = set(self.__dict__.keys()).union(self._opts)
 

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -41,6 +41,15 @@ class BaseKGW(BaseGW):
     fock_opts : dict, optional
         Dictionary of options compatiable with `pyscf.dfragf2.DFRAGF2`
         objects that are used in the Fock loop.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme.  Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression.  Default value is `1e-10`.
     {extra_parameters}
     """
 
@@ -52,9 +61,7 @@ class BaseKGW(BaseGW):
     def cell(self):
         return self._scf.cell
 
-    @property
-    def mol(self):
-        return self.cell
+    mol = cell
 
     get_nmo = get_nmo
     get_nocc = get_nocc

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -85,6 +85,34 @@ class BaseKGW(BaseGW):
     def _gf_to_occ(gf):
         return tuple(BaseGW._gf_to_occ(g) for g in gf)
 
+    def _gf_to_mo_energy(self, gf):
+        """Find the poles of a GF which best overlap with the MOs.
+
+        Parameters
+        ----------
+        gf : tuple of GreensFunction
+            Green's function object.
+
+        Returns
+        -------
+        mo_energy : ndarray
+            Updated MO energies.
+        """
+
+        mo_energy = np.zeros_like(self.mo_energy)
+
+        for k, kpt in self.kpts.loop(1):
+            check = set()
+            for i in range(self.nmo):
+                arg = np.argmax(gf[k].coupling[i] * gf[k].coupling[i].conj())
+                mo_energy[k][i] = gf[k].energy[arg]
+                check.add(arg)
+
+            if len(check) != self.nmo:
+                logger.warn(self, f"Inconsistent quasiparticle weights at k-point {k}!")
+
+        return mo_energy
+
     @property
     def cell(self):
         return self._scf.cell

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -68,13 +68,13 @@ class BaseKGW(BaseGW):
             setattr(self, key, val)
 
         # Do not modify:
-        self.mo_energy = mf.mo_energy
-        self.mo_coeff = mf.mo_coeff
-        self.mo_occ = mf.mo_occ
+        self.mo_energy = np.asarray(mf.mo_energy)
+        self.mo_coeff = np.asarray(mf.mo_coeff)
+        self.mo_occ = np.asarray(mf.mo_occ)
         self.frozen = None
         self._nocc = None
         self._nmo = None
-        self._kpts = KPoints(self.cell, mf.kpts)
+        self._kpts = KPoints(self.cell, getattr(mf, "kpts", np.zeros((1, 3))))
         self.converged = None
         self.se = None
         self.gf = None

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -52,6 +52,10 @@ class BaseKGW(BaseGW):
     {extra_parameters}
     """
 
+    # --- Default KGW options
+
+    compression = None
+
     def __init__(self, mf, **kwargs):
         self._scf = mf
         self.verbose = self.mol.verbose

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -129,6 +129,14 @@ class BaseKGW(BaseGW):
     def _gf_to_occ(gf):
         return tuple(BaseGW._gf_to_occ(g) for g in gf)
 
+    @staticmethod
+    def _gf_to_energy(gf):
+        return tuple(BaseGW._gf_to_energy(g) for g in gf)
+
+    @staticmethod
+    def _gf_to_coupling(gf):
+        return tuple(BaseGW._gf_to_coupling(g) for g in gf)
+
     def _gf_to_mo_energy(self, gf):
         """Find the poles of a GF which best overlap with the MOs.
 

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -153,7 +153,7 @@ class BaseKGW(BaseGW):
 
         mo_energy = np.zeros_like(self.mo_energy)
 
-        for k, kpt in self.kpts.loop(1):
+        for k in self.kpts.loop(1):
             check = set()
             for i in range(self.nmo):
                 arg = np.argmax(gf[k].coupling[i] * gf[k].coupling[i].conj())

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -3,8 +3,9 @@ Base class for moment-constrained GW solvers with periodic boundary
 conditions.
 """
 
-import numpy as np
 import functools
+
+import numpy as np
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.pbc.mp.kmp2 import get_frozen_mask, get_nmo, get_nocc

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -56,6 +56,14 @@ class BaseKGW(BaseGW):
 
     compression = None
 
+    # --- Extra PBC options
+
+    fc = False
+
+    _opts = BaseGW._opts + [
+        "fc",
+    ]
+
     def __init__(self, mf, **kwargs):
         self._scf = mf
         self.verbose = self.mol.verbose

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -81,6 +81,50 @@ class BaseKGW(BaseGW):
 
         self._keys = set(self.__dict__.keys()).union(self._opts)
 
+    def kernel(
+        self,
+        nmom_max,
+        mo_energy=None,
+        mo_coeff=None,
+        moments=None,
+        integrals=None,
+    ):
+        if mo_coeff is None:
+            mo_coeff = self.mo_coeff
+        if mo_energy is None:
+            mo_energy = self.mo_energy
+
+        cput0 = (logger.process_clock(), logger.perf_counter())
+        self.dump_flags()
+        logger.info(self, "nmom_max = %d", nmom_max)
+
+        self.converged, self.gf, self.se, self._qp_energy = self._kernel(
+            nmom_max,
+            mo_energy,
+            mo_coeff,
+            integrals=integrals,
+        )
+
+        gf_occ = self.gf[0].get_occupied()
+        gf_occ.remove_uncoupled(tol=1e-1)
+        for n in range(min(5, gf_occ.naux)):
+            en = -gf_occ.energy[-(n + 1)]
+            vn = gf_occ.coupling[:, -(n + 1)]
+            qpwt = np.linalg.norm(vn) ** 2
+            logger.note(self, "IP energy level (Γ) %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
+
+        gf_vir = self.gf[0].get_virtual()
+        gf_vir.remove_uncoupled(tol=1e-1)
+        for n in range(min(5, gf_vir.naux)):
+            en = gf_vir.energy[n]
+            vn = gf_vir.coupling[:, n]
+            qpwt = np.linalg.norm(vn) ** 2
+            logger.note(self, "EA energy level (Γ) %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
+
+        logger.timer(self, self.name, *cput0)
+
+        return self.converged, self.gf, self.se, self.qp_energy
+
     @staticmethod
     def _gf_to_occ(gf):
         return tuple(BaseGW._gf_to_occ(g) for g in gf)

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -10,6 +10,7 @@ from pyscf.lib import logger
 from pyscf.pbc.mp.kmp2 import get_frozen_mask, get_nmo, get_nocc
 
 from momentGW.base import BaseGW
+from momentGW.pbc.kpts import KPoints
 
 
 class BaseKGW(BaseGW):
@@ -25,9 +26,6 @@ class BaseKGW(BaseGW):
     polarizability : str, optional
         Type of polarizability to use, can be one of `("drpa",
         "drpa-exact").  Default value is `"drpa"`.
-    vhf_df : bool, optional
-        If True, calculate the static self-energy directly from `Lpq`.
-        Default value is False.
     npoints : int, optional
         Number of numerical integration points.  Default value is `48`.
     optimise_chempot : bool, optional
@@ -53,6 +51,31 @@ class BaseKGW(BaseGW):
     {extra_parameters}
     """
 
+    def __init__(self, mf, **kwargs):
+        self._scf = mf
+        self.verbose = self.mol.verbose
+        self.stdout = self.mol.stdout
+        self.max_memory = 1e10
+
+        for key, val in kwargs.items():
+            if not hasattr(self, key):
+                raise AttributeError("%s has no attribute %s", self.name, key)
+            setattr(self, key, val)
+
+        # Do not modify:
+        self.mo_energy = mf.mo_energy
+        self.mo_coeff = mf.mo_coeff
+        self.mo_occ = mf.mo_occ
+        self.frozen = None
+        self._nocc = None
+        self._nmo = None
+        self._kpts = KPoints(self.cell, mf.kpts)
+        self.converged = None
+        self.se = None
+        self.gf = None
+
+        self._keys = set(self.__dict__.keys()).union(self._opts)
+
     @staticmethod
     def _gf_to_occ(gf):
         return tuple(BaseGW._gf_to_occ(g) for g in gf)
@@ -69,7 +92,7 @@ class BaseKGW(BaseGW):
 
     @property
     def kpts(self):
-        return self._scf.kpts
+        return self._kpts
 
     @property
     def nkpts(self):

--- a/momentGW/pbc/evgw.py
+++ b/momentGW/pbc/evgw.py
@@ -23,23 +23,6 @@ class evKGW(KGW, evGW):
     def name(self):
         return "evKG%sW%s" % ("0" if self.g0 else "", "0" if self.w0 else "")
 
-    def update_mo_energy(self, gf):
-        """Update the eigenvalues."""
-
-        mo_energy = np.zeros_like(self.mo_energy)
-
-        for k, kpt in self.kpts.loop(1):
-            check = set()
-            for i in range(self.nmo):
-                arg = np.argmax(gf[k].coupling[i] * gf[k].coupling[i].conj())
-                mo_energy[k][i] = gf[k].energy[arg]
-                check.add(arg)
-
-            if len(check) != self.nmo:
-                logger.warn(self, f"Inconsistent quasiparticle weights at k-point {k}!")
-
-        return mo_energy
-
     def check_convergence(self, mo_energy, mo_energy_prev, th, th_prev, tp, tp_prev):
         """Check for convergence, and print a summary of changes."""
 

--- a/momentGW/pbc/evgw.py
+++ b/momentGW/pbc/evgw.py
@@ -12,12 +12,15 @@ from pyscf.lib import logger
 from pyscf.pbc import dft, gto
 from pyscf.pbc.tools import k2gamma
 
+from momentGW import util
 from momentGW.evgw import evGW
 from momentGW.pbc.gw import KGW
 
 
 class evKGW(KGW, evGW):
     __doc__ = evGW.__doc__.replace("molecules", "periodic systems", 1)
+
+    _opts = util.list_union(KGW._opts, evGW._opts)
 
     @property
     def name(self):

--- a/momentGW/pbc/evgw.py
+++ b/momentGW/pbc/evgw.py
@@ -1,0 +1,115 @@
+"""
+Spin-restricted eigenvalue self-consistent GW via self-energy moment
+constraints for periodic systems.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+from pyscf.agf2 import mpi_helper
+from pyscf.lib import logger
+from pyscf.pbc import dft, gto
+from pyscf.pbc.tools import k2gamma
+
+from momentGW.evgw import evGW, kernel
+from momentGW.pbc.gw import KGW
+
+
+class evKGW(KGW, evGW):
+    __doc__ = evGW.__doc__.replace("molecules", "periodic systems", 1)
+
+    @property
+    def name(self):
+        return "evKG%sW%s" % ("0" if self.g0 else "", "0" if self.w0 else "")
+
+    def update_mo_energy(self, gf):
+        """Update the eigenvalues."""
+
+        mo_energy = np.zeros_like(self.mo_energy)
+
+        for k, kpt in self.kpts.loop(1):
+            check = set()
+            for i in range(self.nmo):
+                arg = np.argmax(gf[k].coupling[i] * gf[k].coupling[i].conj())
+                mo_energy[k][i] = gf[k].energy[arg]
+                check.add(arg)
+
+            if len(check) != self.nmo:
+                logger.warn(self, f"Inconsistent quasiparticle weights at k-point {k}!")
+
+        return mo_energy
+
+    def check_convergence(self, mo_energy, mo_energy_prev, th, th_prev, tp, tp_prev):
+        """Check for convergence, and print a summary of changes."""
+
+        if th_prev is None:
+            th_prev = np.zeros_like(th)
+        if tp_prev is None:
+            tp_prev = np.zeros_like(tp)
+
+        error_homo = max(
+            abs(mo[n - 1] - mo_prev[n - 1])
+            for mo, mo_prev, n in zip(mo_energy, mo_energy_prev, self.nocc)
+        )
+        error_lumo = max(
+            abs(mo[n] - mo_prev[n]) for mo, mo_prev, n in zip(mo_energy, mo_energy_prev, self.nocc)
+        )
+
+        error_th = max(abs(self._moment_error(t, t_prev)) for t, t_prev in zip(th, th_prev))
+        error_tp = max(abs(self._moment_error(t, t_prev)) for t, t_prev in zip(tp, tp_prev))
+
+        logger.info(self, "Change in QPs: HOMO = %.6g  LUMO = %.6g", error_homo, error_lumo)
+        logger.info(self, "Change in moments: occ = %.6g  vir = %.6g", error_th, error_tp)
+
+        return self.conv_logical(
+            (
+                max(error_homo, error_lumo) < self.conv_tol,
+                max(error_th, error_tp) < self.conv_tol_moms,
+            )
+        )
+
+    def kernel(
+        self,
+        nmom_max,
+        mo_energy=None,
+        mo_coeff=None,
+        moments=None,
+        integrals=None,
+    ):
+        if mo_coeff is None:
+            mo_coeff = self.mo_coeff
+        if mo_energy is None:
+            mo_energy = self.mo_energy
+
+        cput0 = (logger.process_clock(), logger.perf_counter())
+        self.dump_flags()
+        logger.info(self, "nmom_max = %d", nmom_max)
+
+        self.converged, self.gf, self.se = kernel(
+            self,
+            nmom_max,
+            mo_energy,
+            mo_coeff,
+            integrals=integrals,
+        )
+
+        gf_occ = self.gf[0].get_occupied()
+        gf_occ.remove_uncoupled(tol=1e-1)
+        for n in range(min(5, gf_occ.naux)):
+            en = -gf_occ.energy[-(n + 1)]
+            vn = gf_occ.coupling[:, -(n + 1)]
+            qpwt = np.linalg.norm(vn) ** 2
+            logger.note(self, "IP energy level (Γ) %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
+
+        gf_vir = self.gf[0].get_virtual()
+        gf_vir.remove_uncoupled(tol=1e-1)
+        for n in range(min(5, gf_vir.naux)):
+            en = gf_vir.energy[n]
+            vn = gf_vir.coupling[:, n]
+            qpwt = np.linalg.norm(vn) ** 2
+            logger.note(self, "EA energy level (Γ) %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
+
+        logger.timer(self, self.name, *cput0)
+
+        return self.converged, self.gf, self.se

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -11,59 +11,11 @@ from pyscf.agf2.chempot import binsearch_chempot, minimize_chempot
 from momentGW import util
 
 
-def get_j(Lpq, dm, kpts):
-    """
-    Build the J matrix.
-    """
-
-    nkpts, nmo, _ = dm.shape
-    vj = np.zeros_like(dm)
-
-    for (ki, kpti), (kk, kptk) in kpts.loop(2):
-        kj = ki
-        kl = kpts.conserve(ki, kj, kk)
-        buf = lib.einsum("Lpq,pq->L", Lpq[kk, kl], dm[kl])
-        vj[ki] += lib.einsum("Lpq,L->pq", Lpq[ki, kj], buf)
-
-    vj /= len(kpts)
-
-    return vj
-
-
-def get_k(Lpq, dm, kpts):
-    """
-    Build the K matrix.
-    """
-
-    nkpts, nmo, _ = dm.shape
-    vk = np.zeros_like(dm)
-
-    for (ki, kpti), (kk, kptk) in kpts.loop(2):
-        kj = ki
-        kl = kpts.conserve(ki, kj, kk)
-        buf = np.dot(Lpq[ki, kl].reshape(-1, nmo), dm[kl].conj())
-        buf = buf.reshape(-1, nmo, nmo).swapaxes(1, 2).reshape(-1, nmo)
-        vk[ki] += np.dot(buf.T, Lpq[kk, kj].reshape(-1, nmo)).T.conj()
-
-    vk /= len(kpts)
-
-    return vk
-
-
-def get_jk(Lpq, dm, kpts):
-    return get_j(Lpq, dm, kpts), get_k(Lpq, dm, kpts)
-
-
-def get_fock(Lpq, dm, h1e, kpts):
-    vj, vk = get_jk(Lpq, dm, kpts)
-    return h1e + vj - vk * 0.5
-
-
 def fock_loop(
     gw,
-    Lpq,
     gf,
     se,
+    integrals=None,
     fock_diis_space=10,
     fock_diis_min_space=1,
     conv_tol_nelec=1e-6,
@@ -74,6 +26,9 @@ def fock_loop(
     """Self-consistent loop for the density matrix via the HF self-
     consistent field.
     """
+
+    if integrals is None:
+        integrals = gw.ao2mo()
 
     h1e = lib.einsum("kpq,kpi,kqj->kij", gw._scf.get_hcore(), np.conj(gw.mo_coeff), gw.mo_coeff)
     nmo = gw.nmo
@@ -88,7 +43,7 @@ def fock_loop(
     diis.min_space = fock_diis_min_space
     gf_to_dm = lambda gf: np.array([g.get_occupied().moment(0) for g in gf]) * 2.0
     rdm1 = gf_to_dm(gf)
-    fock = get_fock(Lpq, rdm1, h1e, kpts)
+    fock = integrals.get_fock(rdm1, h1e)
 
     buf = np.zeros((max(nqmo), max(nqmo)), dtype=complex)
     converged = False
@@ -110,7 +65,7 @@ def fock_loop(
                 gf[k] = gf[k].__class__(w, v[:nmo], chempot=se[k].chempot)
 
             rdm1 = gf_to_dm(gf)
-            fock = get_fock(Lpq, rdm1, h1e, kpts)
+            fock = integrals.get_fock(rdm1, h1e)
             fock = diis.update(fock, xerr=None)
 
             nerr = nerr[np.argmax(np.abs(nerr))]

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -1,0 +1,137 @@
+"""
+Fock matrix and static self-energy parts with periodic boundary
+conditions.
+"""
+
+import numpy as np
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.agf2.chempot import binsearch_chempot, minimize_chempot
+
+from momentGW import util
+
+
+def get_j(Lpq, dm, kpts):
+    """
+    Build the J matrix.
+    """
+
+    nkpts, nmo, _ = dm.shape
+    vj = np.zeros_like(dm)
+
+    for (ki, kpti), (kk, kptk) in kpts.loop(2):
+        kj = ki
+        kl = kpts.conserve(ki, kj, kk)
+        buf = lib.einsum("Lpq,pq->L", Lpq[kk, kl], dm[kl])
+        vj[ki] += lib.einsum("Lpq,L->pq", Lpq[ki, kj], buf)
+
+    return vj
+
+
+def get_k(Lpq, dm, kpts):
+    """
+    Build the K matrix.
+    """
+
+    nkpts, nmo, _ = dm.shape
+    vk = np.zeros_like(dm)
+
+    for (ki, kpti), (kk, kptk) in kpts.loop(2):
+        kj = ki
+        kl = kpts.conserve(ki, kj, kk)
+        buf = np.dot(Lpq[ki, kl].reshape(-1, nmo), dm[kl].conj())
+        buf = buf.reshape(-1, nmo, nmo).swapaxes(1, 2).reshape(-1, nmo)
+        vk[ki] += np.dot(buf.T, Lpq[kk, kj].reshape(-1, nmo)).T.conj()
+
+    return vk
+
+
+def get_jk(Lpq, dm, kpts):
+    return get_j(Lpq, dm, kpts), get_k(Lpq, dm, kpts)
+
+
+def get_fock(Lpq, dm, h1e, kpts):
+    vj, vk = get_jk(Lpq, dm, kpts)
+    return h1e + vj - vk * 0.5
+
+
+def fock_loop(
+    gw,
+    Lpq,
+    gf,
+    se,
+    fock_diis_space=10,
+    fock_diis_min_space=1,
+    conv_tol_nelec=1e-6,
+    conv_tol_rdm1=1e-8,
+    max_cycle_inner=100,
+    max_cycle_outer=20,
+):
+    """Self-consistent loop for the density matrix via the HF self-
+    consistent field.
+    """
+
+    h1e = lib.einsum("kpq,kpi,kqj->kij", gw._scf.get_hcore(), gw.mo_coeff, np.conj(gw.mo_coeff))
+    nmo = gw.nmo
+    nocc = gw.nocc
+    naux = [s.naux for s in se]
+    nqmo = [nmo + n for n in naux]
+    nelec = [n * 2 for n in nocc]
+    kpts = gw.kpts
+
+    diis = util.DIIS()
+    diis.space = fock_diis_space
+    diis.min_space = fock_diis_min_space
+    gf_to_dm = lambda gf: np.array([g.get_occupied.moment(0) for g in gf]) * 2.0
+    rdm1 = gf_to_dm(gf)
+    fock = get_fock(Lpq, rdm1, h1e, kpts)
+
+    buf = np.zeros((max(nqmo), max(nqmo)), dtype=complex)
+    converged = False
+    opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner)
+    rdm1_prev = 0
+
+    for niter1 in range(1, max_cycle_outer + 1):
+        for (k, kpt) in kpts.loop(1):
+            se[k], opt = minimize_chempot(se[k], fock[k], nelec[k], x0=se[k].chempot, **opts)
+
+        for niter2 in range(1, max_cycle_inner + 1):
+            nerr = [0] * len(kpts)
+
+            for (k, kpt) in kpts.loop(1):
+                w, v = se[k].eig(fock[k], chempot=0.0, out=buf)
+                se[k].chempot, nerr[k] = binsearch_chempot((w, v), nmo, nelec[k])
+
+                w, v = se[k].eig(fock[k], out=buf)
+                gf[k] = gf[k].__class__(w, v[:nmo], chempot=se[k].chempot)
+
+            rdm1 = gf_to_dm(gf)
+            fock = get_fock(Lpq, rdm1, h1e, kpts)
+            fock = diis.update(fock, xerr=None)
+
+            nerr = nerr[np.argmax(np.abs(nerr))]
+            if niter2 > 1:
+                derr = np.max(np.absolute(rdm1 - rdm1_prev))
+                if derr < conv_tol_rdm1:
+                    break
+
+            rdm1_prev = rdm1.copy()
+
+        logger.debug1(
+            gw, "fock loop %d  cycles = %d  dN = %.3g  |ddm| = %.3g", niter1, niter2, nerr, derr
+        )
+
+        if derr < conv_tol_rdm1 and abs(nerr) < conv_tol_nelec:
+            converged = True
+            break
+
+    logger.info(
+        gw,
+        "fock converged = %s  chempot (Γ) = %.9g  dN = %.3g  |ddm| = %.3g",
+        converged,
+        se[0].chempot,
+        nerr,
+        derr,
+    )
+
+    return gf, se, converged

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -68,6 +68,11 @@ def fock_loop(
             fock = integrals.get_fock(rdm1, h1e)
             fock = diis.update(fock, xerr=None)
 
+            rdm1_ao = lib.einsum("kij,kpi,kqj->kpq", rdm1, gw.mo_coeff, np.conj(gw.mo_coeff))
+            fock_ao = gw._scf.get_fock(dm=rdm1_ao)
+            fock_test = lib.einsum("kpq,kpi,kqj->kij", fock_ao, np.conj(gw.mo_coeff), gw.mo_coeff)
+            assert np.allclose(integrals.get_fock(rdm1, h1e), fock_test)
+
             nerr = nerr[np.argmax(np.abs(nerr))]
             if niter2 > 1:
                 derr = np.max(np.absolute(rdm1 - rdm1_prev))

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -226,7 +226,7 @@ def fock_loop(
             w, v = zip(*[s.eig(f, chempot=0.0, out=buf) for s, f in zip(se, fock)])
             chempot, nerr = search_chempot(w, v, nmo, sum(nelec))
 
-            for k, kpt in kpts.loop(1):
+            for k in kpts.loop(1):
                 se[k].chempot = chempot
                 w, v = se[k].eig(fock[k], out=buf)
                 gf[k] = gf[k].__class__(w, v[:nmo], chempot=se[k].chempot)

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -5,8 +5,8 @@ conditions.
 
 import numpy as np
 from pyscf import lib
-from pyscf.lib import logger
 from pyscf.agf2.chempot import binsearch_chempot, minimize_chempot
+from pyscf.lib import logger
 
 from momentGW import util
 
@@ -51,13 +51,13 @@ def fock_loop(
     rdm1_prev = 0
 
     for niter1 in range(1, max_cycle_outer + 1):
-        for (k, kpt) in kpts.loop(1):
+        for k, kpt in kpts.loop(1):
             se[k], opt = minimize_chempot(se[k], fock[k], nelec[k], x0=se[k].chempot, **opts)
 
         for niter2 in range(1, max_cycle_inner + 1):
             nerr = [0] * len(kpts)
 
-            for (k, kpt) in kpts.loop(1):
+            for k, kpt in kpts.loop(1):
                 w, v = se[k].eig(fock[k], chempot=0.0, out=buf)
                 se[k].chempot, nerr[k] = binsearch_chempot((w, v), nmo, nelec[k])
 

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -75,7 +75,7 @@ def fock_loop(
     consistent field.
     """
 
-    h1e = lib.einsum("kpq,kpi,kqj->kij", gw._scf.get_hcore(), gw.mo_coeff, np.conj(gw.mo_coeff))
+    h1e = lib.einsum("kpq,kpi,kqj->kij", gw._scf.get_hcore(), np.conj(gw.mo_coeff), gw.mo_coeff)
     nmo = gw.nmo
     nocc = gw.nocc
     naux = [s.naux for s in se]

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -25,6 +25,8 @@ def get_j(Lpq, dm, kpts):
         buf = lib.einsum("Lpq,pq->L", Lpq[kk, kl], dm[kl])
         vj[ki] += lib.einsum("Lpq,L->pq", Lpq[ki, kj], buf)
 
+    vj /= len(kpts)
+
     return vj
 
 
@@ -42,6 +44,8 @@ def get_k(Lpq, dm, kpts):
         buf = np.dot(Lpq[ki, kl].reshape(-1, nmo), dm[kl].conj())
         buf = buf.reshape(-1, nmo, nmo).swapaxes(1, 2).reshape(-1, nmo)
         vk[ki] += np.dot(buf.T, Lpq[kk, kj].reshape(-1, nmo)).T.conj()
+
+    vk /= len(kpts)
 
     return vk
 
@@ -82,7 +86,7 @@ def fock_loop(
     diis = util.DIIS()
     diis.space = fock_diis_space
     diis.min_space = fock_diis_min_space
-    gf_to_dm = lambda gf: np.array([g.get_occupied.moment(0) for g in gf]) * 2.0
+    gf_to_dm = lambda gf: np.array([g.get_occupied().moment(0) for g in gf]) * 2.0
     rdm1 = gf_to_dm(gf)
     fock = get_fock(Lpq, rdm1, h1e, kpts)
 

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -6,8 +6,8 @@ conditions.
 import numpy as np
 import scipy.optimize
 from pyscf import lib
-from pyscf.lib import logger
 from pyscf.agf2 import mpi_helper
+from pyscf.lib import logger
 
 from momentGW import util
 
@@ -20,7 +20,7 @@ def _gradient(x, se, fock, nelec, occupancy=2, buf=None):
     """Gradient of the number of electrons w.r.t shift in auxiliary
     energies.
     """
-    #TODO buf
+    # TODO buf
 
     ws, vs = zip(*[s.eig(f, chempot=x) for s, f in zip(se, fock)])
     chempot, error = search_chempot(ws, vs, se[0].nphys, nelec)
@@ -81,8 +81,8 @@ def search_chempot_constrained(w, v, nphys, nelec, occupancy=2):
 
         if e_homo > e_lumo:
             raise ChemicalPotentialError(
-                    "Could not find a chemical potential under "
-                    "the constrain of equal k-point occupancy."
+                "Could not find a chemical potential under "
+                "the constrain of equal k-point occupancy."
             )
 
         chempot = 0.5 * (e_homo + e_lumo)
@@ -96,7 +96,7 @@ def search_chempot_unconstrained(w, v, nphys, nelec, occupancy=2):
     k-point dependent occupancy.
     """
 
-    kidx = np.concatenate([[i]*x.size for i, x in enumerate(w)])
+    kidx = np.concatenate([[i] * x.size for i, x in enumerate(w)])
     w = np.concatenate(w)
     v = np.hstack([vk[:nphys] for vk in v])
 
@@ -147,6 +147,7 @@ def search_chempot(w, v, nphys, nelec, occupancy=2):
 
     return chempot, error
 
+
 def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200):
     """
     Optimise the shift in auxiliary energies to satisfy the electron
@@ -158,11 +159,11 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
     nkpts = len(se)
     nphys = max([s.nphys for s in se])
     naux = max([s.naux for s in se])
-    buf = np.zeros(((nphys + naux)**2,), dtype=dtype)
+    buf = np.zeros(((nphys + naux) ** 2,), dtype=dtype)
     fargs = (se, fock, nelec, occupancy, buf)
 
     options = dict(maxiter=maxiter, ftol=tol, xtol=tol, gtol=tol)
-    kwargs = dict(x0=x0, method='TNC', jac=True, options=options)
+    kwargs = dict(x0=x0, method="TNC", jac=True, options=options)
     fun = _gradient
 
     opt = scipy.optimize.minimize(fun, args=fargs, **kwargs)

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -38,7 +38,7 @@ class KGW(BaseKGW, GW):
             self.mo_occ,
             compression=self.compression,
             compression_tol=self.compression_tol,
-            store_full=self.fock_loop,
+            store_full=self.has_fock_loop,
         )
         integrals.transform()
 

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -10,6 +10,7 @@ from pyscf.agf2 import GreensFunction, SelfEnergy
 from pyscf.lib import logger
 from pyscf.pbc import scf
 
+from momentGW import util
 from momentGW.gw import GW
 from momentGW.pbc.base import BaseKGW
 from momentGW.pbc.fock import fock_loop, minimize_chempot, search_chempot
@@ -23,6 +24,8 @@ class KGW(BaseKGW, GW):
         + "periodic systems.",
         extra_parameters="",
     )
+
+    _opts = util.list_union(BaseKGW._opts, GW._opts)
 
     @property
     def name(self):

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -135,8 +135,6 @@ class KGW(BaseKGW, GW):
         if not (mo_coeff_g is None and mo_coeff_w is None and nocc_w is None):
             raise NotImplementedError  # TODO
 
-        # TODO MPI
-
         cderi = self.with_df.cderi_array()
 
         # occ-vir blocks may be ragged due to different numbers of

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -72,7 +72,7 @@ class KGW(BaseKGW, GW):
         se_static = vk - v_mf
 
         if self.diagonal_se:
-            se_static = se_static[:, np.diag_indices_from(se_static[0])] = 0.0
+            se_static = lib.einsum("kpq,pq->kpq", se_static, np.eye(se_static.shape[1]))
 
         se_static += np.array([np.diag(e) for e in mo_energy])
 

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -12,7 +12,7 @@ from pyscf.pbc import scf
 
 from momentGW.gw import GW, kernel
 from momentGW.pbc.base import BaseKGW
-from momentGW.pbc.fock import fock_loop, search_chempot, minimize_chempot
+from momentGW.pbc.fock import fock_loop, minimize_chempot, search_chempot
 from momentGW.pbc.ints import KIntegrals
 from momentGW.pbc.tda import TDA
 

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -4,21 +4,21 @@ periodic systems.
 """
 
 import numpy as np
-from dyson import NullLogger, MBLSE, MixedMBLSE
+from dyson import MBLSE, MixedMBLSE, NullLogger
 from pyscf import lib
-from pyscf.pbc import scf
 from pyscf.agf2 import GreensFunction, SelfEnergy, chempot
 from pyscf.lib import logger
+from pyscf.pbc import scf
 
+from momentGW.gw import GW, kernel
 from momentGW.pbc.base import BaseKGW
 from momentGW.pbc.tda import TDA
-from momentGW.gw import GW, kernel
 
 
 class KGW(BaseKGW, GW):
     __doc__ = BaseKGW.__doc__.format(
-        description="Spin-restricted one-shot GW via self-energy moment constraints for " + \
-                "periodic systems.",
+        description="Spin-restricted one-shot GW via self-energy moment constraints for "
+        + "periodic systems.",
         extra_parameters="",
     )
 
@@ -145,12 +145,12 @@ class KGW(BaseKGW, GW):
         Lai = np.empty(shape=(self.nkpts, self.nkpts), dtype=object)
         Lpx = np.empty(shape=(self.nkpts, self.nkpts), dtype=object)
         for (ki, kpti), (kj, kptj) in self.kpts.loop(2):
-            re, im,  _ = next(self.with_df.sr_loop([ki, kj], compact=False, blksize=int(1e10)))
+            re, im, _ = next(self.with_df.sr_loop([ki, kj], compact=False, blksize=int(1e10)))
             cderi = (re + im * 1j).reshape(-1, self.nmo, self.nmo)
             Lpq = lib.einsum("Lpq,pi,qj->Lij", cderi, mo_coeff[ki], mo_coeff[kj])
             Lpx[ki, kj] = Lpq
-            Lia[ki, kj] = Lpq[:, :self.nocc[ki], self.nocc[kj]:]
-            Lai[ki, kj] = Lpq[:, self.nocc[ki]:, :self.nocc[kj]]
+            Lia[ki, kj] = Lpq[:, : self.nocc[ki], self.nocc[kj] :]
+            Lai[ki, kj] = Lpq[:, self.nocc[ki] :, : self.nocc[kj]]
 
         return Lpx, Lia, Lai
 

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -244,6 +244,7 @@ class KGW(BaseKGW, GW):
             logger.debug(
                 self,
                 "Error in moments [kpt %d]: occ = %.6g  vir = %.6g",
+                k,
                 *self.moment_error(se_moments_hole[k], se_moments_part[k], se[k]),
             )
 

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -10,7 +10,7 @@ from pyscf.agf2 import GreensFunction, SelfEnergy
 from pyscf.lib import logger
 from pyscf.pbc import scf
 
-from momentGW.gw import GW, kernel
+from momentGW.gw import GW
 from momentGW.pbc.base import BaseKGW
 from momentGW.pbc.fock import fock_loop, minimize_chempot, search_chempot
 from momentGW.pbc.ints import KIntegrals
@@ -207,48 +207,3 @@ class KGW(BaseKGW, GW):
             gf = [GreensFunction(self.mo_energy, np.eye(self.nmo))]
 
         return np.array([g.make_rdm1() for g in gf])
-
-    def kernel(
-        self,
-        nmom_max,
-        mo_energy=None,
-        mo_coeff=None,
-        moments=None,
-        integrals=None,
-    ):
-        if mo_coeff is None:
-            mo_coeff = self.mo_coeff
-        if mo_energy is None:
-            mo_energy = self.mo_energy
-
-        cput0 = (logger.process_clock(), logger.perf_counter())
-        self.dump_flags()
-        logger.info(self, "nmom_max = %d", nmom_max)
-
-        self.converged, self.gf, self.se = kernel(
-            self,
-            nmom_max,
-            mo_energy,
-            mo_coeff,
-            integrals=integrals,
-        )
-
-        gf_occ = self.gf[0].get_occupied()
-        gf_occ.remove_uncoupled(tol=1e-1)
-        for n in range(min(5, gf_occ.naux)):
-            en = -gf_occ.energy[-(n + 1)]
-            vn = gf_occ.coupling[:, -(n + 1)]
-            qpwt = np.linalg.norm(vn) ** 2
-            logger.note(self, "IP energy level (Γ) %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
-
-        gf_vir = self.gf[0].get_virtual()
-        gf_vir.remove_uncoupled(tol=1e-1)
-        for n in range(min(5, gf_vir.naux)):
-            en = gf_vir.energy[n]
-            vn = gf_vir.coupling[:, n]
-            qpwt = np.linalg.norm(vn) ** 2
-            logger.note(self, "EA energy level (Γ) %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
-
-        logger.timer(self, self.name, *cput0)
-
-        return self.converged, self.gf, self.se

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -111,7 +111,7 @@ class KGW(BaseKGW, GW):
 
         se = []
         gf = []
-        for k, kpt in self.kpts.loop(1):
+        for k in self.kpts.loop(1):
             solver_occ = MBLSE(se_static[k], np.array(se_moments_hole[k]), log=nlog)
             solver_occ.kernel()
 
@@ -141,7 +141,7 @@ class KGW(BaseKGW, GW):
         v = [g.coupling for g in gf]
         cpt, error = search_chempot(w, v, self.nmo, sum(self.nocc) * 2)
 
-        for k, kpt in self.kpts.loop(1):
+        for k in self.kpts.loop(1):
             se[k].chempot = cpt
             gf[k].chempot = cpt
             logger.info(self, "Error in number of electrons [kpt %d]: %.5g", k, error)

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -335,5 +335,5 @@ class KIntegrals(Integrals):
         compression.
         """
         if self._rot is None:
-            return self.naux_full
+            return [self.naux_full] * len(self.kpts)
         return [c.shape[-1] for c in self._rot]

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -91,7 +91,6 @@ class KIntegrals(Integrals):
 
         rot = np.empty((len(self.kpts),), dtype=object)
         if mpi_helper.rank == 0:
-            print(np.sort(np.linalg.eigvalsh(prod).ravel()))
             for q in self.kpts.loop(1):
                 e, v = np.linalg.eigh(prod[q])
                 mask = np.abs(e) > self.compression_tol

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -71,7 +71,7 @@ class KIntegrals(Integrals):
 
                     Lxy = np.zeros((self.naux_full, p1 - p0), dtype=complex)
                     b1 = 0
-                    for block in self.with_df.sr_loop((kpti, kptj), compact=False):
+                    for block in self.with_df.sr_loop((ki, kj), compact=False):
                         if block[2] == -1:
                             raise NotImplementedError("Low dimensional integrals")
                         block = block[0] + block[1] * 1.0j
@@ -127,10 +127,10 @@ class KIntegrals(Integrals):
         cput0 = (logger.process_clock(), logger.perf_counter())
         logger.info(self, f"Transforming {self.__class__.__name__}")
 
-        Lpq = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lpq else none
-        Lpx = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lpx else none
-        Lia = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lia else none
-        Lai = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lia else none
+        Lpq = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lpq else None
+        Lpx = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lpx else None
+        Lia = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lia else None
+        Lai = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lia else None
 
         for (ki, kpti), (kj, kptj) in self.kpts.loop(2):
             # Get the slices on the current process and initialise the arrays
@@ -147,7 +147,7 @@ class KIntegrals(Integrals):
 
             # Build the integrals blockwise
             b1 = 0
-            for block in self.with_df.sr_loop((kpti, kptj), compact=False):
+            for block in self.with_df.sr_loop((ki, kj), compact=False):
                 if block[2] == -1:
                     raise NotImplementedError("Low dimensional integrals")
                 block = block[0] + block[1] * 1.0j

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -118,7 +118,8 @@ class KIntegrals(Integrals):
         if self._rot is None:
             self._rot = self.get_compression_metric()
         rot = self._rot
-        dtype = complex
+        if rot is None:
+            rot = np.eye(self.naux_full)
 
         do_Lpq = self.store_full if do_Lpq is None else do_Lpq
         if not any([do_Lpq, do_Lpx, do_Lia]):
@@ -140,10 +141,10 @@ class KIntegrals(Integrals):
             o0, o1 = 0, self.nmo
             p0, p1 = 0, self.nmo_g[ki]
             q0, q1 = 0, self.nocc_w[kj] * self.nvir_w[kj]
-            Lpq_k = np.zeros((self.naux_full, self.nmo, o1 - o0), dtype=dtype) if do_Lpq else None
-            Lpx_k = np.zeros((self.naux, self.nmo, p1 - p0), dtype=dtype) if do_Lpx else None
-            Lia_k = np.zeros((self.naux, q1 - q0), dtype=dtype) if do_Lia else None
-            Lai_k = np.zeros((self.naux, q1 - q0), dtype=dtype) if do_Lia else None
+            Lpq_k = np.zeros((self.naux_full, self.nmo, o1 - o0), dtype=complex) if do_Lpq else None
+            Lpx_k = np.zeros((self.naux, self.nmo, p1 - p0), dtype=complex) if do_Lpx else None
+            Lia_k = np.zeros((self.naux, q1 - q0), dtype=complex) if do_Lia else None
+            Lai_k = np.zeros((self.naux, q1 - q0), dtype=complex) if do_Lia else None
 
             # Build the integrals blockwise
             b1 = 0

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -33,7 +33,7 @@ class KIntegrals(Integrals):
             mo_coeff,
             mo_occ,
             compression=compression,
-            compression_tol=compression_tol * len(kpts),
+            compression_tol=compression_tol * len(kpts) if compression_tol is not None else None,
             store_full=store_full,
         )
 
@@ -250,7 +250,7 @@ class KIntegrals(Integrals):
 
         assert basis in ("ao", "mo")
 
-        vj = np.zeros_like(dm)
+        vj = np.zeros_like(dm, dtype=complex)
 
         if self.store_full and basis == "mo":
             buf = 0.0
@@ -302,7 +302,7 @@ class KIntegrals(Integrals):
 
         assert basis in ("ao", "mo")
 
-        vk = np.zeros_like(dm)
+        vk = np.zeros_like(dm, dtype=complex)
 
         if self.store_full and basis == "mo":
             for (ki, kpti), (kk, kptk) in self.kpts.loop(2):

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -44,6 +44,8 @@ class KIntegrals(Integrals):
         Return the compression metric.
         """
 
+        # TODO MPI
+
         compression = self._parse_compression()
         if not compression:
             return None
@@ -140,95 +142,123 @@ class KIntegrals(Integrals):
         cput0 = (logger.process_clock(), logger.perf_counter())
         logger.info(self, f"Transforming {self.__class__.__name__}")
 
-        Lpq = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lpq else None
-        Lpx = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lpx else None
-        Lia = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lia else None
-        Lai = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lia else None
+        Lpq = {}
+        Lpx = {}
+        Lia = {}
+        Lai = {}
 
-        for q, kj in self.kpts.loop(2):
-            ki = self.kpts.member(self.kpts.wrap_around(self.kpts[q] - self.kpts[kj]))
+        for q in self.kpts.loop(1):
+            for ki in self.kpts.loop(1, mpi=True):
+                kj = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[ki]))
 
-            # Get the slices on the current process and initialise the arrays
-            Lpq_k = (
-                np.zeros((self.naux_full, self.nmo, self.nmo), dtype=complex) if do_Lpq else None
-            )
-            Lpx_k = (
-                np.zeros((self.naux[q], self.nmo, self.nmo_g[kj]), dtype=complex)
-                if do_Lpx
-                else None
-            )
-            Lia_k = (
-                np.zeros((self.naux[q], self.nocc_w[ki] * self.nvir_w[kj]), dtype=complex)
-                if do_Lia
-                else None
-            )
-            Lai_k = (
-                np.zeros((self.naux[q], self.nocc_w[kj] * self.nvir_w[ki]), dtype=complex)
-                if do_Lia
-                else None
-            )
+                # Get the slices on the current process and initialise the arrays
+                Lpq_k = (
+                    np.zeros((self.naux_full, self.nmo, self.nmo), dtype=complex)
+                    if do_Lpq
+                    else None
+                )
+                Lpx_k = (
+                    np.zeros((self.naux[q], self.nmo, self.nmo_g[kj]), dtype=complex)
+                    if do_Lpx
+                    else None
+                )
+                Lia_k = (
+                    np.zeros((self.naux[q], self.nocc_w[ki] * self.nvir_w[kj]), dtype=complex)
+                    if do_Lia
+                    else None
+                )
+                Lai_k = (
+                    np.zeros((self.naux[q], self.nocc_w[kj] * self.nvir_w[ki]), dtype=complex)
+                    if do_Lia
+                    else None
+                )
 
-            # Build the integrals blockwise
-            b1 = 0
-            for block in self.with_df.sr_loop((ki, kj), compact=False):
-                if block[2] == -1:
-                    raise NotImplementedError("Low dimensional integrals")
-                block = block[0] + block[1] * 1.0j
-                block = block.reshape(self.naux_full, self.nmo, self.nmo)
-                b0, b1 = b1, b1 + block.shape[0]
-                logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
+                # Build the integrals blockwise
+                b1 = 0
+                for block in self.with_df.sr_loop((ki, kj), compact=False):  # TODO lock I/O
+                    if block[2] == -1:
+                        raise NotImplementedError("Low dimensional integrals")
+                    block = block[0] + block[1] * 1.0j
+                    block = block.reshape(self.naux_full, self.nmo, self.nmo)
+                    b0, b1 = b1, b1 + block.shape[0]
+                    logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
 
-                # If needed, rotate the full (L|pq) array
+                    # If needed, rotate the full (L|pq) array
+                    if do_Lpq:
+                        logger.debug(
+                            self, f"(L|pq) size: ({self.naux_full}, {self.nmo}, {self.nmo})"
+                        )
+                        coeffs = (self.mo_coeff[ki], self.mo_coeff[kj])
+                        Lpq_k[b0:b1] = lib.einsum(
+                            "Lpq,pi,qj->Lij", block, coeffs[0].conj(), coeffs[1]
+                        )
+
+                    # Compress the block
+                    block_comp = lib.einsum("L...,LQ->Q...", block, rot[q][b0:b1].conj())
+
+                    # Build the compressed (L|px) array
+                    if do_Lpx:
+                        logger.debug(
+                            self, f"(L|px) size: ({self.naux[q]}, {self.nmo}, {self.nmo_g[ki]})"
+                        )
+                        coeffs = (self.mo_coeff[ki], self.mo_coeff_g[kj])
+                        Lpx_k += lib.einsum(
+                            "Lpq,pi,qj->Lij", block_comp, coeffs[0].conj(), coeffs[1]
+                        )
+
+                    # Build the compressed (L|ia) array
+                    if do_Lia:
+                        logger.debug(
+                            self,
+                            f"(L|ia) size: ({self.naux[q]}, {self.nocc_w[ki] * self.nvir_w[kj]})",
+                        )
+                        coeffs = (
+                            self.mo_coeff_w[ki][:, : self.nocc_w[ki]],
+                            self.mo_coeff_w[kj][:, self.nocc_w[kj] :],
+                        )
+                        tmp = lib.einsum("Lpq,pi,qj->Lij", block_comp, coeffs[0].conj(), coeffs[1])
+                        tmp = tmp.reshape(self.naux[q], -1)
+                        Lia_k += tmp
+
                 if do_Lpq:
-                    logger.debug(self, f"(L|pq) size: ({self.naux_full}, {self.nmo}, {self.nmo})")
-                    coeffs = (self.mo_coeff[ki], self.mo_coeff[kj])
-                    Lpq_k[b0:b1] = lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0].conj(), coeffs[1])
-
-                # Compress the block
-                block_comp = lib.einsum("L...,LQ->Q...", block, rot[q][b0:b1].conj())
-
-                # Build the compressed (L|px) array
+                    Lpq[ki, kj] = Lpq_k
                 if do_Lpx:
-                    logger.debug(
-                        self, f"(L|px) size: ({self.naux[q]}, {self.nmo}, {self.nmo_g[ki]})"
-                    )
-                    coeffs = (self.mo_coeff[ki], self.mo_coeff_g[kj])
-                    Lpx_k += lib.einsum("Lpq,pi,qj->Lij", block_comp, coeffs[0].conj(), coeffs[1])
-
-                # Build the compressed (L|ia) array
+                    Lpx[ki, kj] = Lpx_k
                 if do_Lia:
+                    Lia[ki, kj] = Lia_k
+                else:
+                    continue
+
+                # Inverse q for ki <-> kj
+                q = self.kpts.member(self.kpts.wrap_around(-self.kpts[q]))
+
+                # Build the integrals blockwise
+                b1 = 0
+                for block in self.with_df.sr_loop((kj, ki), compact=False):  # TODO lock I/O
+                    if block[2] == -1:
+                        raise NotImplementedError("Low dimensional integrals")
+                    block = block[0] + block[1] * 1.0j
+                    block = block.reshape(self.naux_full, self.nmo, self.nmo)
+                    b0, b1 = b1, b1 + block.shape[0]
+                    logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
+
+                    # Compress the block
+                    block_comp = lib.einsum("L...,LQ->Q...", block, rot[q][b0:b1].conj())
+
+                    # Build the compressed (L|ai) array
                     logger.debug(
-                        self, f"(L|ia) size: ({self.naux[q]}, {self.nocc_w[ki] * self.nvir_w[kj]})"
+                        self, f"(L|ai) size: ({self.naux[q]}, {self.nvir_w[kj] * self.nocc_w[ki]})"
                     )
                     coeffs = (
-                        self.mo_coeff_w[ki][:, : self.nocc_w[ki]],
                         self.mo_coeff_w[kj][:, self.nocc_w[kj] :],
-                    )
-                    tmp = lib.einsum("Lpq,pi,qj->Lij", block_comp, coeffs[0].conj(), coeffs[1])
-                    tmp = tmp.reshape(self.naux[q], -1)
-                    Lia_k += tmp
-
-                # Build the compressed (L|ai) array
-                if do_Lia:
-                    logger.debug(
-                        self, f"(L|ai) size: ({self.naux[q]}, {self.nvir_w[ki] * self.nocc_w[kj]})"
-                    )
-                    coeffs = (
-                        self.mo_coeff_w[ki][:, self.nocc_w[ki] :],
-                        self.mo_coeff_w[kj][:, : self.nocc_w[kj]],
+                        self.mo_coeff_w[ki][:, : self.nocc_w[ki]],
                     )
                     tmp = lib.einsum("Lpq,pi,qj->Lij", block_comp, coeffs[0].conj(), coeffs[1])
                     tmp = tmp.swapaxes(1, 2)
                     tmp = tmp.reshape(self.naux[q], -1)
                     Lai_k += tmp
 
-            if do_Lpq:
-                Lpq[ki, kj] = Lpq_k
-            if do_Lpx:
-                Lpx[ki, kj] = Lpx_k
-            if do_Lia:
-                Lia[ki, kj] = Lia_k
-                Lai[kj, ki] = Lai_k
+                Lai[ki, kj] = Lai_k
 
         if do_Lpq:
             self._blocks["Lpq"] = Lpq
@@ -249,13 +279,15 @@ class KIntegrals(Integrals):
 
         if self.store_full and basis == "mo":
             buf = 0.0
-            for kk in self.kpts.loop(1):
-                kl = kk
-                buf += lib.einsum("Lpq,pq->L", self.Lpq[kk, kl], dm[kl].conj())
+            for kk in self.kpts.loop(1, mpi=True):
+                buf += lib.einsum("Lpq,pq->L", self.Lpq[kk, kk], dm[kk].conj())
 
-            for ki in self.kpts.loop(1):
-                kj = ki
-                vj[ki] += lib.einsum("Lpq,L->pq", self.Lpq[ki, kj], buf)
+            buf = mpi_helper.allreduce(buf)
+
+            for ki in self.kpts.loop(1, mpi=True):
+                vj[ki] += lib.einsum("Lpq,L->pq", self.Lpq[ki, ki], buf)
+
+            vj = mpi_helper.allreduce(vj)
 
         else:
             if basis == "mo":
@@ -263,27 +295,29 @@ class KIntegrals(Integrals):
 
             buf = np.zeros((self.naux_full,), dtype=complex)
 
-            for kk in self.kpts.loop(1):
-                kl = kk
+            for kk in self.kpts.loop(1, mpi=True):
                 b1 = 0
-                for block in self.with_df.sr_loop((kk, kl), compact=False):
+                for block in self.with_df.sr_loop((kk, kk), compact=False):  # TODO lock I/O
                     if block[2] == -1:
                         raise NotImplementedError("Low dimensional integrals")
                     block = block[0] + block[1] * 1.0j
                     block = block.reshape(self.naux_full, self.nmo, self.nmo)
                     b0, b1 = b1, b1 + block.shape[0]
-                    buf[b0:b1] += lib.einsum("Lpq,pq->L", block, dm[kl].conj())
+                    buf[b0:b1] += lib.einsum("Lpq,pq->L", block, dm[kk].conj())
 
-            for ki in self.kpts.loop(1):
-                kj = ki
+            buf = mpi_helper.allreduce(buf)
+
+            for ki in self.kpts.loop(1, mpi=True):
                 b1 = 0
-                for block in self.with_df.sr_loop((ki, kj), compact=False):
+                for block in self.with_df.sr_loop((ki, ki), compact=False):
                     if block[2] == -1:
                         raise NotImplementedError("Low dimensional integrals")
                     block = block[0] + block[1] * 1.0j
                     block = block.reshape(self.naux_full, self.nmo, self.nmo)
                     b0, b1 = b1, b1 + block.shape[0]
                     vj[ki] += lib.einsum("Lpq,L->pq", block, buf[b0:b1])
+
+            vj = mpi_helper.allreduce(vj)
 
             if basis == "mo":
                 vj = lib.einsum("kpq,kpi,kqj->kij", vj, np.conj(self.mo_coeff), self.mo_coeff)
@@ -300,35 +334,52 @@ class KIntegrals(Integrals):
         vk = np.zeros_like(dm, dtype=complex)
 
         if self.store_full and basis == "mo":
-            for ki, kk in self.kpts.loop(2):
-                kj = ki
-                kl = kk
-                buf = np.dot(self.Lpq[ki, kl].reshape(-1, self.nmo), dm[kl])
-                buf = buf.reshape(-1, self.nmo, self.nmo).swapaxes(1, 2).reshape(-1, self.nmo)
-                vk[ki] += np.dot(buf.T, self.Lpq[kk, kj].reshape(-1, self.nmo)).T.conj()
+            # TODO is there a better way to distribute this?
+            for p0, p1 in lib.prange(0, self.naux_full, 240):
+                buf = np.zeros(
+                    (len(self.kpts), len(self.kpts), p1 - p0, self.nmo, self.nmo), dtype=complex
+                )
+                for ki in self.kpts.loop(1, mpi=True):
+                    for kk in self.kpts.loop(1):
+                        buf[kk, ki] = lib.einsum("Lpq,qr->Lrp", self.Lpq[ki, kk][p0:p1], dm[kk])
+
+                buf = mpi_helper.allreduce(buf)
+
+                for ki in self.kpts.loop(1):
+                    for kk in self.kpts.loop(1, mpi=True):
+                        vk[ki] += lib.einsum("Lrp,Lrs->ps", buf[kk, ki], self.Lpq[kk, ki][p0:p1])
+
+            vk = mpi_helper.allreduce(vk)
 
         else:
             if basis == "mo":
                 dm = lib.einsum("kij,kpi,kqj->kpq", dm, self.mo_coeff, np.conj(self.mo_coeff))
 
-            for ki, kk in self.kpts.loop(2):
-                kj = ki
-                kl = kk
+            for kk in self.kpts.loop(1):
+                buf = np.zeros((len(self.kpts), self.naux_full, self.nmo, self.nmo), dtype=complex)
+                for ki in self.kpts.loop(1, mpi=True):
+                    b1 = 0
+                    for block in self.with_df.sr_loop((ki, kk), compact=False):
+                        if block[2] == -1:
+                            raise NotImplementedError("Low dimensional integrals")
+                        block = block[0] + block[1] * 1.0j
+                        block = block.reshape(self.naux_full, self.nmo, self.nmo)
+                        b0, b1 = b1, b1 + block.shape[0]
+                        buf[ki, b0:b1] = lib.einsum("Lpq,qr->Lrp", block, dm[kk])
 
-                for block in self.with_df.sr_loop((ki, kl), compact=False):
-                    if block[2] == -1:
-                        raise NotImplementedError("Low dimensional integrals")
-                    block = block[0] + block[1] * 1.0j
-                    block = block.reshape(self.naux_full, self.nmo, self.nmo)
-                    buf = np.dot(block.reshape(-1, self.nmo), dm[kl])
-                    buf = buf.reshape(-1, self.nmo, self.nmo).swapaxes(1, 2).reshape(-1, self.nmo)
+                buf = mpi_helper.allreduce(buf)
 
-                for block in self.with_df.sr_loop((kk, kj), compact=False):
-                    if block[2] == -1:
-                        raise NotImplementedError("Low dimensional integrals")
-                    block = block[0] + block[1] * 1.0j
-                    block = block.reshape(self.naux_full, self.nmo, self.nmo)
-                    vk[ki] += np.dot(buf.T, block.reshape(-1, self.nmo)).T.conj()
+                for ki in self.kpts.loop(1, mpi=True):
+                    b1 = 0
+                    for block in self.with_df.sr_loop((kk, ki), compact=False):
+                        if block[2] == -1:
+                            raise NotImplementedError("Low dimensional integrals")
+                        block = block[0] + block[1] * 1.0j
+                        block = block.reshape(self.naux_full, self.nmo, self.nmo)
+                        b0, b1 = b1, b1 + block.shape[0]
+                        vk[ki] += lib.einsum("Lrp,Lrs->ps", buf[ki, b0:b1], block)
+
+            vk = mpi_helper.allreduce(vk)
 
             if basis == "mo":
                 vk = lib.einsum("kpq,kpi,kqj->kij", vk, np.conj(self.mo_coeff), self.mo_coeff)

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -4,8 +4,8 @@ Integral helpers with periodic boundary conditions.
 
 import numpy as np
 from pyscf import lib
-from pyscf.lib import logger
 from pyscf.agf2 import mpi_helper
+from pyscf.lib import logger
 
 from momentGW.ints import Integrals
 
@@ -25,7 +25,15 @@ class KIntegrals(Integrals):
         compression_tol=1e-10,
         store_full=False,
     ):
-        Integrals.__init__(self, with_df, mo_coeff, mo_occ, compression=compression, compression_tol=compression_tol, store_full=store_full)
+        Integrals.__init__(
+            self,
+            with_df,
+            mo_coeff,
+            mo_occ,
+            compression=compression,
+            compression_tol=compression_tol,
+            store_full=store_full,
+        )
 
         self.kpts = kpts
 
@@ -71,7 +79,9 @@ class KIntegrals(Integrals):
                         b0, b1 = b1, b1 + block.shape[0]
                         logger.debug(self, f"  Block [{ki}, {kj}, {p0}:{p1}, {b0}:{b1}]")
 
-                        tmp = lib.einsum("Lpq,pi,qj->Lij", block, ci[ki][:, i0 : i1 + 1].conj(), cj[kj])
+                        tmp = lib.einsum(
+                            "Lpq,pi,qj->Lij", block, ci[ki][:, i0 : i1 + 1].conj(), cj[kj]
+                        )
                         tmp = tmp.reshape(b1 - b0, -1)
                         Lxy[b0:b1] = tmp[:, j0 : j0 + (p1 - p0)]
 
@@ -124,9 +134,9 @@ class KIntegrals(Integrals):
 
         for (ki, kpti), (kj, kptj) in self.kpts.loop(2):
             # Get the slices on the current process and initialise the arrays
-            #o0, o1 = list(mpi_helper.prange(0, self.nmo, self.nmo))[0]
-            #p0, p1 = list(mpi_helper.prange(0, self.nmo_g[k], self.nmo_g[k]))[0]
-            #q0, q1 = list(mpi_helper.prange(0, self.nocc_w[k] * self.nvir_w[k], self.nocc_w[k] * self.nvir_w[k]))[0]
+            # o0, o1 = list(mpi_helper.prange(0, self.nmo, self.nmo))[0]
+            # p0, p1 = list(mpi_helper.prange(0, self.nmo_g[k], self.nmo_g[k]))[0]
+            # q0, q1 = list(mpi_helper.prange(0, self.nocc_w[k] * self.nvir_w[k], self.nocc_w[k] * self.nvir_w[k]))[0]
             o0, o1 = 0, self.nmo
             p0, p1 = 0, self.nmo_g[ki]
             q0, q1 = 0, self.nocc_w[kj] * self.nvir_w[kj]
@@ -165,7 +175,10 @@ class KIntegrals(Integrals):
                     logger.debug(self, f"(L|ia) size: ({self.naux}, {q1 - q0})")
                     i0, a0 = divmod(q0, self.nvir_w[kj])
                     i1, a1 = divmod(q1, self.nvir_w[kj])
-                    coeffs = (self.mo_coeff_w[ki][:, i0 : i1 + 1], self.mo_coeff_w[kj][:, self.nocc_w[kj] :])
+                    coeffs = (
+                        self.mo_coeff_w[ki][:, i0 : i1 + 1],
+                        self.mo_coeff_w[kj][:, self.nocc_w[kj] :],
+                    )
                     tmp = lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0].conj(), coeffs[1])
                     tmp = tmp.reshape(self.naux, -1)
                     Lia_k += tmp[:, a0 : a0 + (q1 - q0)]
@@ -175,7 +188,10 @@ class KIntegrals(Integrals):
                     logger.debug(self, f"(L|ai) size: ({self.naux}, {q1 - q0})")
                     i0, a0 = divmod(q0, self.nocc_w[kj])
                     i1, a1 = divmod(q1, self.nocc_w[kj])
-                    coeffs = (self.mo_coeff_w[ki][:, self.nocc_w[ki] :], self.mo_coeff_w[kj][:, i0 : i1 + 1])
+                    coeffs = (
+                        self.mo_coeff_w[ki][:, self.nocc_w[ki] :],
+                        self.mo_coeff_w[kj][:, i0 : i1 + 1],
+                    )
                     tmp = lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0].conj(), coeffs[1])
                     tmp = tmp.swapaxes(1, 2)
                     tmp = tmp.reshape(self.naux, -1)

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -3,6 +3,7 @@ Integral helpers with periodic boundary conditions.
 """
 
 from collections import defaultdict
+
 import numpy as np
 from pyscf import lib
 from pyscf.agf2 import mpi_helper
@@ -95,7 +96,7 @@ class KIntegrals(Integrals):
         rot = np.empty((len(self.kpts),), dtype=object)
         if mpi_helper.rank == 0:
             for q, qpt in self.kpts.loop(1):
-                e, v = np.linalg.eigh(prod[q])
+                e, v = np.linalg.eig(prod[q])
                 mask = np.abs(e) > self.compression_tol
                 rot[q] = v[:, mask]
         else:
@@ -181,7 +182,7 @@ class KIntegrals(Integrals):
                     Lpq_k[b0:b1] = lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0].conj(), coeffs[1])
 
                 # Compress the block
-                block = lib.einsum("L...,LQ->Q...", block, rot[q][b0:b1])
+                block = lib.einsum("L...,LQ->Q...", block, rot[q][b0:b1].conj())
 
                 # Build the compressed (L|px) array
                 if do_Lpx:

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -1,0 +1,234 @@
+"""
+Integral helpers with periodic boundary conditions.
+"""
+
+import numpy as np
+from pyscf import lib
+from pyscf.lib import logger
+
+from momentGW.ints import Integrals
+
+
+class KIntegrals(Integrals):
+    """
+    Container for the integrals required for KGW methods.
+    """
+
+    def __init__(
+        self,
+        with_df,
+        kpts,
+        mo_coeff,
+        mo_occ,
+        compression="ia",
+        compression_tol=1e-10,
+        store_full=False,
+    ):
+        Integrals.__init__(with_df, mo_coeff, mo_occ, compression=compression, compression_tol=compression_tol, store_full=store_full)
+
+        self.kpts = kpts
+
+    def get_compression_metric(self):
+        """
+        Return the compression metric.
+        """
+
+        compression = self._parse_compression()
+
+        cput0 = (logger.process_clock(), logger.perf_counter())
+        logger.info(self, f"Computing compression metric for {self.__class__.__name__}")
+
+        prod = np.zeros((self.naux_full, self.naux_full), dtype=complex)
+
+        # Loop over required blocks
+        for key in sorted(compression):
+            logger.debug(self, f"Transforming {key} block")
+            ci, cj = [
+                {
+                    "o": [c[:, o > 0] for c, o in zip(self.mo_coeff, self.mo_occ)],
+                    "v": [c[:, o == 0] for c, o in zip(self.mo_coeff, self.mo_occ)],
+                    "i": [c[:, o > 0] for c, o in zip(self.mo_coeff_w, self.mo_occ_w)],
+                    "a": [c[:, o == 0] for c, o in zip(self.mo_coeff_w, self.mo_occ_w)],
+                }[k]
+                for k in key
+            ]
+            ni = [c.shape[-1] for c in ci]
+            nj = [c.shape[-1] for c in cj]
+
+            for (ki, kpti), (kj, kptj) in self.kpts.loop(2):
+                for p0, p1 in lib.prange(0, ni[ki] * nj[kj], self.with_df.blockdim):
+                    i0, j0 = divmod(p0, nj)
+                    i1, j1 = divmod(p1, nj)
+
+                    Lxy = np.zeros((self.naux_full, p1 - p0), dtype=complex)
+                    b1 = 0
+                    for block in self.with_df.sr_loop((kpti, kptj), compact=False):
+                        if block[2] == -1:
+                            raise NotImplementedError("Low dimensional integrals")
+                        block = block[0] + block[1] * 1.0j
+                        b0, b1 = b1, b1 + block.shape[0]
+                        logger.debug(self, f"  Block [{ki}, {kj}, {p0}:{p1}, {b0}:{b1}]")
+
+                        tmp = lib.einsum("Lpq,pi,qj->Lij", block, ci[ki][:, i0 : i1 + 1].conj(), cj[kj])
+                        tmp = tmp.reshape(b1 - b0, -1)
+                        Lxy[b0:b1] = tmp[:, j0 : j0 + (p1 - p0)]
+
+                    prod += np.dot(Lxy, Lxy.T.conj())
+
+        if rot.shape[-1] == self.naux_full:
+            logger.info(self, "No compression found")
+            rot = None
+        else:
+            logger.info(self, f"Compressed auxiliary space from {self.naux_full} to {rot.shape[1]}")
+        logger.timer(self, "compression metric", *cput0)
+
+        return rot
+
+    def transform(self, do_Lpq=None, do_Lpx=True, do_Lia=True):
+        """
+        Initialise the integrals, building:
+            - Lpq: the full (aux, MO, MO) array if `store_full`
+            - Lpx: the compressed (aux, MO, MO) array
+            - Lia: the compressed (aux, occ, vir) array
+        """
+
+        # Get the compression metric
+        if self._rot is None:
+            self._rot = self.get_compression_metric()
+        rot = self._rot
+
+        do_Lpq = self.store_full if do_Lpq is None else do_Lpq
+        if not any([do_Lpq, do_Lpx, do_Lia]):
+            return
+
+        cput0 = (logger.process_clock(), logger.perf_counter())
+        logger.info(self, f"Transforming {self.__class__.__name__}")
+
+        Lpq = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lpq else none
+        Lpx = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lpx else none
+        Lia = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lia else none
+        Lai = np.zeros((len(self.kpts), len(self.kpts)), dtype=object) if do_Lia else none
+
+        for (ki, kpti), (kj, kptj) in self.kpts.loop(2):
+            # Get the slices on the current process and initialise the arrays
+            o0, o1 = list(mpi_helper.prange(0, self.nmo, self.nmo))[0]
+            p0, p1 = list(mpi_helper.prange(0, self.nmo_g[k], self.nmo_g[k]))[0]
+            q0, q1 = list(mpi_helper.prange(0, self.nocc_w[k] * self.nvir_w[k], self.nocc_w[k] * self.nvir_w[k]))[0]
+            Lpq_k = np.zeros((self.naux_full, self.nmo, o1 - o0)) if do_Lpq else None
+            Lpx_k = np.zeros((self.naux, self.nmo, p1 - p0)) if do_Lpx else None
+            Lia_k = np.zeros((self.naux, q1 - q0)) if do_Lia else None
+            Lai_k = np.zeros((self.naux, q1 - q0)) if do_Lia else None
+
+            # Build the integrals blockwise
+            b1 = 0
+            for block in self.with_df.sr_loop((kpti, kptj), compact=False):
+                if block[2] == -1:
+                    raise NotImplementedError("Low dimensional integrals")
+                block = block[0] + block[1] * 1.0j
+                b0, b1 = b1, b1 + block.shape[0]
+                logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
+
+                # If needed, rotate the full (L|pq) array
+                if do_Lpq:
+                    logger.debug(self, f"(L|pq) size: ({self.naux_full}, {self.nmo}, {o1 - o0})")
+                    coeffs = (self.mo_coeff[ki], self.mo_coeff[kj][:, o0:o1])
+                    Lpq_k[b0:b1] = lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0].conj(), coeffs[1])
+
+                # Compress the block
+                block = lib.einsum("L...,LQ->Q...", block, rot[b0:b1])
+
+                # Build the compressed (L|px) array
+                if do_Lpx:
+                    logger.debug(self, f"(L|px) size: ({self.naux}, {self.nmo}, {p1 - p0})")
+                    coeffs = (self.mo_coeff[ki], self.mo_coeff_g[kj][:, p0:p1])
+                    Lpx_k += lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0].conj(), coeffs[1])
+
+                # Build the compressed (L|ia) array
+                if do_Lia:
+                    logger.debug(self, f"(L|ia) size: ({self.naux}, {q1 - q0})")
+                    i0, a0 = divmod(q0, self.nvir_w[kj])
+                    i1, a1 = divmod(q1, self.nvir_w[kj])
+                    coeffs = (self.mo_coeff_w[ki][:, i0 : i1 + 1], self.mo_coeff_w[kj][:, self.nocc_w[kj] :])
+                    tmp = lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0].conj(), coeffs[1])
+                    tmp = tmp.reshape(self.naux, -1)
+                    Lia_k += tmp[:, a0 : a0 + (q1 - q0)]
+
+                # Build the compressed (L|ai) array
+                if do_Lia:
+                    logger.debug(self, f"(L|ai) size: ({self.naux}, {q1 - q0})")
+                    i0, a0 = divmod(q0, self.nocc_w[kj])
+                    i1, a1 = divmod(q1, self.nocc_w[kj])
+                    coeffs = (self.mo_coeff_w[ki][:, self.nocc_w[ki] :], self.mo_coeff_w[kj][:, i0 : i1 + 1])
+                    tmp = lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0].conj(), coeffs[1])
+                    tmp = tmp.swapaxes(1, 2)
+                    tmp = tmp.reshape(self.naux, -1)
+                    Lai_k += tmp[:, a0 : a0 + (q1 - q0)]
+
+            if do_Lpq:
+                Lpq[ki, kj] = Lpq_k
+            if do_Lpx:
+                Lpx[ki, kj] = Lpx_k
+            if do_Lia:
+                Lia[ki, kj] = Lia_k
+                Lai[kj, ki] = Lai_k
+
+        if do_Lpq:
+            self._blocks["Lpq"] = Lpq
+        if do_Lpx:
+            self._blocks["Lpx"] = Lpx
+        if do_Lia:
+            self._blocks["Lia"] = Lia
+
+        logger.timer(self, "transform", *cput0)
+
+    @property
+    def nmo(self):
+        """
+        Return the number of MOs.
+        """
+        assert len({c.shape[-1] for c in self.mo_coeff}) == 1
+        return self.mo_coeff[0].shape[-1]
+
+    @property
+    def nocc(self):
+        """
+        Return the number of occupied MOs.
+        """
+        return [np.sum(o > 0) for o in self.mo_occ]
+
+    @property
+    def nvir(self):
+        """
+        Return the number of virtual MOs.
+        """
+        return [np.sum(o == 0) for o in self.mo_occ]
+
+    @property
+    def nmo_g(self):
+        """
+        Return the number of MOs for the Green's function.
+        """
+        return [c.shape[-1] for c in self.mo_coeff_g]
+
+    @property
+    def nmo_w(self):
+        """
+        Return the number of MOs for the screened Coulomb interaction.
+        """
+        return [c.shape[-1] for c in self.mo_coeff_w]
+
+    @property
+    def nocc_w(self):
+        """
+        Return the number of occupied MOs for the screened Coulomb
+        interaction.
+        """
+        return [np.sum(o > 0) for o in self.mo_occ_w]
+
+    @property
+    def nvir_w(self):
+        """
+        Return the number of virtual MOs for the screened Coulomb
+        interaction.
+        """
+        return [np.sum(o == 0) for o in self.mo_occ_w]

--- a/momentGW/pbc/kpts.py
+++ b/momentGW/pbc/kpts.py
@@ -103,9 +103,9 @@ class KPoints:
         Iterate over all combinations of k-points up to a given depth.
         """
         if depth == 1:
-            yield from enumerate(self)
+            yield from range(len(self))
         else:
-            yield from itertools.product(enumerate(self), repeat=depth)
+            yield from itertools.product(range(len(self)), repeat=depth)
 
     @allow_single_kpt(output_is_kpts=False)
     def is_zero(self, kpts):

--- a/momentGW/pbc/kpts.py
+++ b/momentGW/pbc/kpts.py
@@ -3,6 +3,7 @@ k-points helper utilities.
 """
 
 import itertools
+
 import numpy as np
 from pyscf import lib
 from pyscf.pbc.lib import kpts_helper
@@ -25,6 +26,7 @@ def allow_single_kpt(output_is_kpts=False):
                 return res.reshape(shape)
             else:
                 return res
+
         return wrapper
 
     return decorator

--- a/momentGW/pbc/kpts.py
+++ b/momentGW/pbc/kpts.py
@@ -1,0 +1,159 @@
+"""
+k-points helper utilities.
+"""
+
+import itertools
+import numpy as np
+from pyscf import lib
+from pyscf.pbc.lib import kpts_helper
+
+# TODO make sure this is rigorous
+
+
+def allow_single_kpt(output_is_kpts=False):
+    """
+    Decorator to allow `kpts` arguments to be passed as a single
+    k-point.
+    """
+
+    def decorator(func):
+        def wrapper(self, kpts, *args, **kwargs):
+            shape = kpts.shape
+            kpts = kpts.reshape(-1, 3)
+            res = func(self, kpts, *args, **kwargs)
+            if output_is_kpts:
+                return res.reshape(shape)
+            else:
+                return res
+        return wrapper
+
+    return decorator
+
+
+class KPoints:
+    def __init__(self, cell, kpts, tol=1e-8, wrap_around=True):
+        self.cell = cell
+        self.tol = tol
+
+        if wrap_around:
+            kpts = self.wrap_around(kpts)
+        self._kpts = kpts
+
+        self._kconserv = kpts_helper.get_kconserv(cell, kpts)
+        self._kpts_hash = {self.hash_kpts(kpt): k for k, kpt in enumerate(self._kpts)}
+
+    @allow_single_kpt(output_is_kpts=True)
+    def get_scaled_kpts(self, kpts):
+        """
+        Convert absolute k-points to scaled k-points for the current
+        cell.
+        """
+        return self.cell.get_scaled_kpts(kpts)
+
+    @allow_single_kpt(output_is_kpts=True)
+    def get_abs_kpts(self, kpts):
+        """
+        Convert scaled k-points to absolute k-points for the current
+        cell.
+        """
+        return self.cell.get_abs_kpts(kpts)
+
+    @allow_single_kpt(output_is_kpts=True)
+    def wrap_around(self, kpts, window=(-0.5, 0.5)):
+        """
+        Handle the wrapping of k-points into the first Brillouin zone.
+        """
+
+        kpts = self.get_scaled_kpts(kpts) % 1.0
+        kpts = lib.cleanse(kpts, axis=0, tol=self.tol)
+        kpts = kpts.round(decimals=self.tol_decimals) % 1.0
+
+        kpts[kpts < window[0]] += 1.0
+        kpts[kpts >= window[1]] -= 1.0
+
+        kpts = self.get_abs_kpts(kpts)
+
+        return kpts
+
+    @allow_single_kpt(output_is_kpts=False)
+    def hash_kpts(self, kpts):
+        """
+        Convert k-points to a unique, hashable representation.
+        """
+        return tuple(np.rint(kpts / (self.tol)).ravel().astype(int))
+
+    @property
+    def tol_decimals(self):
+        """Convert the tolerance into a number of decimal places."""
+        return int(-np.log10(self.tol + 1e-16)) + 2
+
+    def conserve(self, ki, kj, kk):
+        """
+        Get the index of the k-point that conserves momentum.
+        """
+        return self._kconserv[ki, kj, kk]
+
+    def loop(self, depth):
+        """
+        Iterate over all combinations of k-points up to a given depth.
+        """
+        return itertools.product(enumerate(self), repeat=depth)
+
+    @allow_single_kpt(output_is_kpts=False)
+    def is_zero(self, kpts):
+        """
+        Check if the k-point is zero.
+        """
+        return np.max(np.abs(kpts)) < self.tol
+
+    def member(self, kpt):
+        """
+        Find the index of the k-point in the k-point list.
+        """
+        if kpt not in self:
+            raise ValueError(f"{kpt} is not in list")
+        return self._kpts_hash[self.hash_kpts(kpt)]
+
+    index = member
+
+    def __contains__(self, kpt):
+        """
+        Check if the k-point is in the k-point list.
+        """
+        return self.hash_kpts(kpt) in self._kpts_hash
+
+    def __getitem__(self, index):
+        """
+        Get the k-point at the given index.
+        """
+        return self._kpts[index]
+
+    def __len__(self):
+        """
+        Get the number of k-points.
+        """
+        return len(self._kpts)
+
+    def __iter__(self):
+        """
+        Iterate over the k-points.
+        """
+        return iter(self._kpts)
+
+    def __repr__(self):
+        """
+        Get a string representation of the k-points.
+        """
+        return repr(self._kpts)
+
+    def __str__(self):
+        """
+        Get a string representation of the k-points.
+        """
+        return str(self._kpts)
+
+    def __array__(self):
+        """
+        Get the k-points as a numpy array.
+        """
+        return np.asarray(self._kpts)

--- a/momentGW/pbc/qsgw.py
+++ b/momentGW/pbc/qsgw.py
@@ -56,7 +56,9 @@ class qsKGW(KGW, qsGW):
         proj = lib.einsum("k...pq,k...pi,k...qj->k...ij", ovlp, np.conj(mo1), mo2)
 
         if isinstance(matrix, np.ndarray):
-            projected_matrix = lib.einsum("k...pq,k...pi,k...qj->k...ij", matrix, np.conj(proj), proj)
+            projected_matrix = lib.einsum(
+                "k...pq,k...pi,k...qj->k...ij", matrix, np.conj(proj), proj
+            )
         else:
             projected_matrix = []
             for k, m in enumerate(matrix):

--- a/momentGW/pbc/qsgw.py
+++ b/momentGW/pbc/qsgw.py
@@ -1,0 +1,110 @@
+"""
+Spin-restricted quasiparticle self-consistent GW via self-energy moment
+constraints for periodic systems.
+"""
+
+import numpy as np
+from pyscf import lib
+from pyscf.agf2 import GreensFunction, mpi_helper
+from pyscf.agf2.dfragf2 import get_jk
+from pyscf.ao2mo import _ao2mo
+from pyscf.lib import logger
+
+from momentGW import util
+from momentGW.pbc.evgw import evKGW
+from momentGW.pbc.gw import KGW
+from momentGW.qsgw import qsGW
+
+
+class qsKGW(KGW, qsGW):
+    __doc__ = qsGW.__doc__.replace("molecules", "periodic systems", 1)
+
+    # --- Default qsKGW options
+
+    solver = KGW
+
+    @property
+    def name(self):
+        return "qsKGW"
+
+    @staticmethod
+    def project_basis(matrix, ovlp, mo1, mo2):
+        """
+        Project a matrix from one basis to another.
+
+        Parameters
+        ----------
+        matrix : numpy.ndarray or tuple of (GreensFunction or SelfEnergy)
+            Matrix to project at each k-point. Can also be a tuple of
+            `GreensFunction` or `SelfEnergy` objects, in which case the
+            `couplings` attributes are projected.
+        ovlp : numpy.ndarray
+            Overlap matrix in the shared (AO) basis at each k-point.
+        mo1 : numpy.ndarray
+            First basis, rotates from the shared (AO) basis into the
+            basis of `matrix` at each k-point.
+        mo2 : numpy.ndarray
+            Second basis, rotates from the shared (AO) basis into the
+            desired basis of the output at each k-point.
+
+        Returns
+        -------
+        projected_matrix : numpy.ndarray or tuple of (GreensFunction or SelfEnergy)
+            Matrix projected into the desired basis at each k-point.
+        """
+
+        proj = lib.einsum("k...pq,k...pi,k...qj->k...ij", ovlp, np.conj(mo1), mo2)
+
+        if isinstance(matrix, np.ndarray):
+            projected_matrix = lib.einsum("k...pq,k...pi,k...qj->k...ij", matrix, proj, proj)
+        else:
+            projected_matrix = []
+            for k, m in enumerate(matrix):
+                coupling = lib.einsum("pk,pi->ik", m.coupling, np.conj(proj[k]))
+                projected_m = m.copy()
+                projected_m.coupling = coupling
+                projected_matrix.append(projected_m)
+
+        return projected_matrix
+
+    @staticmethod
+    def self_energy_to_moments(se, nmom_max):
+        """
+        Return the hole and particle moments for a self-energy.
+
+        Parameters
+        ----------
+        se : tuple of SelfEnergy
+            Self-energy to compute the moments of at each k-point.
+
+        Returns
+        -------
+        th : numpy.ndarray
+            Hole moments at each k-point.
+        tp : numpy.ndarray
+            Particle moments at each k-point.
+        """
+        th = np.array([s.get_occupied().moment(range(nmom_max + 1)) for s in se])
+        tp = np.array([s.get_virtual().moment(range(nmom_max + 1)) for s in se])
+        return th, tp
+
+    def build_static_potential(self, mo_energy, se):
+        """
+        Build the static potential approximation to the self-energy.
+
+        Parameters
+        ----------
+        mo_energy : numpy.ndarray
+            Molecular orbital energies at each k-point.
+        se : tuple of SelfEnergy
+            Self-energy to approximate at each k-point.
+
+        Returns
+        -------
+        se_qp : numpy.ndarray
+            Static potential approximation to the self-energy at each
+            k-point.
+        """
+        return np.array([qsGW.build_static_potential(self, mo, s) for mo, s in zip(mo_energy, se)])
+
+    check_convergence = evKGW.check_convergence

--- a/momentGW/pbc/qsgw.py
+++ b/momentGW/pbc/qsgw.py
@@ -23,6 +23,8 @@ class qsKGW(KGW, qsGW):
 
     solver = KGW
 
+    _opts = util.list_union(KGW._opts, qsGW._opts)
+
     @property
     def name(self):
         return "qsKGW"

--- a/momentGW/pbc/qsgw.py
+++ b/momentGW/pbc/qsgw.py
@@ -56,7 +56,7 @@ class qsKGW(KGW, qsGW):
         proj = lib.einsum("k...pq,k...pi,k...qj->k...ij", ovlp, np.conj(mo1), mo2)
 
         if isinstance(matrix, np.ndarray):
-            projected_matrix = lib.einsum("k...pq,k...pi,k...qj->k...ij", matrix, proj, proj)
+            projected_matrix = lib.einsum("k...pq,k...pi,k...qj->k...ij", matrix, np.conj(proj), proj)
         else:
             projected_matrix = []
             for k, m in enumerate(matrix):

--- a/momentGW/pbc/rpa.py
+++ b/momentGW/pbc/rpa.py
@@ -79,39 +79,38 @@ def build_se_moments_drpa_exact(
                     ki_p_q = kpt_dict[df.hash_array(wrap_around(scaled_kpts[ki] + scaled_kpts[q]))]
                     kj_p_q = kpt_dict[df.hash_array(wrap_around(scaled_kpts[kj] + scaled_kpts[q]))]
 
-                    ei = mo_energy[ki][:nocc[ki]]
-                    ea = mo_energy[ki_p_q][nocc[ki_p_q]:]
+                    ei = mo_energy[ki][: nocc[ki]]
+                    ea = mo_energy[ki_p_q][nocc[ki_p_q] :]
 
-                    Via = Lpq[ki, ki_p_q, :, :nocc[ki], nocc[ki_p_q]:]
-                    Vjb = Lpq[kj, kj_p_q, :, :nocc[kj], nocc[kj_p_q]:]
-                    Vbj = Lpq[kj_p_q, kj, :, nocc[kj_p_q]:, :nocc[kj]]
+                    Via = Lpq[ki, ki_p_q, :, : nocc[ki], nocc[ki_p_q] :]
+                    Vjb = Lpq[kj, kj_p_q, :, : nocc[kj], nocc[kj_p_q] :]
+                    Vbj = Lpq[kj_p_q, kj, :, nocc[kj_p_q] :, : nocc[kj]]
                     iajb = lib.einsum("Lia,Ljb->iajb", Via, Vjb)
                     iabj = lib.einsum("Lia,Lbj->iajb", Via, Vbj)
 
-                    blocks["a", q, ki, kj] = np.diag((ea[:, None] - ei[None]).ravel().astype(iajb.dtype))
+                    blocks["a", q, ki, kj] = np.diag(
+                        (ea[:, None] - ei[None]).ravel().astype(iajb.dtype)
+                    )
                     blocks["a", q, ki, kj] += iabj.reshape(blocks["a", q, ki, kj].shape)
                     blocks["b", q, ki, kj] = iajb.reshape(blocks["a", q, ki, kj].shape)
 
     z = np.zeros((nov[0], nov[0]), dtype=np.complex128)
     for q in range(nkpts):
-        a = np.block([[
-            blocks.get(("a", q, ki, kj), z)
-            for kj in range(nkpts)]
-            for ki in range(nkpts)]
+        a = np.block(
+            [[blocks.get(("a", q, ki, kj), z) for kj in range(nkpts)] for ki in range(nkpts)]
         )
-        b = np.block([[
-            blocks.get(("b", q, ki, kj), z)
-            for kj in range(nkpts)]
-            for ki in range(nkpts)]
+        b = np.block(
+            [[blocks.get(("b", q, ki, kj), z) for kj in range(nkpts)] for ki in range(nkpts)]
         )
         mat = np.block([[a, b], [-b.conj(), -a.conj()]])
         omega, xy = np.linalg.eigh(mat)
-        x, y = xy[:, :np.sum(nov)], xy[:, np.sum(nov):]
+        x, y = xy[:, : np.sum(nov)], xy[:, np.sum(nov) :]
 
 
 if __name__ == "__main__":
-    from momentGW.pbc.gw import KGW
     from pyscf.pbc import gto, scf
+
+    from momentGW.pbc.gw import KGW
 
     cell = gto.Cell()
     cell.atom = "He 1 1 1; He 3 2 3"

--- a/momentGW/pbc/scgw.py
+++ b/momentGW/pbc/scgw.py
@@ -9,6 +9,7 @@ from pyscf.agf2 import GreensFunction, mpi_helper
 from pyscf.ao2mo import _ao2mo
 from pyscf.lib import logger
 
+from momentGW import util
 from momentGW.pbc.evgw import evKGW
 from momentGW.pbc.gw import KGW
 from momentGW.scgw import scGW
@@ -16,6 +17,8 @@ from momentGW.scgw import scGW
 
 class scKGW(KGW, scGW):
     __doc__ = scGW.__doc__.replace("molecules", "periodic systems", 1)
+
+    _opts = util.list_union(KGW._opts, scGW._opts)
 
     @property
     def name(self):

--- a/momentGW/pbc/scgw.py
+++ b/momentGW/pbc/scgw.py
@@ -1,0 +1,49 @@
+"""
+Spin-restricted self-consistent GW via self-energy moment constraitns
+for periodic systems.
+"""
+
+import numpy as np
+from pyscf import lib
+from pyscf.agf2 import GreensFunction, mpi_helper
+from pyscf.ao2mo import _ao2mo
+from pyscf.lib import logger
+
+from momentGW.pbc.evgw import evKGW
+from momentGW.pbc.gw import KGW
+from momentGW.scgw import scGW
+
+
+class scKGW(KGW, scGW):
+    __doc__ = scGW.__doc__.replace("molecules", "periodic systems", 1)
+
+    @property
+    def name(self):
+        return "scKG%sW%s" % ("0" if self.g0 else "", "0" if self.w0 else "")
+
+    def init_gf(self, mo_energy=None):
+        """Initialise the mean-field Green's function.
+
+        Parameters
+        ----------
+        mo_energy : numpy.ndarray, optional
+            Molecular orbital energies at each k-point. Default value is
+            `self.mo_energy`.
+
+        Returns
+        -------
+        gf : tuple of GreensFunction
+            Mean-field Green's function at each k-point.
+        """
+
+        if mo_energy is None:
+            mo_energy = self.mo_energy
+
+        gf = []
+        for k, kpt in self.kpts.loop(1):
+            chempot = 0.5 * (mo_energy[k][self.nocc[k] - 1] + mo_energy[k][self.nocc[k]])
+            gf.append(GreensFunction(mo_energy[k], np.eye(self.nmo), chempot=chempot))
+
+        return gf
+
+    check_convergence = evKGW.check_convergence

--- a/momentGW/pbc/scgw.py
+++ b/momentGW/pbc/scgw.py
@@ -40,7 +40,7 @@ class scKGW(KGW, scGW):
             mo_energy = self.mo_energy
 
         gf = []
-        for k, kpt in self.kpts.loop(1):
+        for k in self.kpts.loop(1):
             chempot = 0.5 * (mo_energy[k][self.nocc[k] - 1] + mo_energy[k][self.nocc[k]])
             gf.append(GreensFunction(mo_energy[k], np.eye(self.nmo), chempot=chempot))
 

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -1,0 +1,233 @@
+"""
+Construct TDA moments with periodic boundary conditions.
+"""
+
+import numpy as np
+import scipy.special
+from pyscf import lib
+from pyscf.agf2 import mpi_helper
+
+from momentGW.tda import TDA as MolTDA
+
+
+class TDA(MolTDA):
+    """
+    Compute the self-energy moments using dTDA and numerical integration
+
+    with periodic boundary conditions.
+    Parameters
+    ----------
+    gw : BaseKGW
+        GW object.
+    nmom_max : int
+        Maximum moment number to calculate.
+    Lpx : numpy.ndarray
+        Density-fitted ERI tensor, where the first two indices
+        enumerate the k-points, the third index is the auxiliary
+        basis function index, and the fourth and fifth indices are
+        the MO and Green's function orbital indices, respectively.
+    Lia : numpy.ndarray
+        Density-fitted ERI tensor, where the first two indices
+        enumerate the k-points, the third index is the auxiliary
+        basis function index, and the fourth and fifth indices are
+        the occupied and virtual screened Coulomb interaction
+        orbital indices, respectively.
+    Lai : numpy.ndarray
+        As above, with transposition of the occupied and virtual
+        indices.
+    mo_energy : numpy.ndarray or tuple of numpy.ndarray, optional
+        Molecular orbital energies at each k-point.  If a tuple is passed,
+        the first element corresponds to the Green's function basis and
+        the second to the screened Coulomb interaction.  Default value is
+        that of `gw._scf.mo_energy`.
+    mo_occ : numpy.ndarray or tuple of numpy.ndarray, optional
+        Molecular orbital occupancies at each k-point.  If a tuple is
+        passed, the first element corresponds to the Green's function basis
+        and the second to the screened Coulomb interaction.  Default value
+        is that of `gw._scf.mo_occ`.
+    """
+
+    def __init__(
+        self,
+        gw,
+        nmom_max,
+        Lpx,
+        Lia,
+        Lai,
+        mo_energy=None,
+        mo_occ=None,
+    ):
+        self.gw = gw
+        self.nmom_max = nmom_max
+        self.Lpx = Lpx
+        self.Lia = Lia
+        self.Lai = Lai
+
+        # Get the MO energies for G and W
+        if mo_energy is None:
+            self.mo_energy_g = self.mo_energy_w = gw._scf.mo_energy
+        elif isinstance(mo_energy, tuple):
+            self.mo_energy_g, self.mo_energy_w = mo_energy
+        else:
+            self.mo_energy_g = self.mo_energy_w = mo_energy
+
+        # Get the MO occupancies for G and W
+        if mo_occ is None:
+            self.mo_occ_g = self.mo_occ_w = gw._scf.mo_occ
+        elif isinstance(mo_occ, tuple):
+            self.mo_occ_g, self.mo_occ_w = mo_occ
+        else:
+            self.mo_occ_g = self.mo_occ_w = mo_occ
+
+        # Reshape ERI tensors
+        for (ki, kpti), (kj, kptj) in self.kpts.loop(2):
+            self.Lia[ki, kj] = self.Lia[ki, kj].reshape(self.naux, self.nov[ki, kj])
+            self.Lai[ki, kj] = self.Lai[ki, kj].swapaxes(1, 2).reshape(self.naux, self.nov[ki, kj])
+            self.Lpx[ki, kj] = self.Lpx[ki, kj].reshape(self.naux, self.nmo, self.mo_energy_g[kj].size)
+        self.Lai = self.Lai.T
+
+        # Options and thresholds
+        self.report_quadrature_error = True
+        if "ia" in getattr(self.gw, "compression", "").split(","):
+            self.compression_tol = gw.compression_tol
+        else:
+            self.compression_tol = None
+
+    def compress_eris(self):
+        """Compress the ERI tensors."""
+
+        return  # TODO
+
+    def build_dd_moments(self):
+        """Build the moments of the density-density response."""
+
+        cput0 = (lib.logger.process_clock(), lib.logger.perf_counter())
+        lib.logger.info(self.gw, "Building density-density moments")
+        lib.logger.debug(self.gw, "Memory usage: %.2f GB", self._memory_usage())
+
+        # TODO MPI
+        kpts = self.kpts
+        moments = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
+
+        # Get the zeroth order moment
+        for (q, qpt), (kb, kptb) in kpts.loop(2):
+            kj = kpts.member(kpts.wrap_around(kptb - qpt))
+            moments[q, kb, 0] += self.Lia[kj, kb] / self.nkpts
+        cput1 = lib.logger.timer(self.gw, "zeroth moment", *cput0)
+
+        # Get the higher order moments
+        for i in range(1, self.nmom_max + 1):
+            for (q, qpt), (kb, kptb) in kpts.loop(2):
+                kj = kpts.member(kpts.wrap_around(kptb - qpt))
+
+                d = lib.direct_sum(
+                    "a-i->ia",
+                    self.mo_energy_w[kb][self.mo_occ_w[kb] == 0],
+                    self.mo_energy_w[kj][self.mo_occ_w[kj] > 0],
+                )
+                moments[q, kb, i] += moments[q, kb, i-1] * d.ravel()[None]
+
+            for (q, qpt), (ka, kpta), (kb, kptb) in kpts.loop(3):
+                ki = kpts.member(kpts.wrap_around(kpta - qpt))
+                kj = kpts.member(kpts.wrap_around(kptb - qpt))
+
+                moments[q, kb, i] += np.linalg.multi_dot((
+                    moments[q, ka, i-1],
+                    self.Lia[ki, ka].T,
+                    self.Lai[kj, kb],
+                )) * 2.0 / self.nkpts
+
+            cput1 = lib.logger.timer(self.gw, "moment %d" % i, *cput1)
+
+        return moments
+
+    def build_se_moments(self, moments_dd):
+        """Build the moments of the self-energy via convolution."""
+
+        cput0 = (lib.logger.process_clock(), lib.logger.perf_counter())
+        lib.logger.info(self.gw, "Building self-energy moments")
+        lib.logger.debug(self.gw, "Memory usage: %.2f GB", self._memory_usage())
+
+        # Setup dependent on diagonal SE
+        if self.gw.diagonal_se:
+            pqchar = charp = qchar = "p"
+            eta_shape = lambda k: (self.mo_energy_g[k].size, self.nmom_max + 1, self.nmo)
+            fproc = lambda x: np.diag(x)
+        else:
+            pqchar, pchar, qchar = "pq", "p", "q"
+            eta_shape = lambda k: (self.mo_energy_g[k].size, self.nmom_max + 1, self.nmo, self.nmo)
+            fproc = lambda x: x
+        eta = np.zeros((self.nkpts, self.nkpts), dtype=object)
+
+        # Get the moments in (aux|aux) and rotate to (mo|mo)
+        for n in range(self.nmom_max + 1):
+            for q, qpt in enumerate(self.kpts):
+                eta_aux = 0
+                for kb, kptb in enumerate(self.kpts):
+                    kj = self.kpts.member(self.kpts.wrap_around(kptb - qpt))
+                    eta_aux += np.dot(moments_dd[q, kb, n], self.Lia[kj, kb].T.conj())
+
+                for kp, kptp in enumerate(self.kpts):
+                    kx = self.kpts.member(self.kpts.wrap_around(kptp - qpt))
+
+                    if not isinstance(eta[kp, q], np.ndarray):
+                        eta[kp, q] = np.zeros(eta_shape(kx), dtype=eta_aux.dtype)
+
+                    for x in range(self.mo_energy_g[kx].size):
+                        Lp = self.Lpx[kp, kx][:, :, x]
+                        eta[kp, q][x, n] += lib.einsum(f"P{pchar},Q{qchar},PQ->{pqchar}", Lp, Lp.conj(), eta_aux) * 2.0 / self.nkpts
+        cput1 = lib.logger.timer(self.gw, "rotating DD moments", *cput0)
+
+        # Construct the self-energy moments
+        moments_occ = np.zeros((self.nkpts, self.nmom_max + 1), dtype=object)
+        moments_vir = np.zeros((self.nkpts, self.nmom_max + 1), dtype=object)
+        moms = np.arange(self.nmom_max + 1)
+        for n in moms:
+            fp = scipy.special.binom(n, moms)
+            fh = fp * (-1) ** moms
+            for (q, qpt), (kp, kptp) in self.kpts.loop(2):
+                kx = self.kpts.member(self.kpts.wrap_around(kptp - qpt))
+
+                eo = np.power.outer(self.mo_energy_g[kx][self.mo_occ_g[kx] > 0], n - moms)
+                to = lib.einsum(f"t,kt,kt{pqchar}->{pqchar}", fh, eo, eta[kp, q][self.mo_occ_g[kx] > 0])
+                moments_occ[kp, n] += fproc(to)
+
+                ev = np.power.outer(self.mo_energy_g[kx][self.mo_occ_g[kx] == 0], n - moms)
+                tv = lib.einsum(f"t,ct,ct{pqchar}->{pqchar}", fp, ev, eta[kp, q][self.mo_occ_g[kx] == 0])
+                moments_vir[kp, n] += fproc(tv)
+
+        for k, kpt in enumerate(self.kpts):
+            for n in range(self.nmom_max + 1):
+                moments_occ[k, n] = 0.5 * (moments_occ[k, n] + moments_occ[k, n].T.conj())
+                moments_vir[k, n] = 0.5 * (moments_vir[k, n] + moments_vir[k, n].T.conj())
+
+        cput1 = lib.logger.timer(self.gw, "constructing SE moments", *cput1)
+
+        return moments_occ, moments_vir
+
+    def build_dd_moments_exact(self):
+        raise NotImplementedError
+
+    @property
+    def naux(self):
+        """Number of auxiliaries."""
+        assert self.Lpx[0, 0].shape[0] == self.Lia[0, 0].shape[0]
+        return self.Lpx[0, 0].shape[0]
+
+    @property
+    def nov(self):
+        """Number of ov states in W."""
+        return np.multiply.outer(
+            [np.sum(occ > 0) for occ in self.mo_occ_w],
+            [np.sum(occ == 0) for occ in self.mo_occ_w],
+        )
+
+    @property
+    def kpts(self):
+        """k-points."""
+        return self.gw.kpts
+
+    @property
+    def nkpts(self):
+        """Number of k-points."""
+        return self.gw.nkpts

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -277,7 +277,6 @@ class TDA(MolTDA):
         kpts = self.kpts
         integrals = self.integrals
 
-
     @property
     def naux(self):
         """Number of auxiliaries."""

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -91,15 +91,15 @@ class TDA(MolTDA):
         moments = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
 
         # Get the zeroth order moment
-        for (q, qpt), (kb, kptb) in kpts.loop(2):
-            kj = kpts.member(kpts.wrap_around(kptb - qpt))
+        for q, kb in kpts.loop(2):
+            kj = kpts.member(kpts.wrap_around(self.kpts[kb] - self.kpts[q]))
             moments[q, kb, 0] += self.integrals.Lia[kj, kb] / self.nkpts
         cput1 = lib.logger.timer(self.gw, "zeroth moment", *cput0)
 
         # Get the higher order moments
         for i in range(1, self.nmom_max + 1):
-            for (q, qpt), (kb, kptb) in kpts.loop(2):
-                kj = kpts.member(kpts.wrap_around(kptb - qpt))
+            for q, kb in kpts.loop(2):
+                kj = kpts.member(kpts.wrap_around(self.kpts[kb] - self.kpts[q]))
 
                 d = lib.direct_sum(
                     "a-i->ia",
@@ -108,9 +108,9 @@ class TDA(MolTDA):
                 )
                 moments[q, kb, i] += moments[q, kb, i - 1] * d.ravel()[None]
 
-            for (q, qpt), (ka, kpta), (kb, kptb) in kpts.loop(3):
-                ki = kpts.member(kpts.wrap_around(kpta - qpt))
-                kj = kpts.member(kpts.wrap_around(kptb - qpt))
+            for q, ka, kb in kpts.loop(3):
+                ki = kpts.member(kpts.wrap_around(self.kpts[ka] - self.kpts[q]))
+                kj = kpts.member(kpts.wrap_around(self.kpts[kb] - self.kpts[q]))
 
                 moments[q, kb, i] += (
                     np.linalg.multi_dot(
@@ -176,8 +176,8 @@ class TDA(MolTDA):
         for n in moms:
             fp = scipy.special.binom(n, moms)
             fh = fp * (-1) ** moms
-            for (q, qpt), (kp, kptp) in self.kpts.loop(2):
-                kx = self.kpts.member(self.kpts.wrap_around(kptp - qpt))
+            for q, kp in self.kpts.loop(2):
+                kx = self.kpts.member(self.kpts.wrap_around(self.kpts[kp] - self.kpts[q]))
 
                 eo = np.power.outer(self.mo_energy_g[kx][self.mo_occ_g[kx] > 0], n - moms)
                 to = lib.einsum(

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -137,7 +137,7 @@ class TDA(MolTDA):
 
         # Setup dependent on diagonal SE
         if self.gw.diagonal_se:
-            pqchar = charp = qchar = "p"
+            pqchar = pchar = qchar = "p"
             eta_shape = lambda k: (self.mo_energy_g[k].size, self.nmom_max + 1, self.nmo)
             fproc = lambda x: np.diag(x)
         else:
@@ -196,10 +196,11 @@ class TDA(MolTDA):
                 if not np.allclose(moments_occ[k, n], moments_occ[k, n].T.conj()):
                     np.set_printoptions(edgeitems=1000, linewidth=1000, precision=4)
                     print(moments_occ[k, n])
-                if not np.allclose(moments_occ[k, n], moments_occ[k, n].T.conj()):
-                    raise ValueError("moments_occ not hermitian")
-                if not np.allclose(moments_vir[k, n], moments_vir[k, n].T.conj()):
-                    raise ValueError("moments_vir not hermitian")
+                    print(np.max(np.abs(moments_occ[k, n] - moments_occ[k, n].T.conj())))
+                # if not np.allclose(moments_occ[k, n], moments_occ[k, n].T.conj()):
+                #    raise ValueError("moments_occ not hermitian")
+                # if not np.allclose(moments_vir[k, n], moments_vir[k, n].T.conj()):
+                #    raise ValueError("moments_vir not hermitian")
                 moments_occ[k, n] = 0.5 * (moments_occ[k, n] + moments_occ[k, n].T.conj())
                 moments_vir[k, n] = 0.5 * (moments_vir[k, n] + moments_vir[k, n].T.conj())
 

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -107,7 +107,6 @@ class TDA(MolTDA):
         lib.logger.info(self.gw, "Building density-density moments")
         lib.logger.debug(self.gw, "Memory usage: %.2f GB", self._memory_usage())
 
-        # TODO MPI
         kpts = self.kpts
         moments = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
 

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -206,8 +206,7 @@ class TDA(MolTDA):
     @property
     def naux(self):
         """Number of auxiliaries."""
-        assert self.integrals.Lpx[0, 0].shape[0] == self.integrals.Lia[0, 0].shape[0]
-        return self.integrals.Lpx[0, 0].shape[0]
+        return self.integrals.naux
 
     @property
     def nov(self):

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -32,12 +32,12 @@ class TDA(MolTDA):
         Molecular orbital energies at each k-point.  If a tuple is passed,
         the first element corresponds to the Green's function basis and
         the second to the screened Coulomb interaction.  Default value is
-        that of `gw._scf.mo_energy`.
+        that of `gw.mo_energy`.
     mo_occ : numpy.ndarray or tuple of numpy.ndarray, optional
         Molecular orbital occupancies at each k-point.  If a tuple is
         passed, the first element corresponds to the Green's function basis
         and the second to the screened Coulomb interaction.  Default value
-        is that of `gw._scf.mo_occ`.
+        is that of `gw.mo_occ`.
     """
 
     def __init__(
@@ -54,7 +54,7 @@ class TDA(MolTDA):
 
         # Get the MO energies for G and W
         if mo_energy is None:
-            self.mo_energy_g = self.mo_energy_w = gw._scf.mo_energy
+            self.mo_energy_g = self.mo_energy_w = gw.mo_energy
         elif isinstance(mo_energy, tuple):
             self.mo_energy_g, self.mo_energy_w = mo_energy
         else:
@@ -62,7 +62,7 @@ class TDA(MolTDA):
 
         # Get the MO occupancies for G and W
         if mo_occ is None:
-            self.mo_occ_g = self.mo_occ_w = gw._scf.mo_occ
+            self.mo_occ_g = self.mo_occ_w = gw.mo_occ
         elif isinstance(mo_occ, tuple):
             self.mo_occ_g, self.mo_occ_w = mo_occ
         else:
@@ -193,14 +193,6 @@ class TDA(MolTDA):
 
         for k, kpt in enumerate(self.kpts):
             for n in range(self.nmom_max + 1):
-                if not np.allclose(moments_occ[k, n], moments_occ[k, n].T.conj()):
-                    np.set_printoptions(edgeitems=1000, linewidth=1000, precision=4)
-                    print(moments_occ[k, n])
-                    print(np.max(np.abs(moments_occ[k, n] - moments_occ[k, n].T.conj())))
-                # if not np.allclose(moments_occ[k, n], moments_occ[k, n].T.conj()):
-                #    raise ValueError("moments_occ not hermitian")
-                # if not np.allclose(moments_vir[k, n], moments_vir[k, n].T.conj()):
-                #    raise ValueError("moments_vir not hermitian")
                 moments_occ[k, n] = 0.5 * (moments_occ[k, n] + moments_occ[k, n].T.conj())
                 moments_vir[k, n] = 0.5 * (moments_vir[k, n] + moments_vir[k, n].T.conj())
 

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -190,8 +190,8 @@ class TDA(MolTDA):
         cput1 = lib.logger.timer(self.gw, "rotating DD moments", *cput0)
 
         # Construct the self-energy moments
-        moments_occ = np.zeros((self.nkpts, self.nmom_max + 1), dtype=object)
-        moments_vir = np.zeros((self.nkpts, self.nmom_max + 1), dtype=object)
+        moments_occ = np.zeros((self.nkpts, self.nmom_max + 1, self.nmo, self.nmo), dtype=complex)
+        moments_vir = np.zeros((self.nkpts, self.nmom_max + 1, self.nmo, self.nmo), dtype=complex)
         moms = np.arange(self.nmom_max + 1)
         for n in moms:
             fp = scipy.special.binom(n, moms)

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -6,6 +6,7 @@ import numpy as np
 import scipy.special
 from pyscf import lib
 from pyscf.agf2 import mpi_helper
+from pyscf.pbc.gw.krgw_ac import get_qij
 
 from momentGW.tda import TDA as MolTDA
 
@@ -218,6 +219,64 @@ class TDA(MolTDA):
 
     def build_dd_moments_exact(self):
         raise NotImplementedError
+
+    def build_dd_moments_fc(self):
+        """
+        Build the moments of the "head" (G=0, G'=0) and "wing"
+        (G=P, G'=0) density-density response.
+        """
+
+        kpts = self.kpts
+        integrals = self.integrals
+
+        # q-point for q->0 finite size correction
+        qpt = np.array([1e-3, 0.0, 0.0])
+        qpt = self.kpts.get_abs_kpts(qpt)
+
+        # 1/sqrt(Ω) * ⟨Ψ_{ik}|e^{iqr}|Ψ_{ak-q}⟩
+        qij = get_qij(self, qpt, self.mo_coeff)
+
+        # Build the DD moments for the "head" (G=0, G'=0) correction
+        moments_head = np.zeros((self.nkpts, self.nmom_max + 1), dtype=complex)
+        for k in kpts.loop(1):
+            d = lib.direct_sum(
+                "a-i->ia",
+                self.mo_energy_w[k][self.mo_occ_w[k] == 0],
+                self.mo_energy_w[k][self.mo_occ_w[k] > 0],
+            )
+            dn = np.ones_like(d)
+            for n in range(self.nmom_max + 1):
+                moments_head[k, n] = lib.einsum("ia,ia,ia->", qij[k], qij[k].conj(), dn)
+                dn *= d
+
+        # Build the DD moments for the "wing" (G=P, G'=0) correction
+        moments_tail = np.zeros((self.nkpts, self.nmom_max + 1), dtype=object)
+        for k in kpts.loop(1):
+            d = lib.direct_sum(
+                "a-i->ia",
+                self.mo_energy_w[k][self.mo_occ_w[k] == 0],
+                self.mo_energy_w[k][self.mo_occ_w[k] > 0],
+            )
+            dn = np.ones_like(d)
+            for n in range(self.nmom_max + 1):
+                moments_wing[k, n] = lib.einsum("Lia,ia,ia->L", integrals.Lia, qij[k].conj(), dn)
+                dn *= d
+
+        moments_head *= -4.0 * np.pi
+        moments_wing *= -4.0 * np.pi
+
+        return moments_head, moments_wing
+
+    def build_se_moments_fc(self, moments_head, moments_wing):
+        """
+        Build the moments of the self-energy corresponding to the
+        "wing" (G=P, G'=0) and "head" (G=0, G'=0) density-density
+        response via convolution.
+        """
+
+        kpts = self.kpts
+        integrals = self.integrals
+
 
     @property
     def naux(self):

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -341,3 +341,7 @@ class qsGW(GW):
         return 0.5 * (se_i + se_j)
 
     check_convergence = evGW.check_convergence
+
+    @property
+    def has_fock_loop(self):
+        return True

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -334,11 +334,14 @@ class qsGW(GW):
             se_i = lib.einsum("pk,qk,pqk->pq", se.coupling, np.conj(se.coupling), reg)
             se_j = se_i.T.conj()
 
-        if not np.iscomplexobj(se.coupling):
-            se_i = se_i.real
-            se_j = se_j.real
+        se_ij = 0.5 * (se_i + se_j)
 
-        return 0.5 * (se_i + se_j)
+        if not np.iscomplexobj(se.coupling):
+            se_ij = se_ij.real
+        else:
+            se_ij[np.diag_indices_from(se_ij)] = se_ij[np.diag_indices_from(se_ij)].real
+
+        return se_ij
 
     check_convergence = evGW.check_convergence
 

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -88,7 +88,8 @@ def kernel(
 
     # Get the self-energy
     solver_options = {} if not gw.solver_options else gw.solver_options.copy()
-    solver_options["polarizability"] = gw.polarizability
+    for key in gw.solver._opts:
+        solver_options[key] = solver_options.get(key, getattr(gw, key))
     subgw = gw.solver(gw._scf, **solver_options)
     subgw.verbose = 0
     subgw.mo_energy = mo_energy
@@ -331,7 +332,7 @@ class qsGW(GW):
             reg /= d2p
             se_qp = lib.einsum("pk,qk,pqk->pq", se.coupling, np.conj(se.coupling), reg)
 
-        se_qp = 0.5 * (se_qp + se_qp.T).real
+        se_qp = 0.5 * (se_qp + se_qp.T.conj()).real
 
         return se_qp
 

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -325,23 +325,20 @@ class qsGW(GW):
             denom = lib.direct_sum("p-q-q->pq", mo_energy, se.energy, eta)
             se_i = lib.einsum("pk,qk,pk->pq", se.coupling, np.conj(se.coupling), 1 / denom)
             se_j = lib.einsum("pk,qk,qk->pq", se.coupling, np.conj(se.coupling), 1 / denom)
-
-            if not np.iscomplexobj(se.coupling):
-                se_i = se_i.real
-                se_j = se_j.real
-
-            se_qp = 0.5 * (se_i + se_j)
-
         else:
             denom = lib.direct_sum("p-q->pq", mo_energy, se.energy)
             d2p = lib.direct_sum("pk,qk->pqk", denom**2, denom**2)
             reg = 1 - np.exp(-d2p * self.srg)
             reg *= lib.direct_sum("pk,qk->pqk", denom, denom)
             reg /= d2p
-            se_qp = lib.einsum("pk,qk,pqk->pq", se.coupling, np.conj(se.coupling), reg)
-            se_qp = 0.5 * (se_qp + se_qp.T)
+            se_i = lib.einsum("pk,qk,pqk->pq", se.coupling, np.conj(se.coupling), reg)
+            se_j = lib.einsum("pk,qk,qpk->pq", se.coupling, np.conj(se.coupling), reg)
 
-        return se_qp
+        if not np.iscomplexobj(se.coupling):
+            se_i = se_i.real
+            se_j = se_j.real
+
+        return 0.5 * (se_i + se_j)
 
     check_convergence = evGW.check_convergence
 

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -59,10 +59,6 @@ def kernel(
     if gw.polarizability == "drpa-exact":
         raise NotImplementedError("%s for polarizability=%s" % (gw.name, gw.polarizability))
 
-    if integrals is None:
-        integrals = gw.ao2mo(mo_coeff)
-    Lpq, Lia = integrals
-
     nmo = gw.nmo
     nocc = gw.nocc
     naux = gw.with_df.get_naoaux()

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -325,20 +325,23 @@ class qsGW(GW):
             denom = lib.direct_sum("p-q-q->pq", mo_energy, se.energy, eta)
             se_i = lib.einsum("pk,qk,pk->pq", se.coupling, np.conj(se.coupling), 1 / denom)
             se_j = lib.einsum("pk,qk,qk->pq", se.coupling, np.conj(se.coupling), 1 / denom)
+
+            if not np.iscomplexobj(se.coupling):
+                se_i = se_i.real
+                se_j = se_j.real
+
+            se_qp = 0.5 * (se_i + se_j)
+
         else:
             denom = lib.direct_sum("p-q->pq", mo_energy, se.energy)
             d2p = lib.direct_sum("pk,qk->pqk", denom**2, denom**2)
             reg = 1 - np.exp(-d2p * self.srg)
             reg *= lib.direct_sum("pk,qk->pqk", denom, denom)
             reg /= d2p
-            se_i = lib.einsum("pk,qk,pqk->pq", se.coupling, np.conj(se.coupling), reg)
-            se_j = lib.einsum("pk,qk,qpk->pq", se.coupling, np.conj(se.coupling), reg)
+            se_qp = lib.einsum("pk,qk,pqk->pq", se.coupling, np.conj(se.coupling), reg)
+            se_qp = 0.5 * (se_qp + se_qp.T)
 
-        if not np.iscomplexobj(se.coupling):
-            se_i = se_i.real
-            se_j = se_j.real
-
-        return 0.5 * (se_i + se_j)
+        return se_qp
 
     check_convergence = evGW.check_convergence
 

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -332,7 +332,7 @@ class qsGW(GW):
             reg *= lib.direct_sum("pk,qk->pqk", denom, denom)
             reg /= d2p
             se_i = lib.einsum("pk,qk,pqk->pq", se.coupling, np.conj(se.coupling), reg)
-            se_j = lib.einsum("pk,qk,qpk->pq", se.coupling, np.conj(se.coupling), reg)
+            se_j = se_i.T.conj()
 
         if not np.iscomplexobj(se.coupling):
             se_i = se_i.real

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -52,6 +52,9 @@ def kernel(
         Green's function object
     se : pyscf.agf2.SelfEnergy
         Self-energy object
+    qp_energy : numpy.ndarray
+        Quasiparticle energies. Always None for scGW, returned for
+        compatibility with other scGW methods.
     """
 
     logger.warn(gw, "scGW is untested!")
@@ -153,7 +156,7 @@ def kernel(
             conv = True
             break
 
-    return conv, gf, se
+    return conv, gf, se, None
 
 
 class scGW(evGW):
@@ -184,52 +187,4 @@ class scGW(evGW):
     def name(self):
         return "scG%sW%s" % ("0" if self.g0 else "", "0" if self.w0 else "")
 
-    def kernel(
-        self,
-        nmom_max,
-        mo_energy=None,
-        mo_coeff=None,
-        moments=None,
-        integrals=None,
-    ):
-        if mo_coeff is None:
-            mo_coeff = self.mo_coeff
-        if mo_energy is None:
-            mo_energy = self.mo_energy
-
-        cput0 = (logger.process_clock(), logger.perf_counter())
-        self.dump_flags()
-        logger.info(self, "nmom_max = %d", nmom_max)
-
-        self.converged, self.gf, self.se = kernel(
-            self,
-            nmom_max,
-            mo_energy,
-            mo_coeff,
-            integrals=integrals,
-        )
-
-        gf_occ = self.gf.get_occupied()
-        gf_occ.remove_uncoupled(tol=1e-1)
-        for n in range(min(5, gf_occ.naux)):
-            en = -gf_occ.energy[-(n + 1)]
-            vn = gf_occ.coupling[:, -(n + 1)]
-            qpwt = np.linalg.norm(vn) ** 2
-            logger.note(self, "IP energy level %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
-
-        gf_vir = self.gf.get_virtual()
-        gf_vir.remove_uncoupled(tol=1e-1)
-        for n in range(min(5, gf_vir.naux)):
-            en = gf_vir.energy[n]
-            vn = gf_vir.coupling[:, n]
-            qpwt = np.linalg.norm(vn) ** 2
-            logger.note(self, "EA energy level %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
-
-        if self.converged:
-            logger.note(self, "%s converged", self.name)
-        else:
-            logger.note(self, "%s failed to converge", self.name)
-
-        logger.timer(self, self.name, *cput0)
-
-        return self.converged, self.gf, self.se
+    _kernel = kernel

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -97,15 +97,6 @@ def kernel(
                 ),
                 mo_occ_w=None if gw.w0 else gw._gf_to_occ(gf),
             )
-        if mo_coeff.ndim == 3:
-            v = integrals.Lia[0, 0].real
-            ci = lib.einsum("pq,qi->pi", mo_coeff[0], gf[0].get_occupied().coupling).real
-            ca = lib.einsum("pq,qi->pi", mo_coeff[0], gf[0].get_virtual().coupling).real
-        else:
-            v = integrals.Lia
-            m = gf.moment(1)
-            ci = lib.einsum("pq,qi->pi", mo_coeff, gf.get_occupied().coupling)
-            ca = lib.einsum("pq,qi->pi", mo_coeff, gf.get_virtual().coupling)
 
         # Update the moments of the SE
         if moments is not None and cycle == 1:

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -62,16 +62,10 @@ def kernel(
     if gw.polarizability == "drpa-exact":
         raise NotImplementedError("%s for polarizability=%s" % (gw.name, gw.polarizability))
 
-    nmo = gw.nmo
-    nocc = gw.nocc
-    naux = gw.with_df.get_naoaux()
-
     if integrals is None:
         integrals = gw.ao2mo()
 
-    chempot = 0.5 * (mo_energy[nocc - 1] + mo_energy[nocc])
-    gf = GreensFunction(mo_energy, np.eye(mo_energy.size), chempot=chempot)
-    gf_ref = gf.copy()
+    gf_ref = gf = gw.init_gf(mo_energy)
 
     diis = util.DIIS()
     diis.space = gw.diis_space
@@ -84,21 +78,34 @@ def kernel(
     )
 
     conv = False
-    th_prev = tp_prev = np.zeros((nmom_max + 1, nmo, nmo))
+    th_prev = tp_prev = None
     for cycle in range(1, gw.max_cycle + 1):
         logger.info(gw, "%s iteration %d", gw.name, cycle)
 
         if cycle > 1:
             # Rotate ERIs into (MO, QMO) and (QMO occ, QMO vir)
-            # TODO reimplement out keyword
-            mo_coeff_g = None if gw.g0 else np.dot(mo_coeff, gf.coupling)
-            mo_coeff_w = None if gw.w0 else np.dot(mo_coeff, gf.coupling)
-            mo_occ_w = (
-                None
-                if gw.w0
-                else np.array([2] * gf.get_occupied().naux + [0] * gf.get_virtual().naux)
+            integrals.update_coeffs(
+                mo_coeff_g=(
+                    None
+                    if gw.g0
+                    else lib.einsum("...pq,...qi->...pi", mo_coeff, gw._gf_to_coupling(gf))
+                ),
+                mo_coeff_w=(
+                    None
+                    if gw.w0
+                    else lib.einsum("...pq,...qi->...pi", mo_coeff, gw._gf_to_coupling(gf))
+                ),
+                mo_occ_w=None if gw.w0 else gw._gf_to_occ(gf),
             )
-            integrals.update_coeffs(mo_coeff_g=mo_coeff_g, mo_coeff_w=mo_coeff_w, mo_occ_w=mo_occ_w)
+        if mo_coeff.ndim == 3:
+            v = integrals.Lia[0, 0].real
+            ci = lib.einsum("pq,qi->pi", mo_coeff[0], gf[0].get_occupied().coupling).real
+            ca = lib.einsum("pq,qi->pi", mo_coeff[0], gf[0].get_virtual().coupling).real
+        else:
+            v = integrals.Lia
+            m = gf.moment(1)
+            ci = lib.einsum("pq,qi->pi", mo_coeff, gf.get_occupied().coupling)
+            ca = lib.einsum("pq,qi->pi", mo_coeff, gf.get_virtual().coupling)
 
         # Update the moments of the SE
         if moments is not None and cycle == 1:
@@ -108,8 +115,8 @@ def kernel(
                 nmom_max,
                 integrals,
                 mo_energy=(
-                    gf.energy if not gw.g0 else gf_ref.energy,
-                    gf.energy if not gw.w0 else gf_ref.energy,
+                    gw._gf_to_energy(gf if not gw.g0 else gf_ref),
+                    gw._gf_to_energy(gf if not gw.w0 else gf_ref),
                 ),
                 mo_occ=(
                     gw._gf_to_occ(gf if not gw.g0 else gf_ref),
@@ -119,41 +126,27 @@ def kernel(
 
         # Extrapolate the moments
         try:
-            th, tp = diis.update_with_scaling(np.array((th, tp)), (2, 3))
+            th, tp = diis.update_with_scaling(np.array((th, tp)), (-2, -1))
         except Exception as e:
-            logger.debug(gw, "DIIS step failed at iteration %d: %s", cycle, repr(e))
+            logger.debug(gw, "DIIS step failed at iteration %d", cycle)
 
         # Damp the moments
-        if gw.damping != 0.0:
+        if gw.damping != 0.0 and cycle > 1:
             th = gw.damping * th_prev + (1.0 - gw.damping) * th
             tp = gw.damping * tp_prev + (1.0 - gw.damping) * tp
 
         # Solve the Dyson equation
-        gf_prev = gf.copy()
         gf, se = gw.solve_dyson(th, tp, se_static, integrals=integrals)
 
+        # Update the MO energies
+        mo_energy_prev = mo_energy.copy()
+        mo_energy = gw._gf_to_mo_energy(gf)
+
         # Check for convergence
-        error_homo = abs(
-            gf.energy[np.argmax(gf.coupling[nocc - 1] ** 2)]
-            - gf_prev.energy[np.argmax(gf_prev.coupling[nocc - 1] ** 2)]
-        )
-        error_lumo = abs(
-            gf.energy[np.argmax(gf.coupling[nocc] ** 2)]
-            - gf_prev.energy[np.argmax(gf_prev.coupling[nocc] ** 2)]
-        )
-        error_th = gw._moment_error(th, th_prev)
-        error_tp = gw._moment_error(tp, tp_prev)
+        conv = gw.check_convergence(mo_energy, mo_energy_prev, th, th_prev, tp, tp_prev)
         th_prev = th.copy()
         tp_prev = tp.copy()
-        logger.info(gw, "Change in QPs: HOMO = %.6g  LUMO = %.6g", error_homo, error_lumo)
-        logger.info(gw, "Change in moments: occ = %.6g  vir = %.6g", error_th, error_tp)
-        if gw.conv_logical(
-            (
-                max(error_homo, error_lumo) < gw.conv_tol,
-                max(error_th, error_tp) < gw.conv_tol_moms,
-            )
-        ):
-            conv = True
+        if conv:
             break
 
     return conv, gf, se, None
@@ -188,3 +181,26 @@ class scGW(evGW):
         return "scG%sW%s" % ("0" if self.g0 else "", "0" if self.w0 else "")
 
     _kernel = kernel
+
+    def init_gf(self, mo_energy=None):
+        """Initialise the mean-field Green's function.
+
+        Parameters
+        ----------
+        mo_energy : numpy.ndarray, optional
+            Molecular orbital energies. Default value is
+            `self.mo_energy`.
+
+        Returns
+        -------
+        gf : GreensFunction
+            Mean-field Green's function.
+        """
+
+        if mo_energy is None:
+            mo_energy = self.mo_energy
+
+        chempot = 0.5 * (mo_energy[self.nocc - 1] + mo_energy[self.nocc])
+        gf = GreensFunction(mo_energy, np.eye(self.nmo), chempot=chempot)
+
+        return gf

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -64,8 +64,7 @@ def kernel(
 
     if integrals is None:
         integrals = gw.ao2mo(mo_coeff)
-    Lpk, Lia = integrals
-    Lpq = Lpk
+    Lpq = integrals[0]
 
     chempot = 0.5 * (mo_energy[nocc - 1] + mo_energy[nocc])
     gf = GreensFunction(mo_energy, np.eye(mo_energy.size), chempot=chempot)
@@ -76,7 +75,6 @@ def kernel(
 
     # Get the static part of the SE
     se_static = gw.build_se_static(
-        Lpq=Lpk,
         mo_energy=mo_energy,
         mo_coeff=mo_coeff,
     )
@@ -92,7 +90,7 @@ def kernel(
             mo_coeff_g = mo_coeff if gw.g0 else np.dot(mo_coeff, gf.coupling)
             mo_coeff_w = mo_coeff if gw.w0 else np.dot(mo_coeff, gf.coupling)
             nocc_w = nocc if gw.w0 else gf.get_occupied().naux
-            Lpk, Lia = gw.ao2mo(
+            integrals = gw.ao2mo(
                 mo_coeff,
                 mo_coeff_g=mo_coeff_g,
                 mo_coeff_w=mo_coeff_w,
@@ -105,8 +103,7 @@ def kernel(
         else:
             th, tp = gw.build_se_moments(
                 nmom_max,
-                Lpk,
-                Lia,
+                *integrals,
                 mo_energy=(
                     gf.energy if not gw.g0 else gf_ref.energy,
                     gf.energy if not gw.w0 else gf_ref.energy,

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -24,12 +24,12 @@ class TDA:
         Molecular orbital energies.  If a tuple is passed, the first
         element corresponds to the Green's function basis and the second to
         the screened Coulomb interaction.  Default value is that of
-        `gw._scf.mo_energy`.
+        `gw.mo_energy`.
     mo_occ : numpy.ndarray or tuple of numpy.ndarray, optional
         Molecular orbital occupancies.  If a tuple is passed, the first
         element corresponds to the Green's function basis and the second to
         the screened Coulomb interaction.  Default value is that of
-        `gw._scf.mo_occ`.
+        `gw.mo_occ`.
     """
 
     def __init__(
@@ -46,7 +46,7 @@ class TDA:
 
         # Get the MO energies for G and W
         if mo_energy is None:
-            self.mo_energy_g = self.mo_energy_w = gw._scf.mo_energy
+            self.mo_energy_g = self.mo_energy_w = gw.mo_energy
         elif isinstance(mo_energy, tuple):
             self.mo_energy_g, self.mo_energy_w = mo_energy
         else:
@@ -54,7 +54,7 @@ class TDA:
 
         # Get the MO occupancies for G and W
         if mo_occ is None:
-            self.mo_occ_g = self.mo_occ_w = gw._scf.mo_occ
+            self.mo_occ_g = self.mo_occ_w = gw.mo_occ
         elif isinstance(mo_occ, tuple):
             self.mo_occ_g, self.mo_occ_w = mo_occ
         else:

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -156,15 +156,8 @@ class TDA:
         moments[0] = self.Lia
         cput1 = lib.logger.timer(self.gw, "zeroth moment", *cput0)
 
-        # Get the first order moment
-        moments[1] = self.Lia * d[None]
-        tmp = np.dot(self.Lia, self.Lia.T)
-        tmp = mpi_helper.allreduce(tmp)
-        moments[1] += np.dot(tmp, self.Lia) * 2.0
-        cput1 = lib.logger.timer(self.gw, "first moment", *cput1)
-
         # Get the higher order moments
-        for i in range(2, self.nmom_max + 1):
+        for i in range(1, self.nmom_max + 1):
             moments[i] = moments[i - 1] * d[None]
             tmp = np.dot(moments[i - 1], self.Lia.T)
             tmp = mpi_helper.allreduce(tmp)

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -62,7 +62,7 @@ class TDA:
 
         # Options and thresholds
         self.report_quadrature_error = True
-        if "ia" in getattr(self.gw, "compression", "").split(","):
+        if self.gw.compression and "ia" in self.gw.compression.split(","):
             self.compression_tol = gw.compression_tol
         else:
             self.compression_tol = None

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -89,19 +89,6 @@ class TDA:
             self.__class__.__name__,
             self.nmom_max,
         )
-        if mpi_helper.size > 1:
-            lib.logger.info(
-                self.gw,
-                "Slice of W space on proc %d: [%d, %d]",
-                mpi_helper.rank,
-                *self.mpi_slice(self.nov),
-            )
-            lib.logger.info(
-                self.gw,
-                "Slice of G space on proc %d: [%d, %d]",
-                mpi_helper.rank,
-                *self.mpi_slice(self.mo_energy_g.size),
-            )
 
         self.compress_eris()
 

--- a/momentGW/thc.py
+++ b/momentGW/thc.py
@@ -1,0 +1,258 @@
+import numpy as np
+from h5py import File
+from pyscf import lib
+from pyscf.agf2 import mpi_helper
+from scipy.special import binom
+
+from momentGW import tda
+
+
+class Integrals:
+    """
+    Container for the integrals required for GW methods.
+    """
+
+    def __init__(
+        self,
+        with_df,
+        mo_coeff,
+        mo_occ,
+        thc_opts,
+    ):
+        self.with_df = with_df
+        self.mo_coeff = mo_coeff
+        self.mo_occ = mo_occ
+        self.filepath = thc_opts["file_path"]
+
+        self._blocks = {}
+
+    def transform(self):
+        """
+        Imports a H5PY file containing a dictionary. Inside the dict, a
+        'collocation_matrix' and a 'coulomb_matrix' must be contained
+        with shapes (aux, MO) and (aux,aux) respectively.
+        """
+
+        if self.filepath is None:
+            raise ValueError("filepath cannot be None for THC implementation")
+
+        thc_eri = File(self.filepath, "r")
+        coll = np.array(thc_eri["collocation_matrix"]).T[0].T
+        cou = np.array(thc_eri["coulomb_matrix"][0]).T[0].T
+        Xip = coll[: self.nocc, :]
+        Xap = coll[self.nocc :, :]
+
+        self._blocks["coll"] = coll
+        self._blocks["cou"] = cou
+        self._blocks["Xip"] = Xip
+        self._blocks["Xap"] = Xap
+
+    @property
+    def Coll(self):
+        """
+        Return the (aux, MO) array.
+        """
+        return self._blocks["coll"]
+
+    @property
+    def Cou(self):
+        """
+        Return the (aux, aux) array.
+        """
+        return self._blocks["cou"]
+
+    @property
+    def Xip(self):
+        """
+        Return the (aux, W occ) array.
+        """
+        return self._blocks["Xip"]
+
+    @property
+    def Xap(self):
+        """
+        Return the (aux, W vir) array.
+        """
+        return self._blocks["Xap"]
+
+    @property
+    def nmo(self):
+        """
+        Return the number of MOs.
+        """
+        return self.mo_coeff.shape[-1]
+
+    @property
+    def nocc(self):
+        """
+        Return the number of occupied MOs.
+        """
+        return np.sum(self.mo_occ > 0)
+
+    @property
+    def naux(self):
+        """
+        Return the number of auxiliary basis functions, after the
+        compression.
+        """
+        return self.Cou.shape[0]
+
+
+class TDA(tda.TDA):
+    def __init__(
+        self,
+        gw,
+        nmom_max,
+        integrals,
+        mo_energy=None,
+        mo_occ=None,
+    ):
+        self.gw = gw
+        self.integrals = integrals
+        self.nmom_max = nmom_max
+
+        # Get the MO energies for G and W
+        if mo_energy is None:
+            self.mo_energy_g = self.mo_energy_w = gw._scf.mo_energy
+        elif isinstance(mo_energy, tuple):
+            self.mo_energy_g, self.mo_energy_w = mo_energy
+        else:
+            self.mo_energy_g = self.mo_energy_w = mo_energy
+
+        # Get the MO occupancies for G and W
+        if mo_occ is None:
+            self.mo_occ_g = self.mo_occ_w = gw._scf.mo_occ
+        elif isinstance(mo_occ, tuple):
+            self.mo_occ_g, self.mo_occ_w = mo_occ
+        else:
+            self.mo_occ_g = self.mo_occ_w = mo_occ
+
+        # Options and thresholds
+        self.report_quadrature_error = True
+        if "ia" in getattr(self.gw, "compression", "").split(","):
+            self.compression_tol = gw.compression_tol
+        else:
+            self.compression_tol = None
+
+    def build_Z_prime(self):
+        """
+        Form the X_iP X_aP X_iQ X_aQ = Z_X contraction at N^3 cost.
+        """
+
+        Y_i_PQ = np.einsum("iP,iQ->PQ", self.XiP, self.XiP)
+        Y_a_PQ = np.einsum("aP,aQ->PQ", self.XaP, self.XaP)
+        Z_X_PQ = np.einsum("PQ,PQ->PQ", Y_i_PQ, Y_a_PQ)
+
+        return Z_X_PQ
+
+    def build_dd_moments(self):
+        """
+        Calcualte the moments recusively, in a form similiar to that of
+        a density-density response, at N^3 cost using only THC elements.
+        """
+
+        cput0 = (lib.logger.process_clock(), lib.logger.perf_counter())
+        lib.logger.info(self.gw, "Building density-density moments")
+        lib.logger.debug(self.gw, "Memory usage: %.2f GB", self._memory_usage())
+
+        zeta = np.zeros((self.total_nmom, self.XiP.shape[1], self.XiP.shape[1]))
+        ZD_left = np.zeros((self.total_nmom, self.naux, self.naux))
+        ZD_only = np.zeros((self.total_nmom, self.naux, self.naux))
+
+        self.Z_prime = self.build_Z_prime()
+        self.ZZ = np.einsum("PQ,QR->PR", self.Z, self.Z_prime)
+
+        zeta[0] = self.Z_prime
+
+        cput1 = lib.logger.timer(self.gw, "Zeta zero", *cput0)
+
+        YaP = np.einsum("aP,aQ->PQ", self.XaP, self.XaP)
+        YiP = np.einsum("aP,aQ->PQ", self.XiP, self.XiP)
+
+        Z_left = np.eye((self.naux))
+
+        for i in range(1, self.total_nmom):
+            ZD_left[0] = Z_left
+            ZD_left = np.roll(ZD_left, 1, axis=0)
+
+            Z_left = np.einsum("PQ,QR->PR", self.ZZ, Z_left) * 2
+
+            Yei_max = np.einsum("i,iP,iQ->PQ", (-1) ** (i) * self.ei ** (i), self.XiP, self.XiP)
+            Yea_max = np.einsum("a,aP,aQ->PQ", self.ea ** (i), self.XaP, self.XaP)
+            ZD_only[i] = np.einsum("PQ,PQ->PQ", Yea_max, YiP) + np.einsum("PQ,PQ->PQ", Yei_max, YaP)
+            ZD_temp = np.zeros((self.naux, self.naux))
+            for j in range(1, i):
+                Yei = np.einsum("i,iP,iQ->PQ", (-1) ** (j) * self.ei ** (j), self.XiP, self.XiP)
+                Yea = np.einsum("a,aP,aQ->PQ", binom(i, j) * self.ea ** (i - j), self.XaP, self.XaP)
+                ZD_only[i] += np.einsum("PQ,PQ->PQ", Yea, Yei)
+                if j == i - 1:
+                    Z_left += np.einsum("PQ,QR->PR", self.Z, ZD_only[j]) * 2
+                else:
+                    Z_left += (
+                        np.einsum("PQ,QR,RS->PS", self.Z, ZD_only[i - 1 - j], ZD_left[i - j]) * 2
+                    )
+                ZD_temp += np.einsum("PQ,QR->PR", ZD_only[j], ZD_left[j])
+            zeta[i] = ZD_only[i] + ZD_temp + np.einsum("PQ,QR->PR", self.Z_prime, Z_left)
+            cput1 = lib.logger.timer(self.gw, "Zeta %d" % i, *cput1)
+
+        return zeta
+
+    def build_se_moments(self, zeta):
+        """
+        Build the moments of the self-energy via convolution.
+        """
+
+        cput0 = (lib.logger.process_clock(), lib.logger.perf_counter())
+        lib.logger.info(self.gw, "Building self-energy moments")
+        lib.logger.debug(self.gw, "Memory usage: %.2f GB", self._memory_usage())
+
+        # Setup dependent on diagonal SE
+        q0, q1 = self.mpi_slice(self.mo_energy_g.size)
+        if self.gw.diagonal_se:
+            eta = np.zeros((q1 - q0, self.nmom_max + 1, self.nmo))
+            pq = p = q = "p"
+        else:
+            eta = np.zeros((q1 - q0, self.nmom_max + 1, self.nmo, self.nmo))
+            pq, p, q = "pq", "p", "q"
+
+        # Get the moments in (aux|aux) and rotate to (mo|mo)
+        for n in range(self.nmom_max + 1):
+            zeta_prime = np.linalg.multi_dot((self.Z, zeta[n], self.Z))
+            for x in range(q1 - q0):
+                Lp = lib.einsum("pP,P->Pp", self.integrals.Coll, self.integrals.Coll[x])
+                eta[x, n] = np.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, zeta_prime) * 2.0
+        cput1 = lib.logger.timer(self.gw, "rotating DD moments", *cput0)
+
+        # Construct the self-energy moments
+        moments_occ, moments_vir = self.convolve(eta)
+        cput1 = lib.logger.timer(self.gw, "constructing SE moments", *cput1)
+
+        return moments_occ, moments_vir
+
+    @property
+    def total_nmom(self):
+        return self.nmom_max + 1
+
+    @property
+    def total_nmom(self):
+        return self.nmom_max + 1
+
+    @property
+    def XiP(self):
+        return self.integrals.Xip
+
+    @property
+    def XaP(self):
+        return self.integrals.XaP
+
+    @property
+    def Z(self):
+        return self.integrals.Cou
+
+    @property
+    def ea(self):
+        return self.mo_energy_w[self.mo_occ_w == 0]
+
+    @property
+    def ea(self):
+        return self.mo_energy_w[self.mo_occ_w > 0]

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -120,3 +120,21 @@ class SilentSCF:
         self.mf.verbose = self._mf_verbose
         if getattr(self.mf, "with_df", None):
             self.mf.with_df.verbose = self._df_verbose
+
+
+def list_union(*args):
+    """
+    Find the union of a list of lists, with the elements sorted
+    by their first occurrence.
+    """
+
+    cache = set()
+    out = []
+    for arg in args:
+        for x in arg:
+            if x not in cache:
+                cache.add(x)
+                out.append(x)
+
+    return out
+

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -137,4 +137,3 @@ def list_union(*args):
                 out.append(x)
 
     return out
-

--- a/tests/test_evgw.py
+++ b/tests/test_evgw.py
@@ -41,7 +41,7 @@ class Test_evGW(unittest.TestCase):
         gw = evGW(self.mf)
         gw.diagonal_se = True
         gw.vhf_df = False
-        conv, gf, se = gw.kernel(nmom_max=1)
+        conv, gf, se, _ = gw.kernel(nmom_max=1)
         self.assertAlmostEqual(
             gf.make_rdm1().trace(),
             self.mol.nelectron,
@@ -49,7 +49,7 @@ class Test_evGW(unittest.TestCase):
         )
         gw.optimise_chempot = True
         gw.vhf_df = False
-        conv, gf, se = gw.kernel(nmom_max=1)
+        conv, gf, se, _ = gw.kernel(nmom_max=1)
         self.assertAlmostEqual(
             gf.make_rdm1().trace(),
             self.mol.nelectron,
@@ -57,7 +57,7 @@ class Test_evGW(unittest.TestCase):
         )
         gw.fock_loop = True
         gw.vhf_df = False
-        conv, gf, se = gw.kernel(nmom_max=1)
+        conv, gf, se, _ = gw.kernel(nmom_max=1)
         self.assertAlmostEqual(
             gf.make_rdm1().trace(),
             self.mol.nelectron,

--- a/tests/test_evkgw.py
+++ b/tests/test_evkgw.py
@@ -1,0 +1,147 @@
+"""
+Tests for `pbc/evgw.py`
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+from pyscf.pbc import gto, dft
+from pyscf.pbc.tools import k2gamma
+from pyscf.agf2 import mpi_helper
+
+from momentGW import evGW
+from momentGW import evKGW
+
+
+class Test_evKGW(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cell = gto.Cell()
+        cell.atom = "He 0 0 0; He 1 1 1"
+        cell.basis = "6-31g"
+        cell.a = np.eye(3) * 3
+        cell.verbose = 0
+        cell.build()
+
+        kmesh = [3, 1, 1]
+        kpts = cell.make_kpts(kmesh)
+
+        mf = dft.KRKS(cell, kpts, xc="hf")
+        mf = mf.density_fit(auxbasis="weigend")
+        mf.conv_tol = 1e-10
+        mf.kernel()
+
+        for k in range(len(kpts)):
+            mf.mo_coeff[k] = mpi_helper.bcast_dict(mf.mo_coeff[k], root=0)
+            mf.mo_energy[k] = mpi_helper.bcast_dict(mf.mo_energy[k], root=0)
+
+        smf = k2gamma.k2gamma(mf, kmesh=kmesh)
+        smf = smf.density_fit(auxbasis="weigend")
+
+        cls.cell, cls.kpts, cls.mf, cls.smf = cell, kpts, mf, smf
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.cell, cls.kpts, cls.mf, cls.smf
+
+    def test_supercell_valid(self):
+        # Require real MOs for supercell comparison
+
+        scell, phase = k2gamma.get_phase(self.cell, self.kpts)
+        nk, nao, nmo = np.shape(self.mf.mo_coeff)
+        nr, _ = np.shape(phase)
+
+        k_conj_groups = k2gamma.group_by_conj_pairs(self.cell, self.kpts, return_kpts_pairs=False)
+        k_phase = np.eye(nk, dtype=np.complex128)
+        r2x2 = np.array([[1., 1j], [1., -1j]]) * .5**.5
+        pairs = [[k, k_conj] for k, k_conj in k_conj_groups
+                 if k_conj is not None and k != k_conj]
+        for idx in np.array(pairs):
+            k_phase[idx[:, None], idx] = r2x2
+
+        c_gamma = np.einsum('Rk,kum,kh->Ruhm', phase, self.mf.mo_coeff, k_phase)
+        c_gamma = c_gamma.reshape(nao*nr, nk*nmo)
+        c_gamma[:, abs(c_gamma.real).max(axis=0) < 1e-5] *= -1j
+
+        self.assertAlmostEqual(np.max(np.abs(np.array(c_gamma).imag)), 0, 8)
+
+    def _test_vs_supercell(self, gw, kgw, full=False, check_convergence=True):
+        if check_convergence:
+            self.assertTrue(gw.converged)
+            self.assertTrue(kgw.converged)
+        e1 = np.concatenate([gf.energy for gf in kgw.gf])
+        w1 = np.concatenate([np.linalg.norm(gf.coupling, axis=0)**2 for gf in kgw.gf])
+        mask = np.argsort(e1)
+        e1 = e1[mask]
+        w1 = w1[mask]
+        e2 = gw.gf.energy
+        w2 = np.linalg.norm(gw.gf.coupling, axis=0)**2
+        if full:
+            np.testing.assert_allclose(e1, e2, atol=1e-8)
+        else:
+            np.testing.assert_allclose(e1[w1 > 0.5], e2[w2 > 0.5], atol=1e-8)
+
+    def test_dtda_vs_supercell(self):
+        nmom_max = 3
+
+        kgw = evKGW(self.mf)
+        kgw.polarizability = "dtda"
+        kgw.max_cycle = 50
+        kgw.conv_tol = 1e-8
+        kgw.damping = 0.5
+        kgw.kernel(nmom_max)
+
+        gw = evGW(self.smf)
+        gw.polarizability = "dtda"
+        gw.max_cycle = 50
+        gw.conv_tol = 1e-8
+        gw.damping = 0.5
+        gw.kernel(nmom_max)
+
+        self._test_vs_supercell(gw, kgw)
+
+    def test_dtda_vs_supercell_diagonal_w0(self):
+        nmom_max = 1
+
+        kgw = evKGW(self.mf)
+        kgw.polarizability = "dtda"
+        kgw.max_cycle = 200
+        kgw.conv_tol = 1e-8
+        kgw.diagonal_se = True
+        kgw.w0 = True
+        kgw.kernel(nmom_max)
+
+        gw = evGW(self.smf)
+        gw.polarizability = "dtda"
+        gw.max_cycle = 200
+        gw.conv_tol = 1e-8
+        gw.diagonal_se = True
+        gw.w0 = True
+        gw.kernel(nmom_max)
+
+        self._test_vs_supercell(gw, kgw)
+
+    def test_dtda_vs_supercell_g0(self):
+        nmom_max = 1
+
+        kgw = evKGW(self.mf)
+        kgw.polarizability = "dtda"
+        kgw.max_cycle = 5
+        kgw.damping = 0.5
+        kgw.g0 = True
+        kgw.kernel(nmom_max)
+
+        gw = evGW(self.smf)
+        gw.polarizability = "dtda"
+        gw.max_cycle = 5
+        gw.damping = 0.5
+        gw.g0 = True
+        gw.kernel(nmom_max)
+
+        self._test_vs_supercell(gw, kgw, full=True, check_convergence=False)
+
+
+if __name__ == "__main__":
+    print("Running tests for evKGW")
+    unittest.main()

--- a/tests/test_gw.py
+++ b/tests/test_gw.py
@@ -45,7 +45,7 @@ class Test_GW(unittest.TestCase):
         gw = GW(self.mf)
         gw.diagonal_se = True
         gw.vhf_df = True
-        conv, gf, se = gw.kernel(nmom_max=7)
+        conv, gf, se, _ = gw.kernel(nmom_max=7)
         gf.remove_uncoupled(tol=1e-8)
         self.assertAlmostEqual(
             gf.get_occupied().energy.max(),
@@ -62,7 +62,7 @@ class Test_GW(unittest.TestCase):
         gw = GW(self.mf)
         gw.diagonal_se = True
         gw.vhf_df = False
-        conv, gf, se = gw.kernel(nmom_max=7)
+        conv, gf, se, _ = gw.kernel(nmom_max=7)
         gf.remove_uncoupled(tol=1e-8)
         self.assertAlmostEqual(
             gf.get_occupied().energy.max(),
@@ -79,7 +79,7 @@ class Test_GW(unittest.TestCase):
         gw = GW(self.mf)
         gw.diagonal_se = True
         gw.vhf_df = False
-        conv, gf, se = gw.kernel(nmom_max=1)
+        conv, gf, se, _ = gw.kernel(nmom_max=1)
         self.assertAlmostEqual(
             gf.make_rdm1().trace(),
             self.mol.nelectron,
@@ -87,7 +87,7 @@ class Test_GW(unittest.TestCase):
         )
         gw.optimise_chempot = True
         gw.vhf_df = False
-        conv, gf, se = gw.kernel(nmom_max=1)
+        conv, gf, se, _ = gw.kernel(nmom_max=1)
         self.assertAlmostEqual(
             gf.make_rdm1().trace(),
             self.mol.nelectron,
@@ -99,7 +99,7 @@ class Test_GW(unittest.TestCase):
         gw.diagonal_se = True
         gw.vhf_df = False
         th1, tp1 = gw.build_se_moments(5, gw.ao2mo())
-        conv, gf, se = gw.kernel(nmom_max=5)
+        conv, gf, se, _ = gw.kernel(nmom_max=5)
         th2 = se.get_occupied().moment(range(5))
         tp2 = se.get_virtual().moment(range(5))
 

--- a/tests/test_kgw.py
+++ b/tests/test_kgw.py
@@ -24,11 +24,11 @@ class Test_KGW(unittest.TestCase):
         cell.verbose = 0
         cell.build()
 
-        kmesh = [2, 2, 2]
+        kmesh = [2, 1, 1]
         kpts = cell.make_kpts(kmesh)
 
         mf = dft.KRKS(cell, kpts, xc="hf")
-        mf = mf.density_fit(auxbasis="weigend")
+        mf = mf.density_fit()
         mf.conv_tol = 1e-10
         mf.kernel()
 
@@ -37,7 +37,7 @@ class Test_KGW(unittest.TestCase):
             mf.mo_energy[k] = mpi_helper.bcast_dict(mf.mo_energy[k], root=0)
 
         smf = k2gamma.k2gamma(mf, kmesh=kmesh)
-        smf = smf.density_fit(auxbasis="weigend")
+        smf = smf.density_fit()
 
         cls.cell, cls.kpts, cls.mf, cls.smf = cell, kpts, mf, smf
 

--- a/tests/test_kgw.py
+++ b/tests/test_kgw.py
@@ -105,6 +105,7 @@ class Test_KGW(unittest.TestCase):
         kgw = KGW(self.mf)
         kgw.polarizability = "dtda"
         kgw.fock_loop = True
+        kgw.compression = None
         kgw.kernel(nmom_max)
 
         gw = GW(self.smf)

--- a/tests/test_kgw.py
+++ b/tests/test_kgw.py
@@ -43,6 +43,7 @@ class Test_KGW(unittest.TestCase):
 
         smf = k2gamma.k2gamma(mf, kmesh=kmesh)
         smf = smf.density_fit(auxbasis="weigend")
+        smf.exxdiv = None
         smf.with_df._prefer_ccdf = True
         smf.with_df.force_dm_kbuild = True
 

--- a/tests/test_kgw.py
+++ b/tests/test_kgw.py
@@ -1,0 +1,71 @@
+"""
+Tests for `kgw.py`
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+from pyscf.pbc import gto, dft
+from pyscf.pbc.tools import k2gamma
+from pyscf.agf2 import mpi_helper
+
+from momentGW import GW, KGW
+
+
+class Test_KGW(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cell = gto.Cell()
+        cell.atom = "He 0 0 0; He 1 0 1"
+        cell.basis = "6-31g"
+        cell.a = np.eye(3) * 3
+        cell.precision = 1e-7
+        cell.verbose = 0
+        cell.build()
+
+        kmesh = [2, 2, 2]
+        kpts = cell.make_kpts(kmesh)
+
+        mf = dft.KRKS(cell, kpts, xc="hf")
+        mf = mf.density_fit(auxbasis="weigend")
+        mf.conv_tol = 1e-10
+        mf.kernel()
+
+        for k in range(len(kpts)):
+            mf.mo_coeff[k] = mpi_helper.bcast_dict(mf.mo_coeff[k], root=0)
+            mf.mo_energy[k] = mpi_helper.bcast_dict(mf.mo_energy[k], root=0)
+
+        smf = k2gamma.k2gamma(mf, kmesh=kmesh)
+        smf = smf.density_fit(auxbasis="weigend")
+
+        cls.cell, cls.kpts, cls.mf, cls.smf = cell, kpts, mf, smf
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.cell, cls.kpts, cls.mf, cls.smf
+
+    def test_supercell_valid(self):
+        # Require real MOs for supercell comparison
+        self.assertAlmostEqual(np.max(np.abs(np.array(self.mf.mo_coeff).imag)), 0, 8)
+
+    def test_dtda_vs_supercell(self):
+        nmom_max = 5
+
+        kgw = KGW(self.mf)
+        kgw.polarizability = "dtda"
+        kgw.kernel(nmom_max)
+
+        gw = GW(self.smf)
+        gw.polarizability = "dtda"
+        gw.kernel(nmom_max)
+
+        e1 = np.sort(np.concatenate([gf.energy for gf in kgw.gf]))
+        e2 = gw.gf.energy
+
+        np.testing.assert_allclose(e1, e2, atol=1e-8)
+
+
+if __name__ == "__main__":
+    print("Running tests for KGW")
+    unittest.main()

--- a/tests/test_kgw.py
+++ b/tests/test_kgw.py
@@ -1,34 +1,39 @@
 """
-Tests for `kgw.py`
+Tests for `pbc/gw.py`
 """
 
 import unittest
 
 import numpy as np
 import pytest
-from pyscf.pbc import gto, dft
+from pyscf.pbc import gto, dft, scf
 from pyscf.pbc.tools import k2gamma
 from pyscf.agf2 import mpi_helper
 
-from momentGW import GW, KGW
+from momentGW import GW
+from momentGW import KGW
 
 
 class Test_KGW(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cell = gto.Cell()
-        cell.atom = "He 0 0 0; He 1 0 1"
+        cell.atom = "He 0 0 0; He 1 1 1"
         cell.basis = "6-31g"
         cell.a = np.eye(3) * 3
-        cell.precision = 1e-7
+        cell.max_memory = 1e10
         cell.verbose = 0
         cell.build()
 
-        kmesh = [2, 2, 2]
+        kmesh = [3, 1, 1]
         kpts = cell.make_kpts(kmesh)
 
         mf = dft.KRKS(cell, kpts, xc="hf")
+        #mf = scf.KRHF(cell, kpts)
         mf = mf.density_fit(auxbasis="weigend")
+        mf.with_df._prefer_ccdf = True
+        mf.with_df.force_dm_kbuild = True
+        mf.exxdiv = None
         mf.conv_tol = 1e-10
         mf.kernel()
 
@@ -38,6 +43,8 @@ class Test_KGW(unittest.TestCase):
 
         smf = k2gamma.k2gamma(mf, kmesh=kmesh)
         smf = smf.density_fit(auxbasis="weigend")
+        smf.with_df._prefer_ccdf = True
+        smf.with_df.force_dm_kbuild = True
 
         cls.cell, cls.kpts, cls.mf, cls.smf = cell, kpts, mf, smf
 
@@ -47,7 +54,24 @@ class Test_KGW(unittest.TestCase):
 
     def test_supercell_valid(self):
         # Require real MOs for supercell comparison
-        self.assertAlmostEqual(np.max(np.abs(np.array(self.mf.mo_coeff).imag)), 0, 8)
+
+        scell, phase = k2gamma.get_phase(self.cell, self.kpts)
+        nk, nao, nmo = np.shape(self.mf.mo_coeff)
+        nr, _ = np.shape(phase)
+
+        k_conj_groups = k2gamma.group_by_conj_pairs(self.cell, self.kpts, return_kpts_pairs=False)
+        k_phase = np.eye(nk, dtype=np.complex128)
+        r2x2 = np.array([[1., 1j], [1., -1j]]) * .5**.5
+        pairs = [[k, k_conj] for k, k_conj in k_conj_groups
+                 if k_conj is not None and k != k_conj]
+        for idx in np.array(pairs):
+            k_phase[idx[:, None], idx] = r2x2
+
+        c_gamma = np.einsum('Rk,kum,kh->Ruhm', phase, self.mf.mo_coeff, k_phase)
+        c_gamma = c_gamma.reshape(nao*nr, nk*nmo)
+        c_gamma[:, abs(c_gamma.real).max(axis=0) < 1e-5] *= -1j
+
+        self.assertAlmostEqual(np.max(np.abs(np.array(c_gamma).imag)), 0, 8)
 
     def _test_vs_supercell(self, gw, kgw, full=False):
         e1 = np.concatenate([gf.energy for gf in kgw.gf])
@@ -70,7 +94,7 @@ class Test_KGW(unittest.TestCase):
         kgw.kernel(nmom_max)
 
         gw = GW(self.smf)
-        gw.polarizability = "dtda"
+        gw.__dict__.update({opt: getattr(kgw, opt) for opt in kgw._opts})
         gw.kernel(nmom_max)
 
         self._test_vs_supercell(gw, kgw, full=True)
@@ -84,28 +108,25 @@ class Test_KGW(unittest.TestCase):
         kgw.kernel(nmom_max)
 
         gw = GW(self.smf)
-        gw.polarizability = "dtda"
-        gw.fock_loop = True
+        gw.__dict__.update({opt: getattr(kgw, opt) for opt in kgw._opts})
         gw.kernel(nmom_max)
 
         self._test_vs_supercell(gw, kgw)
 
-    def test_dtda_vs_supercell_compression(self):
-        nmom_max = 5
+    #def test_dtda_vs_supercell_compression(self):
+    #    nmom_max = 5
 
-        kgw = KGW(self.mf)
-        kgw.polarizability = "dtda"
-        kgw.compression = "ov,oo"
-        kgw.compression_tol = 1e-3
-        kgw.kernel(nmom_max)
+    #    kgw = KGW(self.mf)
+    #    kgw.polarizability = "dtda"
+    #    kgw.compression = "ov,oo"
+    #    kgw.compression_tol = 1e-3
+    #    kgw.kernel(nmom_max)
 
-        gw = GW(self.smf)
-        gw.polarizability = "dtda"
-        gw.compression = "ov,oo"
-        gw.compression_tol = 1e-3
-        gw.kernel(nmom_max)
+    #    gw = GW(self.smf)
+    #    gw.__dict__.update({opt: getattr(kgw, opt) for opt in kgw._opts})
+    #    gw.kernel(nmom_max)
 
-        self._test_vs_supercell(gw, kgw, full=True)
+    #    self._test_vs_supercell(gw, kgw, full=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_kgw.py
+++ b/tests/test_kgw.py
@@ -74,7 +74,7 @@ class Test_KGW(unittest.TestCase):
 
         self.assertAlmostEqual(np.max(np.abs(np.array(c_gamma).imag)), 0, 8)
 
-    def _test_vs_supercell(self, gw, kgw, full=False):
+    def _test_vs_supercell(self, gw, kgw, full=False, tol=1e-8):
         e1 = np.concatenate([gf.energy for gf in kgw.gf])
         w1 = np.concatenate([np.linalg.norm(gf.coupling, axis=0)**2 for gf in kgw.gf])
         mask = np.argsort(e1)
@@ -83,9 +83,9 @@ class Test_KGW(unittest.TestCase):
         e2 = gw.gf.energy
         w2 = np.linalg.norm(gw.gf.coupling, axis=0)**2
         if full:
-            np.testing.assert_allclose(e1, e2, atol=1e-8)
+            np.testing.assert_allclose(e1, e2, atol=tol)
         else:
-            np.testing.assert_allclose(e1[w1 > 1e-1], e2[w2 > 1e-1], atol=1e-8)
+            np.testing.assert_allclose(e1[w1 > 1e-1], e2[w2 > 1e-1], atol=tol)
 
     def test_dtda_vs_supercell(self):
         nmom_max = 5
@@ -115,20 +115,20 @@ class Test_KGW(unittest.TestCase):
 
         self._test_vs_supercell(gw, kgw)
 
-    #def test_dtda_vs_supercell_compression(self):
-    #    nmom_max = 5
+    def test_dtda_vs_supercell_compression(self):
+        nmom_max = 5
 
-    #    kgw = KGW(self.mf)
-    #    kgw.polarizability = "dtda"
-    #    kgw.compression = "ov,oo"
-    #    kgw.compression_tol = 1e-3
-    #    kgw.kernel(nmom_max)
+        kgw = KGW(self.mf)
+        kgw.polarizability = "dtda"
+        kgw.compression = "ov,oo,vv"
+        kgw.compression_tol = 1e-7
+        kgw.kernel(nmom_max)
 
-    #    gw = GW(self.smf)
-    #    gw.__dict__.update({opt: getattr(kgw, opt) for opt in kgw._opts})
-    #    gw.kernel(nmom_max)
+        gw = GW(self.smf)
+        gw.__dict__.update({opt: getattr(kgw, opt) for opt in kgw._opts})
+        gw.kernel(nmom_max)
 
-    #    self._test_vs_supercell(gw, kgw, full=False)
+        self._test_vs_supercell(gw, kgw, full=False, tol=1e-6)
 
 
 if __name__ == "__main__":

--- a/tests/test_kgw.py
+++ b/tests/test_kgw.py
@@ -127,7 +127,7 @@ class Test_KGW(unittest.TestCase):
     #    gw.__dict__.update({opt: getattr(kgw, opt) for opt in kgw._opts})
     #    gw.kernel(nmom_max)
 
-    #    self._test_vs_supercell(gw, kgw, full=True)
+    #    self._test_vs_supercell(gw, kgw, full=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_qsgw.py
+++ b/tests/test_qsgw.py
@@ -39,20 +39,20 @@ class Test_qsGW(unittest.TestCase):
 
     def test_regression_simple(self):
         # Quasiparticle energies:
-        ip = -0.283719805037
-        ea = 0.007318176449
+        ip = -0.283873786007
+        ea = 0.007418993395
         # GF poles:
-        ip_full = -0.265178368463
-        ea_full = 0.004998463727
+        ip_full = -0.265327792151
+        ea_full = 0.005099478300
         self._test_regression("hf", dict(), 1, ip, ea, ip_full, ea_full, "simple")
 
     def test_regression_pbe_srg(self):
         # Quasiparticle energies:
-        ip = -0.298283765946
-        ea = 0.008369048047
+        ip = -0.298283035898
+        ea = 0.008368594912
         # GF poles:
-        ip_full = -0.418233032000
-        ea_full = 0.059983899102
+        ip_full = -0.418234914925
+        ea_full = 0.059983672577
         self._test_regression("pbe", dict(srg=1e-3), 1, ip, ea, ip_full, ea_full, "pbe srg")
 
 

--- a/tests/test_qsgw.py
+++ b/tests/test_qsgw.py
@@ -15,27 +15,11 @@ from momentGW import qsGW
 class Test_qsGW(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        mol = gto.Mole()
-        mol.atom = "Li 0 0 0; H 0 0 1.64"
-        mol.basis = "cc-pvdz"
-        mol.verbose = 0
-        mol.build()
-
-        mf = dft.RKS(mol)
-        mf.xc = "hf"
-        mf.conv_tol = 1e-11
-        mf.kernel()
-        mf.mo_coeff = mpi_helper.bcast_dict(mf.mo_coeff, root=0)
-        mf.mo_energy = mpi_helper.bcast_dict(mf.mo_energy, root=0)
-
-        mf = mf.density_fit(auxbasis="cc-pv5z-ri")
-        mf.with_df.build()
-
-        cls.mol, cls.mf = mol, mf
+        pass
 
     @classmethod
     def tearDownClass(cls):
-        del cls.mol, cls.mf
+        pass
 
     def _test_regression(self, xc, kwargs, nmom_max, ip, ea, ip_full, ea_full, name=""):
         mol = gto.M(atom="H 0 0 0; Li 0 0 1.64", basis="6-31g", verbose=0)

--- a/tests/test_qsgw.py
+++ b/tests/test_qsgw.py
@@ -31,7 +31,7 @@ class Test_qsGW(unittest.TestCase):
         gw.conv_tol = 1e-10
         gw.conv_tol_qp = 1e-10
         gw.kernel(nmom_max)
-        gw.gf.remove_uncoupled(tol=0.5)
+        gw.gf.remove_uncoupled(tol=0.1)
         qp_energy = gw.qp_energy
         self.assertTrue(gw.converged)
         self.assertAlmostEqual(gw.gf.get_occupied().energy[-1], ip_full, 7, msg=name)

--- a/tests/test_qsgw.py
+++ b/tests/test_qsgw.py
@@ -31,7 +31,7 @@ class Test_qsGW(unittest.TestCase):
         gw.conv_tol = 1e-10
         gw.conv_tol_qp = 1e-10
         gw.kernel(nmom_max)
-        gw.gf.remove_uncoupled(tol=0.1)
+        gw.gf.remove_uncoupled(tol=0.5)
         qp_energy = gw.qp_energy
         self.assertTrue(gw.converged)
         self.assertAlmostEqual(gw.gf.get_occupied().energy[-1], ip_full, 7, msg=name)

--- a/tests/test_qsgw.py
+++ b/tests/test_qsgw.py
@@ -30,12 +30,14 @@ class Test_qsGW(unittest.TestCase):
         gw.max_cycle = 200
         gw.conv_tol = 1e-10
         gw.conv_tol_qp = 1e-10
+        gw.damping = 0.5
         gw.kernel(nmom_max)
         gw.gf.remove_uncoupled(tol=0.5)
         qp_energy = gw.qp_energy
         self.assertTrue(gw.converged)
         self.assertAlmostEqual(np.max(qp_energy[mf.mo_occ > 0]), ip, 7, msg=name)
         self.assertAlmostEqual(np.min(qp_energy[mf.mo_occ == 0]), ea, 7, msg=name)
+        print(gw.gf.energy)
         self.assertAlmostEqual(gw.gf.get_occupied().energy[-1], ip_full, 7, msg=name)
         self.assertAlmostEqual(gw.gf.get_virtual().energy[0], ea_full, 7, msg=name)
 
@@ -53,7 +55,7 @@ class Test_qsGW(unittest.TestCase):
         ip = -0.278223798218
         ea = 0.006428331070
         # GF poles:
-        ip_full = -0.382666081545
+        ip_full = -0.382666250130
         ea_full = 0.056791348829
         self._test_regression("pbe", dict(srg=1000), 3, ip, ea, ip_full, ea_full, "pbe srg")
 

--- a/tests/test_qsgw.py
+++ b/tests/test_qsgw.py
@@ -48,12 +48,12 @@ class Test_qsGW(unittest.TestCase):
 
     def test_regression_pbe_srg(self):
         # Quasiparticle energies:
-        ip = -0.298283035898
-        ea = 0.008368594912
+        ip = -0.282053566732
+        ea = 0.007299240529
         # GF poles:
-        ip_full = -0.418234914925
-        ea_full = 0.059983672577
-        self._test_regression("pbe", dict(srg=1e-3), 1, ip, ea, ip_full, ea_full, "pbe srg")
+        ip_full = -0.394724963441
+        ea_full = 0.058359286390
+        self._test_regression("pbe", dict(srg=1000), 1, ip, ea, ip_full, ea_full, "pbe srg")
 
 
 if __name__ == "__main__":

--- a/tests/test_qsgw.py
+++ b/tests/test_qsgw.py
@@ -28,6 +28,8 @@ class Test_qsGW(unittest.TestCase):
         mf.mo_energy = mpi_helper.bcast_dict(mf.mo_energy, root=0)
         gw = qsGW(mf, **kwargs)
         gw.max_cycle = 200
+        gw.conv_tol = 1e-10
+        gw.conv_tol_qp = 1e-10
         gw.kernel(nmom_max)
         gw.gf.remove_uncoupled(tol=0.1)
         qp_energy = gw.qp_energy

--- a/tests/test_qsgw.py
+++ b/tests/test_qsgw.py
@@ -37,7 +37,6 @@ class Test_qsGW(unittest.TestCase):
         self.assertTrue(gw.converged)
         self.assertAlmostEqual(np.max(qp_energy[mf.mo_occ > 0]), ip, 7, msg=name)
         self.assertAlmostEqual(np.min(qp_energy[mf.mo_occ == 0]), ea, 7, msg=name)
-        print(gw.gf.energy)
         self.assertAlmostEqual(gw.gf.get_occupied().energy[-1], ip_full, 7, msg=name)
         self.assertAlmostEqual(gw.gf.get_virtual().energy[0], ea_full, 7, msg=name)
 

--- a/tests/test_qsgw.py
+++ b/tests/test_qsgw.py
@@ -31,13 +31,13 @@ class Test_qsGW(unittest.TestCase):
         gw.conv_tol = 1e-10
         gw.conv_tol_qp = 1e-10
         gw.kernel(nmom_max)
-        gw.gf.remove_uncoupled(tol=0.1)
+        gw.gf.remove_uncoupled(tol=0.5)
         qp_energy = gw.qp_energy
         self.assertTrue(gw.converged)
-        self.assertAlmostEqual(gw.gf.get_occupied().energy[-1], ip_full, 7, msg=name)
-        self.assertAlmostEqual(gw.gf.get_virtual().energy[0], ea_full, 7, msg=name)
         self.assertAlmostEqual(np.max(qp_energy[mf.mo_occ > 0]), ip, 7, msg=name)
         self.assertAlmostEqual(np.min(qp_energy[mf.mo_occ == 0]), ea, 7, msg=name)
+        self.assertAlmostEqual(gw.gf.get_occupied().energy[-1], ip_full, 7, msg=name)
+        self.assertAlmostEqual(gw.gf.get_virtual().energy[0], ea_full, 7, msg=name)
 
     def test_regression_simple(self):
         # Quasiparticle energies:
@@ -50,12 +50,12 @@ class Test_qsGW(unittest.TestCase):
 
     def test_regression_pbe_srg(self):
         # Quasiparticle energies:
-        ip = -0.282053566732
-        ea = 0.007299240529
+        ip = -0.278223798218
+        ea = 0.006428331070
         # GF poles:
-        ip_full = -0.394724963441
-        ea_full = 0.058359286390
-        self._test_regression("pbe", dict(srg=1000), 1, ip, ea, ip_full, ea_full, "pbe srg")
+        ip_full = -0.382666081545
+        ea_full = 0.056791348829
+        self._test_regression("pbe", dict(srg=1000), 3, ip, ea, ip_full, ea_full, "pbe srg")
 
 
 if __name__ == "__main__":

--- a/tests/test_qskgw.py
+++ b/tests/test_qskgw.py
@@ -22,7 +22,7 @@ class Test_qsKGW(unittest.TestCase):
         cell.basis = "6-31g"
         cell.a = np.eye(3) * 3
         cell.verbose = 0
-        cell.precision = 1e-10
+        cell.precision = 1e-12
         cell.build()
 
         kmesh = [3, 1, 1]
@@ -30,7 +30,7 @@ class Test_qsKGW(unittest.TestCase):
 
         mf = dft.KRKS(cell, kpts, xc="hf")
         mf = mf.density_fit(auxbasis="weigend")
-        mf.conv_tol = 1e-10
+        mf.conv_tol = 1e-11
         mf.kernel()
 
         for k in range(len(kpts)):
@@ -107,7 +107,7 @@ class Test_qsKGW(unittest.TestCase):
         kgw.polarizability = "dtda"
         kgw.srg = 100
         kgw.compression = None
-        kgw.conv_tol_qp = 1e-10
+        kgw.conv_tol_qp = 1e-12
         kgw.conv_tol = 1e-10
         kgw.kernel(nmom_max)
 
@@ -115,7 +115,7 @@ class Test_qsKGW(unittest.TestCase):
         gw.polarizability = "dtda"
         gw.srg = 100
         gw.compression = None
-        gw.conv_tol_qp = 1e-10
+        gw.conv_tol_qp = 1e-12
         gw.conv_tol = 1e-10
         gw.kernel(nmom_max)
 

--- a/tests/test_qskgw.py
+++ b/tests/test_qskgw.py
@@ -108,6 +108,7 @@ class Test_qsKGW(unittest.TestCase):
         kgw.srg = 100
         kgw.compression = None
         kgw.conv_tol_qp = 1e-10
+        kgw.conv_tol = 1e-10
         kgw.kernel(nmom_max)
 
         gw = qsGW(self.smf)
@@ -115,6 +116,7 @@ class Test_qsKGW(unittest.TestCase):
         gw.srg = 100
         gw.compression = None
         gw.conv_tol_qp = 1e-10
+        gw.conv_tol = 1e-10
         gw.kernel(nmom_max)
 
         self._test_vs_supercell(gw, kgw)

--- a/tests/test_qskgw.py
+++ b/tests/test_qskgw.py
@@ -22,7 +22,7 @@ class Test_qsKGW(unittest.TestCase):
         cell.basis = "6-31g"
         cell.a = np.eye(3) * 3
         cell.verbose = 0
-        cell.precision = 1e-14
+        cell.precision = 1e-10
         cell.build()
 
         kmesh = [3, 1, 1]
@@ -86,12 +86,16 @@ class Test_qsKGW(unittest.TestCase):
         kgw.polarizability = "dtda"
         kgw.compression = None
         kgw.conv_tol_qp = 1e-10
+        kgw.conv_tol = 1e-10
+        kgw.eta = 1e-2
         kgw.kernel(nmom_max)
 
         gw = qsGW(self.smf)
         gw.polarizability = "dtda"
         gw.compression = None
         gw.conv_tol_qp = 1e-10
+        gw.conv_tol = 1e-10
+        gw.eta = 1e-2
         gw.kernel(nmom_max)
 
         self._test_vs_supercell(gw, kgw)

--- a/tests/test_qskgw.py
+++ b/tests/test_qskgw.py
@@ -71,27 +71,27 @@ class Test_qsKGW(unittest.TestCase):
         if check_convergence:
             self.assertTrue(gw.converged)
             self.assertTrue(kgw.converged)
-        e1 = np.concatenate([gf.energy for gf in kgw.gf])
-        w1 = np.concatenate([np.linalg.norm(gf.coupling, axis=0)**2 for gf in kgw.gf])
-        mask = np.argsort(e1)
-        e1 = e1[mask]
-        w1 = w1[mask]
-        e2 = gw.gf.energy
-        w2 = np.linalg.norm(gw.gf.coupling, axis=0)**2
         if full:
-            np.testing.assert_allclose(e1, e2, atol=1e-8)
+            e1 = np.sort(np.concatenate([gf.energy for gf in kgw.gf]))
+            e2 = gw.gf.energy
         else:
-            np.testing.assert_allclose(e1[w1 > 0.5], e2[w2 > 0.5], atol=1e-8)
+            e1 = np.sort(kgw.qp_energy.ravel())
+            e2 = gw.qp_energy
+        np.testing.assert_allclose(e1, e2, atol=1e-8)
 
     def test_dtda_vs_supercell(self):
         nmom_max = 3
 
         kgw = qsKGW(self.mf)
         kgw.polarizability = "dtda"
+        kgw.compression = None
+        kgw.conv_tol_qp = 1e-10
         kgw.kernel(nmom_max)
 
         gw = qsGW(self.smf)
         gw.polarizability = "dtda"
+        gw.compression = None
+        gw.conv_tol_qp = 1e-10
         gw.kernel(nmom_max)
 
         self._test_vs_supercell(gw, kgw)
@@ -102,11 +102,15 @@ class Test_qsKGW(unittest.TestCase):
         kgw = qsKGW(self.mf)
         kgw.polarizability = "dtda"
         kgw.srg = 100
+        kgw.compression = None
+        kgw.conv_tol_qp = 1e-10
         kgw.kernel(nmom_max)
 
         gw = qsGW(self.smf)
         gw.polarizability = "dtda"
         gw.srg = 100
+        gw.compression = None
+        gw.conv_tol_qp = 1e-10
         gw.kernel(nmom_max)
 
         self._test_vs_supercell(gw, kgw)

--- a/tests/test_qskgw.py
+++ b/tests/test_qskgw.py
@@ -1,0 +1,117 @@
+"""
+Tests for `pbc/qsgw.py`
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+from pyscf.pbc import gto, dft
+from pyscf.pbc.tools import k2gamma
+from pyscf.agf2 import mpi_helper
+
+from momentGW import qsGW
+from momentGW import qsKGW
+
+
+class Test_qsKGW(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cell = gto.Cell()
+        cell.atom = "He 0 0 0; He 1 1 1"
+        cell.basis = "6-31g"
+        cell.a = np.eye(3) * 3
+        cell.verbose = 0
+        cell.precision = 1e-14
+        cell.build()
+
+        kmesh = [3, 1, 1]
+        kpts = cell.make_kpts(kmesh)
+
+        mf = dft.KRKS(cell, kpts, xc="hf")
+        mf = mf.density_fit(auxbasis="weigend")
+        mf.conv_tol = 1e-10
+        mf.kernel()
+
+        for k in range(len(kpts)):
+            mf.mo_coeff[k] = mpi_helper.bcast_dict(mf.mo_coeff[k], root=0)
+            mf.mo_energy[k] = mpi_helper.bcast_dict(mf.mo_energy[k], root=0)
+
+        smf = k2gamma.k2gamma(mf, kmesh=kmesh)
+        smf = smf.density_fit(auxbasis="weigend")
+
+        cls.cell, cls.kpts, cls.mf, cls.smf = cell, kpts, mf, smf
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.cell, cls.kpts, cls.mf, cls.smf
+
+    def test_supercell_valid(self):
+        # Require real MOs for supercell comparison
+
+        scell, phase = k2gamma.get_phase(self.cell, self.kpts)
+        nk, nao, nmo = np.shape(self.mf.mo_coeff)
+        nr, _ = np.shape(phase)
+
+        k_conj_groups = k2gamma.group_by_conj_pairs(self.cell, self.kpts, return_kpts_pairs=False)
+        k_phase = np.eye(nk, dtype=np.complex128)
+        r2x2 = np.array([[1., 1j], [1., -1j]]) * .5**.5
+        pairs = [[k, k_conj] for k, k_conj in k_conj_groups
+                 if k_conj is not None and k != k_conj]
+        for idx in np.array(pairs):
+            k_phase[idx[:, None], idx] = r2x2
+
+        c_gamma = np.einsum('Rk,kum,kh->Ruhm', phase, self.mf.mo_coeff, k_phase)
+        c_gamma = c_gamma.reshape(nao*nr, nk*nmo)
+        c_gamma[:, abs(c_gamma.real).max(axis=0) < 1e-5] *= -1j
+
+        self.assertAlmostEqual(np.max(np.abs(np.array(c_gamma).imag)), 0, 8)
+
+    def _test_vs_supercell(self, gw, kgw, full=False, check_convergence=True):
+        if check_convergence:
+            self.assertTrue(gw.converged)
+            self.assertTrue(kgw.converged)
+        e1 = np.concatenate([gf.energy for gf in kgw.gf])
+        w1 = np.concatenate([np.linalg.norm(gf.coupling, axis=0)**2 for gf in kgw.gf])
+        mask = np.argsort(e1)
+        e1 = e1[mask]
+        w1 = w1[mask]
+        e2 = gw.gf.energy
+        w2 = np.linalg.norm(gw.gf.coupling, axis=0)**2
+        if full:
+            np.testing.assert_allclose(e1, e2, atol=1e-8)
+        else:
+            np.testing.assert_allclose(e1[w1 > 0.5], e2[w2 > 0.5], atol=1e-8)
+
+    def test_dtda_vs_supercell(self):
+        nmom_max = 3
+
+        kgw = qsKGW(self.mf)
+        kgw.polarizability = "dtda"
+        kgw.kernel(nmom_max)
+
+        gw = qsGW(self.smf)
+        gw.polarizability = "dtda"
+        gw.kernel(nmom_max)
+
+        self._test_vs_supercell(gw, kgw)
+
+    def test_dtda_vs_supercell_srg(self):
+        nmom_max = 5
+
+        kgw = qsKGW(self.mf)
+        kgw.polarizability = "dtda"
+        kgw.srg = 100
+        kgw.kernel(nmom_max)
+
+        gw = qsGW(self.smf)
+        gw.polarizability = "dtda"
+        gw.srg = 100
+        gw.kernel(nmom_max)
+
+        self._test_vs_supercell(gw, kgw)
+
+
+if __name__ == "__main__":
+    print("Running tests for qsKGW")
+    unittest.main()

--- a/tests/test_scgw.py
+++ b/tests/test_scgw.py
@@ -41,7 +41,7 @@ class Test_scGW(unittest.TestCase):
         gw = scGW(self.mf)
         gw.diagonal_se = True
         gw.vhf_df = False
-        conv, gf, se = gw.kernel(nmom_max=1)
+        conv, gf, se, _ = gw.kernel(nmom_max=1)
         self.assertAlmostEqual(
             gf.make_rdm1().trace(),
             self.mol.nelectron,
@@ -49,7 +49,7 @@ class Test_scGW(unittest.TestCase):
         )
         gw.optimise_chempot = True
         gw.vhf_df = False
-        conv, gf, se = gw.kernel(nmom_max=1)
+        conv, gf, se, _ = gw.kernel(nmom_max=1)
         self.assertAlmostEqual(
             gf.make_rdm1().trace(),
             self.mol.nelectron,
@@ -57,7 +57,7 @@ class Test_scGW(unittest.TestCase):
         )
         gw.fock_loop = True
         gw.vhf_df = False
-        conv, gf, se = gw.kernel(nmom_max=1)
+        conv, gf, se, _ = gw.kernel(nmom_max=1)
         self.assertAlmostEqual(
             gf.make_rdm1().trace(),
             self.mol.nelectron,

--- a/tests/test_sckgw.py
+++ b/tests/test_sckgw.py
@@ -25,7 +25,7 @@ class Test_scKGW(unittest.TestCase):
         cell.verbose = 0
         cell.build()
 
-        kmesh = [1, 1, 1]
+        kmesh = [3, 1, 1]
         kpts = cell.make_kpts(kmesh)
 
         mf = dft.KRKS(cell, kpts, xc="hf")
@@ -128,16 +128,16 @@ class Test_scKGW(unittest.TestCase):
 
         kgw = scKGW(self.mf)
         kgw.polarizability = "dtda"
-        kgw.max_cycle = 5
-        kgw.damping = 0.5
+        kgw.max_cycle = 200
+        kgw.conv_tol = 1e-8
         kgw.g0 = True
         kgw.compression = None
         kgw.kernel(nmom_max)
 
         gw = scGW(self.smf)
         gw.polarizability = "dtda"
-        gw.max_cycle = 5
-        gw.damping = 0.5
+        gw.max_cycle = 200
+        gw.conv_tol = 1e-8
         gw.g0 = True
         gw.compression = None
         gw.kernel(nmom_max)


### PR DESCRIPTION
Implements k-space TDA.

This PR also changes exactly what is outputed by qsGW. The `gf` attribute of a qsGW calculation is now the self-consistent Green's function in a larger space than the physical space, the size of which is dictated by `nmom_max` as in other methods. The quasiparticle energies which previously were stored in this Green's function can be recovered with the `qsgw.qp_energy` property. This property applies for all `momentGW` methods, and for other solvers it simply selects the best overlapping poles of the Green's function with each MO.

To-do:
- [x] Compression
  - Not the same as supercell!
- [x] Fock loop
- [x] Self-consistency
  - [x] evGW
  - [x] qsGW
     - Need to check this more thoroughly though
  - [x] scGW
- [x] Parallelism
- [x] Interpolation
- [ ] Finite-size q=0, G=0 correction: Should be extra simple for TDA