### PR TITLE
Total energies

### DIFF
--- a/momentGW/energy.py
+++ b/momentGW/energy.py
@@ -1,0 +1,114 @@
+"""
+Energy functionals.
+"""
+
+import numpy as np
+from pyscf import lib
+
+
+def hartree_fock(rdm1, fock, h1e):
+    """Hartree--Fock energy functional."""
+    return lib.einsum("ij,ji->", rdm1, h1e + fock) * 0.5
+
+
+def galitskii_migdal(gf, se, flip=False):
+    r"""Galitskii--Migdal energy functional.
+
+    Parameters
+    ----------
+    gf : GreensFunction
+        Green's function.
+    se : SelfEnergy
+        Self-energy.
+    flip : bool, optional
+        Default option is to use the occupied Green's function and the
+        virtual self-energy. If `flip=True`, the virtual Green's
+        function and the occupied self-energy are used instead. Default
+        value is `False`.
+
+    Returns
+    -------
+    e_2b : float
+        Galitskii--Migdal energy.
+
+    Notes
+    -----
+    This functional is the analytically integrated version of
+
+    .. math:: \frac{\pi}{4} \int d\omega \mathrm{Tr}[G(i\omega) \Sigma(i\omega)]
+
+    in terms of the poles of the Green's function and the self-energy.
+    This scales as :math:`\mathcal{O}(N^4)` with system size.
+    """
+
+    if flip:
+        gf = gf.get_virtual()
+        se = se.get_occupied()
+    else:
+        gf = gf.get_occupied()
+        se = se.get_virtual()
+
+    e_2b = 0.0
+    for i in range(gf.naux):
+        v_gf = gf.coupling[:, i]
+        v_se = se.coupling
+        v = v_se * v_gf[:, None]
+        denom = gf.energy[i] - se.energy
+
+        e_2b += np.ravel(lib.einsum("xk,yk,k->", v, v.conj(), 1.0 / denom))[0]
+
+    e_2b *= 2.0
+
+    return e_2b
+
+
+def galitskii_migdal_g0(mo_energy, mo_occ, se, flip=False):
+    r"""
+    Galitskii--Migdal energy functional for the non-interacting Green's
+    function.
+
+    Parameters
+    ----------
+    mo_energy : numpy.ndarray
+        MO energies (poles of the Green's function).
+    mo_occ : numpy.ndarray
+        MO occupancies.
+    se : SelfEnergy
+        Self-energy.
+    flip : bool, optional
+        Default option is to use the occupied Green's function and the
+        virtual self-energy. If `flip=True`, the virtual Green's
+        function and the occupied self-energy are used instead. Default
+        value is `False`.
+
+    Returns
+    -------
+    e_2b : float
+        Galitskii--Migdal energy.
+
+    Notes
+    -----
+    This functional is the analytically integrated version of
+
+    .. math:: \frac{\pi}{4} \int d\omega \mathrm{Tr}[G_{0}(i\omega) \Sigma(i\omega)]
+
+    in terms of the poles of the mean-field Green's function and the
+    self-energy. This scales as :math:`\mathcal{O}(N^3)` with system
+    size.
+    """
+
+    if flip:
+        mo = mo_energy[mo_occ == 0]
+        se = se.get_occupied()
+        se.coupling = se.coupling[mo_occ == 0]
+    else:
+        mo = mo_energy[mo_occ > 0]
+        se = se.get_virtual()
+        se.coupling = se.coupling[mo_occ > 0]
+
+    denom = lib.direct_sum("i-j->ij", mo, se.energy)
+
+    e_2b = np.ravel(lib.einsum("xk,xk,xk->", se.coupling, se.coupling.conj(), 1.0 / denom))[0]
+    e_2b *= 2.0
+
+    return e_2b

--- a/momentGW/pbc/scgw.py
+++ b/momentGW/pbc/scgw.py
@@ -24,29 +24,4 @@ class scKGW(KGW, scGW):
     def name(self):
         return "scKG%sW%s" % ("0" if self.g0 else "", "0" if self.w0 else "")
 
-    def init_gf(self, mo_energy=None):
-        """Initialise the mean-field Green's function.
-
-        Parameters
-        ----------
-        mo_energy : numpy.ndarray, optional
-            Molecular orbital energies at each k-point. Default value is
-            `self.mo_energy`.
-
-        Returns
-        -------
-        gf : tuple of GreensFunction
-            Mean-field Green's function at each k-point.
-        """
-
-        if mo_energy is None:
-            mo_energy = self.mo_energy
-
-        gf = []
-        for k in self.kpts.loop(1):
-            chempot = 0.5 * (mo_energy[k][self.nocc[k] - 1] + mo_energy[k][self.nocc[k]])
-            gf.append(GreensFunction(mo_energy[k], np.eye(self.nmo), chempot=chempot))
-
-        return gf
-
     check_convergence = evKGW.check_convergence

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -172,26 +172,3 @@ class scGW(evGW):
         return "scG%sW%s" % ("0" if self.g0 else "", "0" if self.w0 else "")
 
     _kernel = kernel
-
-    def init_gf(self, mo_energy=None):
-        """Initialise the mean-field Green's function.
-
-        Parameters
-        ----------
-        mo_energy : numpy.ndarray, optional
-            Molecular orbital energies. Default value is
-            `self.mo_energy`.
-
-        Returns
-        -------
-        gf : GreensFunction
-            Mean-field Green's function.
-        """
-
-        if mo_energy is None:
-            mo_energy = self.mo_energy
-
-        chempot = 0.5 * (mo_energy[self.nocc - 1] + mo_energy[self.nocc])
-        gf = GreensFunction(mo_energy, np.eye(self.nmo), chempot=chempot)
-
-        return gf

--- a/tests/test_kgw.py
+++ b/tests/test_kgw.py
@@ -128,7 +128,7 @@ class Test_KGW(unittest.TestCase):
         gw.__dict__.update({opt: getattr(kgw, opt) for opt in kgw._opts})
         gw.kernel(nmom_max)
 
-        self._test_vs_supercell(gw, kgw, full=False, tol=1e-6)
+        self._test_vs_supercell(gw, kgw, full=False, tol=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reports total energies using the Galitskii-Migdal formula. Currently reports this using both G0 and the G resulting from `solve_dyson`. I think this happily lives inside `solve_dyson`, because then the energies are reported every time a method solves for a Green's function - though maybe qsGW needs some additional reporting.