### PR TITLE
`Integrals` class

### DIFF
--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -21,9 +21,6 @@ class BaseGW(lib.StreamObject):
     polarizability : str, optional
         Type of polarizability to use, can be one of `("drpa",
         "drpa-exact", "dtda").  Default value is `"drpa"`.
-    vhf_df : bool, optional
-        If True, calculate the static self-energy directly from `Lpq`.
-        Default value is False.
     npoints : int, optional
         Number of numerical integration points.  Default value is `48`.
     optimise_chempot : bool, optional
@@ -53,7 +50,6 @@ class BaseGW(lib.StreamObject):
 
     diagonal_se = False
     polarizability = "drpa"
-    vhf_df = False
     npoints = 48
     optimise_chempot = False
     fock_loop = False
@@ -71,7 +67,6 @@ class BaseGW(lib.StreamObject):
     _opts = [
         "diagonal_se",
         "polarizability",
-        "vhf_df",
         "npoints",
         "optimise_chempot",
         "fock_loop",

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -9,6 +9,7 @@ from pyscf.lib import logger
 
 from momentGW import util
 from momentGW.base import BaseGW
+from momentGW.ints import Integrals
 from momentGW.gw import GW
 
 
@@ -37,9 +38,9 @@ def kernel(
         Tuple of (hole, particle) moments, if passed then they will
         be used  as the initial guess instead of calculating them.
         Default value is None.
-    integrals : tuple of numpy.ndarray, optional
-        Density-fitted ERI tensors. If None, generate from `gw.ao2mo`.
-        Default value is None.
+    integrals : Integrals, optional
+        Density-fitted integrals. If None, generate from scratch.
+        Default value is `None`.
 
     Returns
     -------
@@ -57,8 +58,7 @@ def kernel(
         raise NotImplementedError("%s for polarizability=%s" % (gw.name, gw.polarizability))
 
     if integrals is None:
-        integrals = gw.ao2mo(mo_coeff)
-    Lpq, Lia = integrals
+        integrals = gw.ao2mo()
 
     nmo = gw.nmo
     nocc = gw.nocc
@@ -70,7 +70,6 @@ def kernel(
 
     # Get the static part of the SE
     se_static = gw.build_se_static(
-        Lpq=Lpq,
         mo_energy=mo_energy,
         mo_coeff=mo_coeff,
     )
@@ -86,8 +85,7 @@ def kernel(
         else:
             th, tp = gw.build_se_moments(
                 nmom_max,
-                Lpq,
-                Lia,
+                integrals,
                 mo_energy=(
                     mo_energy if not gw.g0 else mo_energy_ref,
                     mo_energy if not gw.w0 else mo_energy_ref,
@@ -106,7 +104,7 @@ def kernel(
             tp = gw.damping * tp_prev + (1.0 - gw.damping) * tp
 
         # Solve the Dyson equation
-        gf, se = gw.solve_dyson(th, tp, se_static, Lpq=Lpq)
+        gf, se = gw.solve_dyson(th, tp, se_static, integrals=integrals)
 
         # Update the MO energies
         check = set()

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -9,8 +9,8 @@ from pyscf.lib import logger
 
 from momentGW import util
 from momentGW.base import BaseGW
-from momentGW.ints import Integrals
 from momentGW.gw import GW
+from momentGW.ints import Integrals
 
 
 def kernel(

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -16,8 +16,8 @@ from pyscf.ao2mo import _ao2mo
 from pyscf.lib import logger
 
 from momentGW.base import BaseGW
-from momentGW.ints import Integrals
 from momentGW.fock import fock_loop
+from momentGW.ints import Integrals
 from momentGW.rpa import RPA
 from momentGW.tda import TDA
 
@@ -180,8 +180,7 @@ class GW(BaseGW):
             raise NotImplementedError
 
     def ao2mo(self):
-        """Get the integrals.
-        """
+        """Get the integrals."""
 
         integrals = Integrals(
             self.with_df,

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -16,6 +16,7 @@ from pyscf.ao2mo import _ao2mo
 from pyscf.lib import logger
 
 from momentGW.base import BaseGW
+from momentGW.ints import Integrals
 from momentGW.fock import fock_loop
 from momentGW.rpa import RPA
 from momentGW.tda import TDA
@@ -44,8 +45,8 @@ def kernel(
     moments : tuple of numpy.ndarray, optional
         Tuple of (hole, particle) moments, if passed then they will
         be used instead of calculating them. Default value is None.
-    integrals : tuple of numpy.ndarray, optional
-        Density-fitted ERI tensors. If None, generate from `gw.ao2mo`.
+    integrals : Integrals, optional
+        Density-fitted integrals. If None, generate from scratch.
         Default value is None.
 
     Returns
@@ -60,12 +61,10 @@ def kernel(
     """
 
     if integrals is None:
-        integrals = gw.ao2mo(mo_coeff)
-    Lpq, Lia = integrals
+        integrals = gw.ao2mo()
 
     # Get the static part of the SE
     se_static = gw.build_se_static(
-        Lpq=Lpq,
         mo_energy=mo_energy,
         mo_coeff=mo_coeff,
     )
@@ -74,15 +73,14 @@ def kernel(
     if moments is None:
         th, tp = gw.build_se_moments(
             nmom_max,
-            Lpq,
-            Lia,
+            integrals,
             mo_energy=mo_energy,
         )
     else:
         th, tp = moments
 
     # Solve the Dyson equation
-    gf, se = gw.solve_dyson(th, tp, se_static, Lpq=Lpq)
+    gf, se = gw.solve_dyson(th, tp, se_static, integrals=integrals)
     conv = True
 
     return conv, gf, se
@@ -98,15 +96,12 @@ class GW(BaseGW):
     def name(self):
         return "G0W0"
 
-    def build_se_static(self, Lpq=None, mo_coeff=None, mo_energy=None):
+    def build_se_static(self, mo_coeff=None, mo_energy=None):
         """Build the static part of the self-energy, including the
         Fock matrix.
 
         Parameters
         ----------
-        Lpq : np.ndarray, optional
-            Density-fitted ERI tensor. If None, generate from `gw.ao2mo`.
-            Default value is None.
         mo_energy : numpy.ndarray, optional
             Molecular orbital energies.  Default value is that of
             `self.mo_energy`.
@@ -125,8 +120,6 @@ class GW(BaseGW):
             mo_coeff = self.mo_coeff
         if mo_energy is None:
             mo_energy = self.mo_energy
-        if Lpq is None and self.vhf_df:
-            Lpq, _ = self.ao2mo(mo_coeff)
 
         with lib.temporary_env(self._scf, verbose=0):
             with lib.temporary_env(self._scf.with_df, verbose=0):
@@ -134,24 +127,11 @@ class GW(BaseGW):
                 dm = self._scf.make_rdm1(mo_coeff=mo_coeff)
         v_mf = lib.einsum("pq,pi,qj->ij", v_mf, mo_coeff, mo_coeff)
 
-        # v_hf from DFT/HF density
-        if self.vhf_df:
-            vk = np.zeros_like(v_mf)
-            p0, p1 = list(mpi_helper.prange(0, self.nmo, self.nmo))[0]
-
-            sc = np.dot(self._scf.get_ovlp(), mo_coeff)
-            dm = lib.einsum("pq,pi,qj->ij", dm, sc, sc)
-
-            tmp = lib.einsum("Qik,kl->Qil", Lpq, dm[p0:p1])
-            tmp = mpi_helper.allreduce(tmp)
-            vk[:, p0:p1] = -lib.einsum("Qil,Qlj->ij", tmp, Lpq) * 0.5
-            vk = mpi_helper.allreduce(vk)
-        else:
+        with lib.temporary_env(self._scf.with_df, verbose=0):
             with lib.temporary_env(self._scf.with_df, verbose=0):
-                with lib.temporary_env(self._scf.with_df, verbose=0):
-                    vk = scf.hf.SCF.get_veff(self._scf, self.mol, dm)
-                    vk -= scf.hf.SCF.get_j(self._scf, self.mol, dm)
-            vk = lib.einsum("pq,pi,qj->ij", vk, mo_coeff, mo_coeff)
+                vk = scf.hf.SCF.get_veff(self._scf, self.mol, dm)
+                vk -= scf.hf.SCF.get_j(self._scf, self.mol, dm)
+        vk = lib.einsum("pq,pi,qj->ij", vk, mo_coeff, mo_coeff)
 
         se_static = vk - v_mf
 
@@ -162,193 +142,15 @@ class GW(BaseGW):
 
         return se_static
 
-    def get_compression_metric(self):
-        """
-        Get the compression metric for the ERIs.
-
-        Returns
-        -------
-        rot : numpy.ndarray, optional
-            Rotation matrix for the auxiliary basis. If no compression
-            is needed at this point, return `None`.
-        """
-
-        compression = set(x for x in self.compression.split(",") if x != "ia")
-        if not compression:
-            return None
-
-        cput0 = (logger.process_clock(), logger.perf_counter())
-        logger.info(self, "Computing compression metric for ERIs")
-
-        naux = self.with_df.get_naoaux()
-        mo_occ = self.mo_occ
-        mo_coeff = self.mo_coeff
-
-        # Initialise rotation matrix
-        prod = np.zeros((naux, naux))
-
-        # Loop over the required blocks
-        for key in compression:
-            logger.debug(self, "Transforming %s block", key)
-            ci, cj = tuple(
-                mo_coeff[:, mo_occ > 0] if k == "o" else mo_coeff[:, mo_occ == 0] for k in key
-            )
-            ni, nj = ci.shape[-1], cj.shape[-1]
-
-            for p0, p1 in mpi_helper.prange(0, ni * nj, self.with_df.blockdim):
-                i0, j0 = divmod(p0, nj)
-                i1, j1 = divmod(p1, nj)
-
-                Lxy = np.zeros((naux, p1 - p0))
-                b1 = 0
-                for block in self.with_df.loop():
-                    block = lib.unpack_tril(block)
-                    b0, b1 = b1, b1 + block.shape[0]
-                    logger.debug(self, "Block [%d:%d, %d:%d]", p0, p1, b0, b1)
-
-                    Lxy_tmp = lib.einsum("Lpq,pi,qj->Lij", block, ci[:, i0 : i1 + 1], cj)
-                    Lxy_tmp = Lxy_tmp.reshape(b1 - b0, -1)
-                    Lxy[b0:b1] = Lxy_tmp[:, j0 : j0 + (p1 - p0)]
-
-                prod += np.dot(Lxy, Lxy.T)
-
-        prod = mpi_helper.reduce(prod, root=0)
-
-        if mpi_helper.rank == 0:
-            e, v = np.linalg.eigh(prod)
-            mask = np.abs(e) > self.compression_tol
-            rot = v[:, mask]
-        else:
-            rot = np.zeros((0,))
-        del prod
-
-        rot = mpi_helper.bcast(rot, root=0)
-
-        if rot.shape[-1] == naux:
-            logger.info(self, "No compression found")
-            rot = None
-        else:
-            logger.info(self, "Compressed ERI auxiliary space from %d to %d", *rot.shape)
-        logger.timer(self, "compressing ERIs", *cput0)
-
-        return rot
-
-    def ao2mo(self, mo_coeff, mo_coeff_g=None, mo_coeff_w=None, nocc_w=None, rot=None):
-        """
-        Get the density-fitted integrals. This routine returns two
-        arrays, allowing self-consistency in G or W.
-
-        When using MPI, these integral arrays are distributed as
-        follows. The `Lia` array is distributed over its second and
-        third indices, and the `Lpx` array over its third index. The
-        distribution is according to
-        `pyscf.agf2.mpi_helper.prange(0, N, N)`.
-
-        Parameters
-        ----------
-        mo_coeff : numpy.ndarray
-            Molecular orbital coefficients.
-        mo_coeff_g : numpy.ndarray, optional
-            Molecular orbital coefficients corresponding to the
-            Green's function. Default value is that of `mo_coeff`.
-        mo_coeff_w : numpy.ndarray, optional
-            Molecular orbital coefficients corresponding to the
-            screened Coulomb interaction. Default value is that of
-            `mo_coeff`.
-        nocc_w : int, optional
-            Number of occupied orbitals corresponding to the
-            screened Coulomb interaction. Must be specified if
-            `mo_coeff_w` is specified.
-        rot : numpy.ndarray, optional
-            Rotation matrix for the auxiliary basis. If not specified,
-            the metric is computed and used to rotate the auxiliary
-            basis. Default value is `None`.
-
-        Returns
-        -------
-        Lpx : numpy.ndarray
-            Density-fitted ERI tensor, where the first index is
-            the auxiliary basis function index, and the second and
-            third indices are the MO and Green's function orbital
-            indices, respectively.
-        Lia : numpy.ndarray
-            Density-fitted ERI tensor, where the first index is
-            the auxiliary basis function index, and the second and
-            third indices are the occupied and virtual screened
-            Coulomb interaction orbital indices, respectively.
-        """
-
-        # Get the rotation matrix
-        if rot is None:
-            rot = self.get_compression_metric()
-
-        cput0 = (logger.process_clock(), logger.perf_counter())
-        logger.info(self, "Transforming density-fitted ERIs")
-
-        if mo_coeff_g is None:
-            mo_coeff_g = mo_coeff
-        if mo_coeff_w is None:
-            mo_coeff_w = mo_coeff
-            nocc_w = self.nocc
-
-        naux = self.with_df.get_naoaux()
-        naux_c = rot.shape[1] if rot is not None else naux
-        nmo = mo_coeff.shape[-1]
-        nmo_g = mo_coeff_g.shape[-1]
-        nmo_w = mo_coeff_w.shape[-1]
-        nvir_w = nmo_w - nocc_w
-
-        # Get the slices on the current process and initialise arrays
-        p0, p1 = list(mpi_helper.prange(0, nmo_g, nmo_g))[0]
-        q0, q1 = list(mpi_helper.prange(0, nocc_w * nvir_w, nocc_w * nvir_w))[0]
-        Lpx = np.zeros((naux_c, nmo, p1 - p0))
-        Lia = np.zeros((naux_c, q1 - q0))
-
-        # Build the integrals blockwise
-        b1 = 0
-        for block in self.with_df.loop():
-            block = lib.unpack_tril(block)
-            b0, b1 = b1, b1 + block.shape[0]
-            logger.debug(self, "Block [%d:%d]", b0, b1)
-
-            # Rotate the entire block
-            logger.debug(self, "(L|px) size: (%d, %d)", naux_c, nmo * (p1 - p0))
-            tmp = lib.einsum("Lpq,pi,qj->Lij", block, mo_coeff, mo_coeff_g[:, p0:p1])
-            if rot is None:
-                Lpx[b0:b1] += tmp
-            else:
-                Lpx += lib.einsum("L...,LQ->Q...", tmp, rot[b0:b1])
-
-            # Rotate for all required occupied indices - should be partitioned closely enough
-            logger.debug(self, "(L|ia) size: (%d, %d)", naux_c, q1 - q0)
-            i0, a0 = divmod(q0, nvir_w)
-            i1, a1 = divmod(q1, nvir_w)
-            tmp = lib.einsum(
-                "Lpq,pi,qj->Lij", block, mo_coeff_w[:, i0 : i1 + 1], mo_coeff_w[:, nocc_w:]
-            )
-            tmp = tmp.reshape(b1 - b0, -1)
-
-            # Convert slice from (i0, 0) : (i1, 0) to (i0, j0) : (i1-1, j1)
-            if rot is None:
-                Lia[b0:b1] += tmp[:, a0 : a0 + (q1 - q0)]
-            else:
-                Lia += lib.einsum("L...,LQ->Q...", tmp[:, a0 : a0 + (q1 - q0)], rot[b0:b1])
-
-        logger.timer(self, "transforming ERIs", *cput0)
-
-        return Lpx, Lia
-
-    def build_se_moments(self, nmom_max, Lpq, Lia, **kwargs):
+    def build_se_moments(self, nmom_max, integrals, **kwargs):
         """Build the moments of the self-energy.
 
         Parameters
         ----------
         nmom_max : int
             Maximum moment number to calculate.
-        Lpq : numpy.ndarray
-            Density-fitted ERI tensor. See `self.ao2mo` for details.
-        Lia : numpy.ndarray
-            Density-fitted ERI tensor. See `self.ao2mo` for details.
+        integrals : Integrals
+            Density-fitted integrals.
 
         See functions in `momentGW.rpa` for `kwargs` options.
 
@@ -363,21 +165,37 @@ class GW(BaseGW):
         """
 
         if self.polarizability == "drpa":
-            rpa = RPA(self, nmom_max, Lpq, Lia, **kwargs)
+            rpa = RPA(self, nmom_max, integrals, **kwargs)
             return rpa.kernel()
 
         elif self.polarizability == "drpa-exact":
-            rpa = RPA(self, nmom_max, Lpq, Lia, **kwargs)
+            rpa = RPA(self, nmom_max, integrals, **kwargs)
             return rpa.kernel(exact=True)
 
         elif self.polarizability == "dtda":
-            tda = TDA(self, nmom_max, Lpq, Lia, **kwargs)
+            tda = TDA(self, nmom_max, integrals, **kwargs)
             return tda.kernel()
 
         else:
             raise NotImplementedError
 
-    def solve_dyson(self, se_moments_hole, se_moments_part, se_static, Lpq=None):
+    def ao2mo(self):
+        """Get the integrals.
+        """
+
+        integrals = Integrals(
+            self.with_df,
+            self.mo_coeff,
+            self.mo_occ,
+            compression=self.compression,
+            compression_tol=self.compression_tol,
+            store_full=self.fock_loop,
+        )
+        integrals.transform()
+
+        return integrals
+
+    def solve_dyson(self, se_moments_hole, se_moments_part, se_static, integrals=None):
         """Solve the Dyson equation due to a self-energy resulting
         from a list of hole and particle moments, along with a static
         contribution.
@@ -400,8 +218,8 @@ class GW(BaseGW):
             Moments of the particle self-energy.
         se_static : numpy.ndarray
             Static part of the self-energy.
-        Lpq : np.ndarray, optional
-            Density-fitted ERI tensor.  Required if `self.fock_loop` is
+        integrals : Integrals
+            Density-fitted integrals.  Required if `self.fock_loop` is
             `True`.  Default value is `None`.
 
         Returns
@@ -438,11 +256,11 @@ class GW(BaseGW):
         gf.coupling = mpi_helper.bcast(gf.coupling, root=0)
 
         if self.fock_loop:
-            if Lpq is None:
+            if integrals is None:
                 raise ValueError("Lpq must be passed to solve_dyson if fock_loop=True")
 
             try:
-                gf, se, conv = fock_loop(self, Lpq, gf, se, **self.fock_opts)
+                gf, se, conv = fock_loop(self, integrals.Lpq, gf, se, **self.fock_opts)
             except IndexError:
                 pass
 

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -127,7 +127,7 @@ class Integrals:
             return
 
         cput0 = (logger.process_clock(), logger.perf_counter())
-        logger.info(self, f"Initialising {self.__class__.__name__}")
+        logger.info(self, f"Transforming {self.__class__.__name__}")
 
         # Get the slices on the current process and initialise the arrays
         o0, o1 = list(mpi_helper.prange(0, self.nmo, self.nmo))[0]

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -1,0 +1,318 @@
+"""
+Integral helpers.
+"""
+
+import numpy as np
+
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.agf2 import mpi_helper
+
+
+class Integrals:
+    """
+    Container for the integrals required for GW methods.
+    """
+
+    def __init__(
+        self,
+        with_df,
+        mo_coeff,
+        mo_occ,
+        compression="ia",
+        compression_tol=1e-10,
+        store_full=False,
+    ):
+        self.verbose = with_df.mol.verbose
+        self.stdout = with_df.mol.stdout
+
+        self.with_df = with_df
+        self.mo_coeff = mo_coeff
+        self.mo_occ = mo_occ
+        self.compression = compression
+        self.compression_tol = compression_tol
+        self.store_full = store_full
+
+        self._blocks = {}
+        self._mo_coeff_g = None
+        self._mo_coeff_w = None
+        self._mo_occ_w = None
+        self._rot = None
+
+    def get_compression_metric(self):
+        """
+        Return the compression metric.
+        """
+        # TODO cache this if needed
+
+        compression = self.compression.replace("vo", "ov")
+        compression = set(x for x in compression.split(","))
+        if not compression:
+            return None
+        if "ia" in compression and "ov" in compression:
+            raise ValueError("`compression` cannot contain both `'ia'` and `'ov'` (or `'vo'`)")
+
+        cput0 = (logger.process_clock(), logger.perf_counter())
+        logger.info(self, f"Computing compression metric for {self.__class__.__name__}")
+
+        prod = np.zeros((self.naux_full, self.naux_full))
+
+        # Loop over required blocks
+        for key in sorted(compression):
+            logger.debug(self, f"Transforming {key} block")
+            coeffs = [
+                {
+                    "o": self.mo_coeff[:, self.mo_occ > 0],
+                    "v": self.mo_coeff[:, self.mo_occ == 0],
+                    "i": self.mo_coeff_w[:, self.mo_occ_w > 0],
+                    "a": self.mo_coeff_w[:, self.mo_occ_w == 0],
+                }[k]
+                for k in key
+            ]
+            ni, nj = coeffs[0].shape[-1], coeffs[1].shape[-1]
+
+            for p0, p1 in mpi_helper.prange(0, ni * nj, self.with_df.blockdim):
+                i0, j0 = divmod(p0, nj)
+                i1, j1 = divmod(p1, nj)
+
+                Lxy = np.zeros((self.naux_full, p1 - p0))
+                b1 = 0
+                for block in self.with_df.loop():
+                    block = lib.unpack_tril(block)
+                    b0, b1 = b1, b1 + block.shape[0]
+                    logger.debug(self, f"  Block [{p0}:{p1}, {b0}:{b1}]")
+
+                    tmp = lib.einsum("Lpq,pi,qj->Lij", block, *coeffs)
+                    tmp = tmp.reshape(b1 - b0, ni * nj)
+                    Lxy[b0:b1] = tmp[:, j0 : j0 + (p1 - p0)]
+
+                prod += np.dot(Lxy, Lxy.T)
+
+        prod = mpi_helper.allreduce(prod, root=0)
+
+        if mpi_helper.rank == 0:
+            e, v = np.linalg.eigh(prod)
+            mask = np.abs(e) > self.compression_tol
+            rot = v[:, mask]
+        else:
+            rot = np.zeros((0,))
+        del prod
+
+        rot = mpi_helper.bcast(rot, root=0)
+
+        if rot.shape[-1] == self.naux_full:
+            logger.info(self, "No compression found")
+            rot = None
+        else:
+            logger.info(self, f"Compressed auxiliary space from {self.naux_full} to {rot.shape[1]}")
+        logger.timer(self, "compression metric", *cput0)
+
+        return rot
+
+    def transform(self, do_Lpq=None, do_Lpx=True, do_Lia=True):
+        """
+        Initialise the integrals, building:
+            - Lpq: the full (aux, MO, MO) array if `store_full`
+            - Lpx: the compressed (aux, MO, MO) array
+            - Lia: the compressed (aux, occ, vir) array
+        """
+
+        # Get the compression metric
+        if self._rot is None:
+            self._rot = self.get_compression_metric()
+        rot = self._rot
+
+        do_Lpq = self.store_full if do_Lpq is None else do_Lpq
+        if not any([do_Lpq, do_Lpx, do_Lia]):
+            return
+
+        cput0 = (logger.process_clock(), logger.perf_counter())
+        logger.info(self, f"Initialising {self.__class__.__name__}")
+
+        # Get the slices on the current process and initialise the arrays
+        o0, o1 = list(mpi_helper.prange(0, self.nmo, self.nmo))[0]
+        p0, p1 = list(mpi_helper.prange(0, self.nmo_g, self.nmo_g))[0]
+        q0, q1 = list(mpi_helper.prange(0, self.nocc_w * self.nvir_w, self.nocc_w * self.nvir_w))[0]
+        Lpq = np.zeros((self.naux_full, self.nmo, o1 - o0)) if do_Lpq else None
+        Lpx = np.zeros((self.naux, self.nmo, p1 - p0)) if do_Lpx else None
+        Lia = np.zeros((self.naux, q1 - q0)) if do_Lia else None
+
+        # Build the integrals blockwise
+        b1 = 0
+        for block in self.with_df.loop():
+            block = lib.unpack_tril(block)
+            b0, b1 = b1, b1 + block.shape[0]
+            logger.debug(self, f"  Block [{b0}:{b1}]")
+
+            # If needed, rotate the full (L|pq) array
+            if do_Lpq:
+                logger.debug(self, f"(L|pq) size: ({self.naux_full}, {self.nmo}, {o1 - o0})")
+                Lpq[b0:b1] = lib.einsum("Lpq,pi,qj->Lij", block, self.mo_coeff, self.mo_coeff)
+
+            # Compress the block
+            block = lib.einsum("L...,LQ->Q...", block, rot[b0:b1])
+
+            # Build the compressed (L|px) array
+            if do_Lpx:
+                logger.debug(self, f"(L|px) size: ({self.naux}, {self.nmo}, {p1 - p0})")
+                Lpx += lib.einsum("Lpq,pi,qj->Lij", block, self.mo_coeff, self.mo_coeff_g)
+
+            # Build the compressed (L|ia) array
+            if do_Lia:
+                logger.debug(self, f"(L|ia) size: ({self.naux}, {q1 - q0})")
+                i0, a0 = divmod(q0, self.nvir_w)
+                i1, a1 = divmod(q1, self.nvir_w)
+                coeffs = [self.mo_coeff_w[:, i0 : i1 + 1], self.mo_coeff_w[:, self.nocc_w:]]
+                tmp = lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0], coeffs[1])
+                tmp = tmp.reshape(self.naux, -1)
+                Lia += tmp[:, a0 : a0 + (q1 - q0)]
+
+        if do_Lpq:
+            self._blocks["Lpq"] = Lpq
+        if do_Lpx:
+            self._blocks["Lpx"] = Lpx
+        if do_Lia:
+            self._blocks["Lia"] = Lia
+
+        logger.timer(self, "transform", *cput0)
+
+    def update_coeffs(self, mo_coeff_g=None, mo_coeff_w=None, mo_occ_w=None):
+        """
+        Update the MO coefficients for the Green's function and the
+        screened Coulomb interaction.
+        """
+
+        if any((mo_coeff_w is not None, mo_occ_w is not None)):
+            assert mo_coeff_w is not None and mo_occ_w is not None
+
+        if mo_coeff_g is not None:
+            self._mo_coeff_g = mo_coeff_g
+
+        if mo_coeff_w is not None:
+            self._mo_coeff_w = mo_coeff_w
+            self._mo_occ_w = mo_occ_w
+            if "ia" in self.compression:
+                self.rot = self.get_compression_metric()
+
+        self.transform(
+            do_Lpq=False,
+            do_Lpx=mo_coeff_g is not None,
+            do_Lia=mo_coeff_w is not None,
+        )
+
+    @property
+    def Lpq(self):
+        """
+        Return the full uncompressed (aux, MO, MO) array.
+        """
+        return self._blocks["Lpq"]
+
+    @property
+    def Lpx(self):
+        """
+        Return the compressed (aux, MO, G) array.
+        """
+        return self._blocks["Lpx"]
+
+    @property
+    def Lia(self):
+        """
+        Return the compressed (aux, W occ, W vir) array.
+        """
+        return self._blocks["Lia"]
+
+    @property
+    def mo_coeff_g(self):
+        """
+        Return the MO coefficients for the Green's function.
+        """
+        return self._mo_coeff_g if self._mo_coeff_g is not None else self.mo_coeff
+
+    @property
+    def mo_coeff_w(self):
+        """
+        Return the MO coefficients for the screened Coulomb interaction.
+        """
+        return self._mo_coeff_w if self._mo_coeff_w is not None else self.mo_coeff
+
+    @property
+    def mo_occ_w(self):
+        """
+        Return the MO occupation numbers for the screened Coulomb interaction.
+        """
+        return self._mo_occ_w if self._mo_occ_w is not None else self.mo_occ
+
+    @property
+    def nmo(self):
+        """
+        Return the number of MOs.
+        """
+        return self.mo_coeff.shape[-1]
+
+    @property
+    def nocc(self):
+        """
+        Return the number of occupied MOs.
+        """
+        return np.sum(self.mo_occ > 0)
+
+    @property
+    def nvir(self):
+        """
+        Return the number of virtual MOs.
+        """
+        return np.sum(self.mo_occ == 0)
+
+    @property
+    def nmo_g(self):
+        """
+        Return the number of MOs for the Green's function.
+        """
+        return self.mo_coeff_g.shape[-1]
+
+    @property
+    def nmo_w(self):
+        """
+        Return the number of MOs for the screened Coulomb interaction.
+        """
+        return self.mo_coeff_w.shape[-1]
+
+    @property
+    def nocc_w(self):
+        """
+        Return the number of occupied MOs for the screened Coulomb
+        interaction.
+        """
+        return np.sum(self.mo_occ_w > 0)
+
+    @property
+    def nvir_w(self):
+        """
+        Return the number of virtual MOs for the screened Coulomb
+        interaction.
+        """
+        return np.sum(self.mo_occ_w == 0)
+
+    @property
+    def naux(self):
+        """
+        Return the number of auxiliary basis functions, after the
+        compression.
+        """
+        return self._rot.shape[1]
+
+    @property
+    def naux_full(self):
+        """
+        Return the number of auxiliary basis functions, before the
+        compression.
+        """
+        return self.with_df.get_naoaux()
+
+    @property
+    def is_bare(self):
+        """
+        Return a boolean flag indicating whether the integrals have
+        no self-consistencies.
+        """
+        return self._mo_coeff_g is None and self._mo_coeff_w is None

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -3,10 +3,9 @@ Integral helpers.
 """
 
 import numpy as np
-
 from pyscf import lib
-from pyscf.lib import logger
 from pyscf.agf2 import mpi_helper
+from pyscf.lib import logger
 
 
 class Integrals:
@@ -162,7 +161,7 @@ class Integrals:
                 logger.debug(self, f"(L|ia) size: ({self.naux}, {q1 - q0})")
                 i0, a0 = divmod(q0, self.nvir_w)
                 i1, a1 = divmod(q1, self.nvir_w)
-                coeffs = [self.mo_coeff_w[:, i0 : i1 + 1], self.mo_coeff_w[:, self.nocc_w:]]
+                coeffs = [self.mo_coeff_w[:, i0 : i1 + 1], self.mo_coeff_w[:, self.nocc_w :]]
                 tmp = lib.einsum("Lpq,pi,qj->Lij", block, coeffs[0], coeffs[1])
                 tmp = tmp.reshape(self.naux, -1)
                 Lia += tmp[:, a0 : a0 + (q1 - q0)]

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -12,8 +12,8 @@ from pyscf.lib import logger
 
 from momentGW import util
 from momentGW.base import BaseGW
-from momentGW.ints import Integrals
 from momentGW.gw import GW
+from momentGW.ints import Integrals
 
 
 def kernel(

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -12,6 +12,7 @@ from pyscf.lib import logger
 
 from momentGW import util
 from momentGW.base import BaseGW
+from momentGW.ints import Integrals
 from momentGW.gw import GW
 
 
@@ -40,8 +41,8 @@ def kernel(
         Tuple of (hole, particle) moments, if passed then they will
         be used  as the initial guess instead of calculating them.
         Default value is None.
-    integrals : tuple of numpy.ndarray, optional
-        Density-fitted ERI tensors. If None, generate from `gw.ao2mo`.
+    integrals : Integrals, optional
+        Density-fitted integrals. If None, generate from scratch.
         Default value is None.
 
     Returns
@@ -58,10 +59,6 @@ def kernel(
 
     if gw.polarizability == "drpa-exact":
         raise NotImplementedError("%s for polarizability=%s" % (gw.name, gw.polarizability))
-
-    if integrals is None:
-        integrals = gw.ao2mo(mo_coeff)
-    Lpq, Lia = integrals
 
     nmo = gw.nmo
     nocc = gw.nocc
@@ -91,7 +88,7 @@ def kernel(
     subgw.verbose = 0
     subgw.mo_energy = mo_energy
     subgw.mo_coeff = mo_coeff
-    subconv, gf, se = subgw.kernel(nmom_max=nmom_max)
+    subconv, gf, se = subgw.kernel(nmom_max=nmom_max, integrals=integrals)
 
     # Get the moments
     th = se.get_occupied().moment(range(nmom_max + 1))

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -11,8 +11,8 @@ from pyscf.lib import logger
 
 from momentGW import util
 from momentGW.base import BaseGW
-from momentGW.ints import Integrals
 from momentGW.evgw import evGW
+from momentGW.ints import Integrals
 
 
 def kernel(
@@ -89,7 +89,11 @@ def kernel(
             # TODO reimplement out keyword
             mo_coeff_g = None if gw.g0 else np.dot(mo_coeff, gf.coupling)
             mo_coeff_w = None if gw.w0 else np.dot(mo_coeff, gf.coupling)
-            mo_occ_w = None if gw.w0 else np.array([2] * gf.get_occupied().naux + [0] * gf.get_virtual().naux)
+            mo_occ_w = (
+                None
+                if gw.w0
+                else np.array([2] * gf.get_occupied().naux + [0] * gf.get_virtual().naux)
+            )
             integrals.update_coeffs(mo_coeff_g=mo_coeff_g, mo_coeff_w=mo_coeff_w, mo_occ_w=mo_occ_w)
 
         # Update the moments of the SE

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -11,6 +11,7 @@ from pyscf.lib import logger
 
 from momentGW import util
 from momentGW.base import BaseGW
+from momentGW.ints import Integrals
 from momentGW.evgw import evGW
 
 
@@ -39,9 +40,9 @@ def kernel(
         Tuple of (hole, particle) moments, if passed then they will
         be used  as the initial guess instead of calculating them.
         Default value is None.
-    integrals : tuple of numpy.ndarray, optional
-        Density-fitted ERI tensors. If None, generate from `gw.ao2mo`.
-        Default value is None.
+    integrals : Integrals, optional
+        Density-fitted integrals. If None, generate from scratch.
+        Default value is `None`.
 
     Returns
     -------
@@ -63,9 +64,7 @@ def kernel(
     naux = gw.with_df.get_naoaux()
 
     if integrals is None:
-        integrals = gw.ao2mo(mo_coeff)
-    Lpk, Lia = integrals
-    Lpq = Lpk
+        integrals = gw.ao2mo()
 
     chempot = 0.5 * (mo_energy[nocc - 1] + mo_energy[nocc])
     gf = GreensFunction(mo_energy, np.eye(mo_energy.size), chempot=chempot)
@@ -76,7 +75,6 @@ def kernel(
 
     # Get the static part of the SE
     se_static = gw.build_se_static(
-        Lpq=Lpk,
         mo_energy=mo_energy,
         mo_coeff=mo_coeff,
     )
@@ -89,15 +87,10 @@ def kernel(
         if cycle > 1:
             # Rotate ERIs into (MO, QMO) and (QMO occ, QMO vir)
             # TODO reimplement out keyword
-            mo_coeff_g = mo_coeff if gw.g0 else np.dot(mo_coeff, gf.coupling)
-            mo_coeff_w = mo_coeff if gw.w0 else np.dot(mo_coeff, gf.coupling)
-            nocc_w = nocc if gw.w0 else gf.get_occupied().naux
-            Lpk, Lia = gw.ao2mo(
-                mo_coeff,
-                mo_coeff_g=mo_coeff_g,
-                mo_coeff_w=mo_coeff_w,
-                nocc_w=nocc_w,
-            )
+            mo_coeff_g = None if gw.g0 else np.dot(mo_coeff, gf.coupling)
+            mo_coeff_w = None if gw.w0 else np.dot(mo_coeff, gf.coupling)
+            mo_occ_w = None if gw.w0 else np.array([2] * gf.get_occupied().naux + [0] * gf.get_virtual().naux)
+            integrals.update_coeffs(mo_coeff_g=mo_coeff_g, mo_coeff_w=mo_coeff_w, mo_occ_w=mo_occ_w)
 
         # Update the moments of the SE
         if moments is not None and cycle == 1:
@@ -105,8 +98,7 @@ def kernel(
         else:
             th, tp = gw.build_se_moments(
                 nmom_max,
-                Lpk,
-                Lia,
+                integrals,
                 mo_energy=(
                     gf.energy if not gw.g0 else gf_ref.energy,
                     gf.energy if not gw.w0 else gf_ref.energy,
@@ -130,7 +122,7 @@ def kernel(
 
         # Solve the Dyson equation
         gf_prev = gf.copy()
-        gf, se = gw.solve_dyson(th, tp, se_static, Lpq=Lpq)
+        gf, se = gw.solve_dyson(th, tp, se_static, integrals=integrals)
 
         # Check for convergence
         error_homo = abs(

--- a/tests/test_gw.py
+++ b/tests/test_gw.py
@@ -98,7 +98,7 @@ class Test_GW(unittest.TestCase):
         gw = GW(self.mf)
         gw.diagonal_se = True
         gw.vhf_df = False
-        th1, tp1 = gw.build_se_moments(5, *gw.ao2mo(self.mf.mo_coeff))
+        th1, tp1 = gw.build_se_moments(5, gw.ao2mo())
         conv, gf, se = gw.kernel(nmom_max=5)
         th2 = se.get_occupied().moment(range(5))
         tp2 = se.get_virtual().moment(range(5))
@@ -117,13 +117,15 @@ class Test_GW(unittest.TestCase):
         gw = GW(self.mf)
         gw.diagonal_se = True
         nocc, nvir = gw.nocc, gw.nmo - gw.nocc
-        th1, tp1 = gw.build_se_moments(5, *gw.ao2mo(self.mf.mo_coeff))
+        th1, tp1 = gw.build_se_moments(5, gw.ao2mo())
 
         td = tdscf.dRPA(self.mf)
         td.nstates = nocc * nvir
         td.kernel()
         z = np.sum(np.array(td.xy) * 2, axis=1).reshape(len(td.e), nocc, nvir)
-        Lpq, Lia = gw.ao2mo(self.mf.mo_coeff)
+        integrals = gw.ao2mo()
+        Lpq = integrals.Lpx
+        Lia = integrals.Lia
         z = z.reshape(-1, nocc * nvir)
 
         m = lib.einsum("Qx,vx,Qpj->vpj", Lia, z, Lpq[:, :, :nocc])
@@ -159,14 +161,16 @@ class Test_GW(unittest.TestCase):
         gw.diagonal_se = True
         gw.polarizability = "dtda"
         nocc, nvir = gw.nocc, gw.nmo - gw.nocc
-        th1, tp1 = gw.build_se_moments(5, *gw.ao2mo(self.mf.mo_coeff))
+        th1, tp1 = gw.build_se_moments(5, gw.ao2mo())
 
         td = tdscf.dTDA(self.mf)
         td.nstates = nocc * nvir
         td.kernel()
         xy = np.array([x[0] for x in td.xy])
         z = xy * 2
-        Lpq, Lia = gw.ao2mo(self.mf.mo_coeff)
+        integrals = gw.ao2mo()
+        Lpq = integrals.Lpx
+        Lia = integrals.Lia
         z = z.reshape(-1, nocc * nvir)
 
         m = lib.einsum("Qx,vx,Qpj->vpj", Lia, z, Lpq[:, :, :nocc])

--- a/tests/test_scgw.py
+++ b/tests/test_scgw.py
@@ -79,8 +79,8 @@ class Test_scGW(unittest.TestCase):
         self.assertAlmostEqual(gw.gf.get_virtual().energy[0], ea, 7, msg=name)
 
     def test_regression_simple(self):
-        ip = -0.281519393467
-        ea = 0.005957163934
+        ip = -0.284272286382
+        ea = 0.006112609950
         self._test_regression("hf", dict(), 1, ip, ea, "simple")
 
     def test_regression_gw0(self):
@@ -89,13 +89,13 @@ class Test_scGW(unittest.TestCase):
         self._test_regression("hf", dict(w0=True), 3, ip, ea, "gw0")
 
     def test_regression_g0w(self):
-        ip = -0.279847875711
-        ea = 0.005920076111
+        ip = -0.281972676272
+        ea = 0.006097777589
         self._test_regression("hf", dict(g0=True, damping=0.5), 1, ip, ea, "g0w")
 
     def test_regression_pbe_fock_loop(self):
-        ip = -0.286584356813
-        ea = 0.006248912698
+        ip = -0.288061231008
+        ea = 0.006223662638
         self._test_regression("pbe", dict(fock_loop=True), 1, ip, ea, "pbe fock loop")
 
 


### PR DESCRIPTION
- Adds `ints.py` with a class `Integrals`, which should simplify the interfaces going forward when we add k-points and THC. I will probably subclass this as `KIntegrals` and `THCIntegrals`.
- Deprecates `vhf_df` - I may want to reimplement this later but it has been causing issues in the current implementation.
- Fixes a bug that caused compressed integrals to be used for evaluating the Fock matrix when `fock_loop=True`.