### PR TITLE
Clarify naming convention for dTDA and dRPA

### DIFF
--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -46,8 +46,8 @@ except ImportError:
 
 # --- Imports
 
-from momentGW.tda import TDA
-from momentGW.rpa import RPA
+from momentGW.tda import dTDA
+from momentGW.rpa import dRPA
 from momentGW.gw import GW
 from momentGW.evgw import evGW
 from momentGW.scgw import scGW

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -53,7 +53,7 @@ def kernel(
         compatibility with other evGW methods.
     """
 
-    if gw.polarizability == "drpa-exact":
+    if gw.polarizability.lower() == "drpa-exact":
         raise NotImplementedError("%s for polarizability=%s" % (gw.name, gw.polarizability))
 
     if integrals is None:

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -13,8 +13,8 @@ from momentGW import energy, thc, util
 from momentGW.base import BaseGW
 from momentGW.fock import fock_loop
 from momentGW.ints import Integrals
-from momentGW.rpa import RPA
-from momentGW.tda import TDA
+from momentGW.rpa import dRPA
+from momentGW.tda import dTDA
 
 
 def kernel(
@@ -166,20 +166,20 @@ class GW(BaseGW):
             non-diagonal elements are set to zero.
         """
 
-        if self.polarizability == "drpa":
-            rpa = RPA(self, nmom_max, integrals, **kwargs)
+        if self.polarizability.lower() == "drpa":
+            rpa = dRPA(self, nmom_max, integrals, **kwargs)
             return rpa.kernel()
 
-        elif self.polarizability == "drpa-exact":
-            rpa = RPA(self, nmom_max, integrals, **kwargs)
+        elif self.polarizability.lower() == "drpa-exact":
+            rpa = dRPA(self, nmom_max, integrals, **kwargs)
             return rpa.kernel(exact=True)
 
-        elif self.polarizability == "dtda":
-            tda = TDA(self, nmom_max, integrals, **kwargs)
+        elif self.polarizability.lower() == "dtda":
+            tda = dTDA(self, nmom_max, integrals, **kwargs)
             return tda.kernel()
 
-        elif self.polarizability == "thc-dtda":
-            tda = thc.TDA(self, nmom_max, integrals, **kwargs)
+        elif self.polarizability.lower() == "thc-dtda":
+            tda = thc.dTDA(self, nmom_max, integrals, **kwargs)
             return tda.kernel()
 
         else:

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -14,7 +14,7 @@ from momentGW.gw import GW
 from momentGW.pbc.base import BaseKGW
 from momentGW.pbc.fock import fock_loop, minimize_chempot, search_chempot
 from momentGW.pbc.ints import KIntegrals
-from momentGW.pbc.tda import TDA
+from momentGW.pbc.tda import dTDA
 
 
 class KGW(BaseKGW, GW):
@@ -71,8 +71,8 @@ class KGW(BaseKGW, GW):
             `self.diagonal_se`, non-diagonal elements are set to zero.
         """
 
-        if self.polarizability == "dtda":
-            tda = TDA(self, nmom_max, integrals, **kwargs)
+        if self.polarizability.lower() == "dtda":
+            tda = dTDA(self, nmom_max, integrals, **kwargs)
             return tda.kernel()
         else:
             raise NotImplementedError

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -7,10 +7,10 @@ import scipy.special
 from pyscf import lib
 from pyscf.agf2 import mpi_helper
 
-from momentGW.tda import TDA as MolTDA
+from momentGW.tda import dTDA as MoldTDA
 
 
-class TDA(MolTDA):
+class dTDA(MoldTDA):
     """
     Compute the self-energy moments using dTDA and numerical integration
 

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -55,7 +55,7 @@ def kernel(
         Quasiparticle energies.
     """
 
-    if gw.polarizability == "drpa-exact":
+    if gw.polarizability.lower() == "drpa-exact":
         raise NotImplementedError("%s for polarizability=%s" % (gw.name, gw.polarizability))
 
     if integrals is None:

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -7,10 +7,10 @@ import scipy.optimize
 from pyscf import lib
 from pyscf.agf2 import mpi_helper
 
-from momentGW import TDA
+from momentGW import dTDA
 
 
-class RPA(TDA):
+class dRPA(dTDA):
     """
     Compute the self-energy moments using dRPA and numerical integration.
 

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -54,7 +54,7 @@ def kernel(
         compatibility with other scGW methods.
     """
 
-    if gw.polarizability == "drpa-exact":
+    if gw.polarizability.lower() == "drpa-exact":
         raise NotImplementedError("%s for polarizability=%s" % (gw.name, gw.polarizability))
 
     if integrals is None:

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -8,10 +8,9 @@ from pyscf import lib
 from pyscf.agf2 import mpi_helper
 
 
-class TDA:
+class dTDA:
     """
-    Compute the self-energy moments using dTDA and numerical
-    integration.
+    Compute the self-energy moments using dTDA.
 
     Parameters
     ----------

--- a/momentGW/thc.py
+++ b/momentGW/thc.py
@@ -231,7 +231,7 @@ class Integrals(ints.Integrals):
     naux_full = naux
 
 
-class TDA(tda.TDA):
+class dTDA(tda.dTDA):
     """
     Compute the self-energy moments using dTDA and numerical integration
     with tensor-hypercontraction.


### PR DESCRIPTION
Changes naming conventions so that they specify dTDA and dRPA where intended, and allows `polarizability` input keyword to be case-insensitive.