### PR TITLE
Migrates the fock build into the Integrals class

### DIFF
--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -4,6 +4,7 @@ Base class for moment-constrained GW solvers.
 
 import numpy as np
 from pyscf import lib
+from pyscf.agf2 import mpi_helper
 from pyscf.lib import logger
 from pyscf.mp.mp2 import get_frozen_mask, get_nmo, get_nocc
 
@@ -87,8 +88,8 @@ class BaseGW(lib.StreamObject):
             setattr(self, key, val)
 
         # Do not modify:
-        self.mo_energy = mf.mo_energy
-        self.mo_coeff = mf.mo_coeff
+        self.mo_energy = mpi_helper.bcast(mf.mo_energy, root=0)
+        self.mo_coeff = mpi_helper.bcast(mf.mo_coeff, root=0)
         self.mo_occ = mf.mo_occ
         self.frozen = None
         self._nocc = None

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -70,6 +70,7 @@ def kernel(
 
     # Get the static part of the SE
     se_static = gw.build_se_static(
+        integrals,
         mo_energy=mo_energy,
         mo_coeff=mo_coeff,
     )

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -15,6 +15,7 @@ from pyscf.agf2.dfragf2 import DFRAGF2
 from pyscf.ao2mo import _ao2mo
 from pyscf.lib import logger
 
+from momentGW import util
 from momentGW.base import BaseGW
 from momentGW.fock import fock_loop
 from momentGW.ints import Integrals
@@ -65,6 +66,7 @@ def kernel(
 
     # Get the static part of the SE
     se_static = gw.build_se_static(
+        integrals,
         mo_energy=mo_energy,
         mo_coeff=mo_coeff,
     )
@@ -96,12 +98,14 @@ class GW(BaseGW):
     def name(self):
         return "G0W0"
 
-    def build_se_static(self, mo_coeff=None, mo_energy=None):
+    def build_se_static(self, integrals, mo_coeff=None, mo_energy=None):
         """Build the static part of the self-energy, including the
         Fock matrix.
 
         Parameters
         ----------
+        integrals : Integrals
+            Density-fitted integrals.
         mo_energy : numpy.ndarray, optional
             Molecular orbital energies.  Default value is that of
             `self.mo_energy`.
@@ -121,19 +125,16 @@ class GW(BaseGW):
         if mo_energy is None:
             mo_energy = self.mo_energy
 
-        with lib.temporary_env(self._scf, verbose=0):
-            with lib.temporary_env(self._scf.with_df, verbose=0):
-                v_mf = self._scf.get_veff() - self._scf.get_j()
+        if getattr(self._scf, "xc", "hf") == "hf":
+            se_static = np.zeros((self.nmo, self.nmo))
+        else:
+            with util.SilentSCF(self._scf):
+                vmf = self._scf.get_j() - self._scf.get_veff()
                 dm = self._scf.make_rdm1(mo_coeff=mo_coeff)
-        v_mf = lib.einsum("pq,pi,qj->ij", v_mf, mo_coeff, mo_coeff)
+                vk = integrals.get_k(dm, basis="ao")
 
-        with lib.temporary_env(self._scf.with_df, verbose=0):
-            with lib.temporary_env(self._scf.with_df, verbose=0):
-                vk = scf.hf.SCF.get_veff(self._scf, self.mol, dm)
-                vk -= scf.hf.SCF.get_j(self._scf, self.mol, dm)
-        vk = lib.einsum("pq,pi,qj->ij", vk, mo_coeff, mo_coeff)
-
-        se_static = vk - v_mf
+            se_static = vmf - vk * 0.5
+            se_static = lib.einsum("pq,pi,qj->ij", se_static, mo_coeff, mo_coeff)
 
         if self.diagonal_se:
             se_static = np.diag(np.diag(se_static))
@@ -255,11 +256,8 @@ class GW(BaseGW):
         gf.coupling = mpi_helper.bcast(gf.coupling, root=0)
 
         if self.fock_loop:
-            if integrals is None:
-                raise ValueError("Lpq must be passed to solve_dyson if fock_loop=True")
-
             try:
-                gf, se, conv = fock_loop(self, integrals.Lpq, gf, se, **self.fock_opts)
+                gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
             except IndexError:
                 pass
 

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -2,10 +2,31 @@
 Integral helpers.
 """
 
+import contextlib
+import types
+
 import numpy as np
 from pyscf import lib
 from pyscf.agf2 import mpi_helper
 from pyscf.lib import logger
+
+
+@contextlib.contextmanager
+def patch_df_loop(with_df):
+    """
+    Context manager for monkey patching PySCF's density fitting objects
+    to loop over blocks of the auxiliary functions distributed over MPI.
+    """
+
+    def prange(self, start, stop, end):
+        yield from mpi_helper.prange(start, stop, end)
+
+    pre_patch = with_df.prange
+    setattr(with_df, "prange", types.MethodType(prange, with_df))
+
+    yield with_df
+
+    setattr(with_df, "prange", pre_patch)
 
 
 class Integrals:
@@ -43,6 +64,7 @@ class Integrals:
         Return the compression metric.
         """
         # TODO cache this if needed
+        return None
 
         compression = self.compression.replace("vo", "ov")
         compression = set(x for x in compression.split(","))
@@ -120,6 +142,8 @@ class Integrals:
         if self._rot is None:
             self._rot = self.get_compression_metric()
         rot = self._rot
+        if rot is None:
+            rot = np.eye(self.naux_full)
 
         do_Lpq = self.store_full if do_Lpq is None else do_Lpq
         if not any([do_Lpq, do_Lpx, do_Lia]):
@@ -200,6 +224,83 @@ class Integrals:
             do_Lpx=mo_coeff_g is not None,
             do_Lia=mo_coeff_w is not None,
         )
+
+    def get_j(self, dm, basis="mo"):
+        """Build the J matrix."""
+
+        assert basis in ("ao", "mo")
+
+        p0, p1 = list(mpi_helper.prange(0, self.nmo, self.nmo))[0]
+        vj = np.zeros_like(dm, dtype=np.result_type(dm, self.dtype))
+
+        if self.store_full and basis == "mo":
+            tmp = lib.einsum("Qkl,lk->Q", self.Lpq, dm[p0:p1])
+            tmp = mpi_helper.allreduce(tmp)
+            vj[:, p0:p1] = lib.einsum("Qij,Q->ij", self.Lpq, tmp)
+            vj = mpi_helper.allreduce(vj)
+
+        else:
+            if basis == "mo":
+                dm = np.linalg.multi_dot((self.mo_coeff, dm, self.mo_coeff.T))
+
+            with patch_df_loop(self.with_df):
+                for block in self.with_df.loop():
+                    naux = block.shape[0]
+                    if block.size == naux * self.nmo * (self.nmo + 1) // 2:
+                        block = lib.unpack_tril(block)
+                    block = block.reshape(naux, self.nmo, self.nmo)
+
+                    tmp = lib.einsum("Qkl,lk->Q", block, dm)
+                    vj += lib.einsum("Qij,Q->ij", block, tmp)
+
+            vj = mpi_helper.allreduce(vj)
+            if basis == "mo":
+                vj = np.linalg.multi_dot((self.mo_coeff.T, vj, self.mo_coeff))
+
+        return vj
+
+    def get_k(self, dm, basis="mo"):
+        """Build the K matrix."""
+
+        assert basis in ("ao", "mo")
+
+        p0, p1 = list(mpi_helper.prange(0, self.nmo, self.nmo))[0]
+        vk = np.zeros_like(dm, dtype=np.result_type(dm, self.dtype))
+
+        if self.store_full and basis == "mo":
+            tmp = lib.einsum("Qik,kl->Qil", self.Lpq, dm[p0:p1])
+            tmp = mpi_helper.allreduce(tmp)
+            vk[:, p0:p1] = lib.einsum("Qil,Qlj->ij", tmp, self.Lpq)
+            vk = mpi_helper.allreduce(vk)
+
+        else:
+            if basis == "mo":
+                dm = np.linalg.multi_dot((self.mo_coeff, dm, self.mo_coeff.T))
+
+            with patch_df_loop(self.with_df):
+                for block in self.with_df.loop():
+                    naux = block.shape[0]
+                    if block.size == naux * self.nmo * (self.nmo + 1) // 2:
+                        block = lib.unpack_tril(block)
+                    block = block.reshape(naux, self.nmo, self.nmo)
+
+                    tmp = lib.einsum("Qik,kl->Qil", block, dm)
+                    vk += lib.einsum("Qil,Qlj->ij", tmp, block)
+
+            vk = mpi_helper.allreduce(vk)
+            if basis == "mo":
+                vk = np.linalg.multi_dot((self.mo_coeff.T, vk, self.mo_coeff))
+
+        return vk
+
+    def get_jk(self, dm, **kwargs):
+        """Build the J and K matrices."""
+        return self.get_j(dm, **kwargs), self.get_k(dm, **kwargs)
+
+    def get_fock(self, dm, h1e, **kwargs):
+        """Build the Fock matrix."""
+        vj, vk = self.get_jk(dm, **kwargs)
+        return h1e + vj - vk * 0.5
 
     @property
     def Lpq(self):
@@ -300,6 +401,8 @@ class Integrals:
         Return the number of auxiliary basis functions, after the
         compression.
         """
+        if self._rot is None:
+            return self.naux_full
         return self._rot.shape[1]
 
     @property
@@ -317,3 +420,10 @@ class Integrals:
         no self-consistencies.
         """
         return self._mo_coeff_g is None and self._mo_coeff_w is None
+
+    @property
+    def dtype(self):
+        """
+        Return the dtype of the integrals.
+        """
+        return np.result_type(*self._blocks.values())

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -75,6 +75,7 @@ def kernel(
 
     # Get the static part of the SE
     se_static = gw.build_se_static(
+        integrals,
         mo_energy=mo_energy,
         mo_coeff=mo_coeff,
     )

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -65,3 +65,31 @@ class DIIS(lib.diis.DIIS):
             for p0, p1 in lib.prange(0, xi.size, lib.diis.BLOCK_SIZE):
                 xnew[p0:p1] += xi[p0:p1] * ci
         return xnew
+
+
+class SilentSCF:
+    """
+    Context manager to shut PySCF's SCF classes up.
+    """
+
+    def __init__(self, mf):
+        self.mf = mf
+
+    def __enter__(self):
+        self._mol_verbose = self.mf.mol.verbose
+        self.mf.mol.verbose = 0
+
+        self._mf_verbose = self.mf.verbose
+        self.mf.verbose = 0
+
+        if getattr(self.mf, "with_df", None):
+            self._df_verbose = self.mf.with_df.verbose
+            self.mf.with_df.verbose = 0
+
+        return self.mf
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.mf.mol.verbose = self._mol_verbose
+        self.mf.verbose = self._mf_verbose
+        if getattr(self.mf, "with_df", None):
+            self.mf.with_df.verbose = self._df_verbose

--- a/tests/test_gw.py
+++ b/tests/test_gw.py
@@ -200,7 +200,7 @@ class Test_GW(unittest.TestCase):
             self.assertAlmostEqual(dif, 0, 8)
 
     def _test_regression(self, xc, kwargs, nmom_max, ip, ea, name=""):
-        mol = gto.M(atom="H 0 0 0; Li 0 0 1.64", basis="6-31g", verbose=9)
+        mol = gto.M(atom="H 0 0 0; Li 0 0 1.64", basis="6-31g", verbose=0)
         mf = dft.RKS(mol, xc=xc).density_fit().run()
         mf.mo_coeff = mpi_helper.bcast_dict(mf.mo_coeff, root=0)
         mf.mo_energy = mpi_helper.bcast_dict(mf.mo_energy, root=0)

--- a/tests/test_scgw.py
+++ b/tests/test_scgw.py
@@ -79,8 +79,8 @@ class Test_scGW(unittest.TestCase):
         self.assertAlmostEqual(gw.gf.get_virtual().energy[0], ea, 7, msg=name)
 
     def test_regression_simple(self):
-        ip = -0.284272286382
-        ea = 0.006112609950
+        ip = -0.281519393467
+        ea = 0.005957163934
         self._test_regression("hf", dict(), 1, ip, ea, "simple")
 
     def test_regression_gw0(self):
@@ -89,13 +89,13 @@ class Test_scGW(unittest.TestCase):
         self._test_regression("hf", dict(w0=True), 3, ip, ea, "gw0")
 
     def test_regression_g0w(self):
-        ip = -0.281972676272
-        ea = 0.006097777589
+        ip = -0.279847875711
+        ea = 0.005920076111
         self._test_regression("hf", dict(g0=True, damping=0.5), 1, ip, ea, "g0w")
 
     def test_regression_pbe_fock_loop(self):
-        ip = -0.288061231008
-        ea = 0.006223662638
+        ip = -0.286584356813
+        ea = 0.006248912698
         self._test_regression("pbe", dict(fock_loop=True), 1, ip, ea, "pbe fock loop")
 
 


### PR DESCRIPTION
The fock build functions are now part of the `Integrals` classes, making THC integration easier. Also `build_se_static` now uses these functions to build the exchange matrix.