### PR TITLE
Optimisations for integral transformations

### DIFF
--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -323,7 +323,7 @@ class KIntegrals(Integrals):
                         self.nvir_w[kj] + self.nocc_w[ki],
                     )
                     tmp = _ao2mo_e2(block_comp, coeffs, orb_slice)
-                    tmp = tmp.reshape(-1, self.nvir_w[kj], self.nocc_w[ki])
+                    tmp = tmp.reshape(self.naux[q], self.nvir_w[kj], self.nocc_w[ki])
                     tmp = tmp.swapaxes(1, 2)
                     Lai_k += tmp.reshape(Lai_k.shape)
 

--- a/tests/test_evugw.py
+++ b/tests/test_evugw.py
@@ -43,9 +43,9 @@ class Test_evUGW_vs_evRGW(unittest.TestCase):
         rgw.compression = None
         rgw.polarizability = "dtda"
         rgw.max_cycle = 300
-        rgw.conv_tol_moms = 1e-3
-        rgw.conv_tol = 1e-6
-        rgw.kernel(5)
+        rgw.conv_tol_moms = 1e-5
+        rgw.conv_tol = 1e-7
+        rgw.kernel(3)
 
         uhf = self.mf.to_uks()
         uhf.with_df = self.mf.with_df
@@ -54,9 +54,9 @@ class Test_evUGW_vs_evRGW(unittest.TestCase):
         ugw.compression = None
         ugw.polarizability = "dtda"
         ugw.max_cycle = 300
-        ugw.conv_tol_moms = 1e-3
-        ugw.conv_tol = 1e-6
-        ugw.kernel(5)
+        ugw.conv_tol_moms = 1e-5
+        ugw.conv_tol = 1e-7
+        ugw.kernel(3)
 
         self.assertTrue(rgw.converged)
         self.assertTrue(ugw.converged)

--- a/tests/test_evugw.py
+++ b/tests/test_evugw.py
@@ -42,9 +42,9 @@ class Test_evUGW_vs_evRGW(unittest.TestCase):
         rgw = evGW(self.mf)
         rgw.compression = None
         rgw.polarizability = "dtda"
-        rgw.max_cycle = 250
-        rgw.conv_tol_moms = 1e-4
-        rgw.conv_tol = 1e-7
+        rgw.max_cycle = 300
+        rgw.conv_tol_moms = 1e-3
+        rgw.conv_tol = 1e-6
         rgw.kernel(5)
 
         uhf = self.mf.to_uks()
@@ -53,9 +53,9 @@ class Test_evUGW_vs_evRGW(unittest.TestCase):
         ugw = evUGW(uhf)
         ugw.compression = None
         ugw.polarizability = "dtda"
-        ugw.max_cycle = 250
-        ugw.conv_tol_moms = 1e-4
-        ugw.conv_tol = 1e-7
+        ugw.max_cycle = 300
+        ugw.conv_tol_moms = 1e-3
+        ugw.conv_tol = 1e-6
         ugw.kernel(5)
 
         self.assertTrue(rgw.converged)


### PR DESCRIPTION
I used `einsum` for the integral transformations whilst figuring out the algorithms. I forgot to replace these with calls to `pyscf.ao2mo._ao2mo.nr_e2` and `pyscf.ao2mo._ao2mo.r_e2`, which are faster and can exploit symmetry in the AO basis integrals.

This PR replaces the `einsum` calls, which offers large optimisations, as the integral transformations can often constitute a large portion of the run time.