### PR TITLE
More optimisations for integral transformations

### DIFF
--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -240,7 +240,7 @@ class Integrals:
                 )
 
             # Compress the block
-            block = lib.einsum("L...,LQ->Q...", block, rot[b0:b1])
+            block = np.dot(rot[b0:b1].T, block)
 
             # Build the compressed (L|px) array
             if do_Lpx:

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -115,6 +115,7 @@ class KIntegrals(Integrals):
                     b0, b1 = b1, b1 + block.shape[0]
                     logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
 
+                    # TODO optimise
                     tmp = lib.einsum("Lpq,pi,qj->Lij", block, ci[ki].conj(), cj[kj])
                     tmp = tmp.reshape(b1 - b0, -1)
                     Lxy[b0:b1] = tmp


### PR DESCRIPTION
- Removes another `einsum` call in favour of the PySCF optimised routines.
- Replaces an `einsum` that falls back to `numpy` with a `dot` call

There are some similar optimisations available for k-space, but I haven't done any benchmarking for that yet, I'll wait for all that stuff to settle post RPA merge.