### PR TITLE
Direct DD moment convolution

### DIFF
--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -240,7 +240,7 @@ class Integrals:
                 )
 
             # Compress the block
-            block = lib.einsum("L...,LQ->Q...", block, rot[b0:b1])
+            block = np.dot(rot[b0:b1].T, block)
 
             # Build the compressed (L|px) array
             if do_Lpx:

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -115,6 +115,7 @@ class KIntegrals(Integrals):
                     b0, b1 = b1, b1 + block.shape[0]
                     logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
 
+                    # TODO optimise
                     tmp = lib.einsum("Lpq,pi,qj->Lij", block, ci[ki].conj(), cj[kj])
                     tmp = tmp.reshape(b1 - b0, -1)
                     Lxy[b0:b1] = tmp

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -143,7 +143,7 @@ class dTDA:
 
     build_dd_moments_exact = build_dd_moments
 
-    def convolve(self, eta, mo_energy_g=None, mo_occ_g=None):
+    def convolve(self, eta, eta_orders=None, mo_energy_g=None, mo_occ_g=None):
         """
         Handle the convolution of the moments of the Green's function
         and screened Coulomb interaction.
@@ -156,6 +156,10 @@ class dTDA:
         mo_energy_g : numpy.ndarray, optional
             Energies of the Green's function. If `None`, use
             `self.mo_energy_g`. Default value is `None`.
+        eta_orders : list, optional
+            List of orders for the rotated density-density moments in
+            `eta`. If `None`, assume it spans all required orders.
+            Default value is `None`.
         mo_occ_g : numpy.ndarray, optional
             Occupancies of the Green's function. If `None`, use
             `self.mo_occ_g`. Default value is `None`.
@@ -185,19 +189,22 @@ class dTDA:
         nmo = eta.shape[-1]  # avoiding self.nmo for inheritence
         moments_occ = np.zeros((self.nmom_max + 1, nmo, nmo))
         moments_vir = np.zeros((self.nmom_max + 1, nmo, nmo))
-        moms = np.arange(self.nmom_max + 1)
 
-        for n in moms:
-            fp = scipy.special.binom(n, moms)
-            fh = fp * (-1) ** moms
+        if eta_orders is None:
+            eta_orders = np.arange(self.nmom_max + 1)
+        eta_orders = np.asarray(eta_orders)
+
+        for n in range(self.nmom_max + 1):
+            fp = scipy.special.binom(n, eta_orders)
+            fh = fp * (-1) ** eta_orders
 
             if np.any(mo_occ_g[q0:q1] > 0):
-                eo = np.power.outer(mo_energy_g[q0:q1][mo_occ_g[q0:q1] > 0], n - moms)
+                eo = np.power.outer(mo_energy_g[q0:q1][mo_occ_g[q0:q1] > 0], n - eta_orders)
                 to = lib.einsum(f"t,kt,kt{pq}->{pq}", fh, eo, eta[mo_occ_g[q0:q1] > 0])
                 moments_occ[n] += fproc(to)
 
             if np.any(mo_occ_g[q0:q1] == 0):
-                ev = np.power.outer(mo_energy_g[q0:q1][mo_occ_g[q0:q1] == 0], n - moms)
+                ev = np.power.outer(mo_energy_g[q0:q1][mo_occ_g[q0:q1] == 0], n - eta_orders)
                 tv = lib.einsum(f"t,ct,ct{pq}->{pq}", fp, ev, eta[mo_occ_g[q0:q1] == 0])
                 moments_vir[n] += fproc(tv)
 
@@ -233,11 +240,15 @@ class dTDA:
         # Setup dependent on diagonal SE
         q0, q1 = self.mpi_slice(self.mo_energy_g.size)
         if self.gw.diagonal_se:
-            eta = np.zeros((q1 - q0, self.nmom_max + 1, self.nmo))
+            eta = np.zeros((q1 - q0, self.nmo))
             pq = p = q = "p"
         else:
-            eta = np.zeros((q1 - q0, self.nmom_max + 1, self.nmo, self.nmo))
+            eta = np.zeros((q1 - q0, self.nmo, self.nmo))
             pq, p, q = "pq", "p", "q"
+
+        # Initialise output moments
+        moments_occ = np.zeros((self.nmom_max + 1, self.nmo, self.nmo))
+        moments_vir = np.zeros((self.nmom_max + 1, self.nmo, self.nmo))
 
         # Get the moments in (aux|aux) and rotate to (mo|mo)
         for n in range(self.nmom_max + 1):
@@ -245,12 +256,15 @@ class dTDA:
             eta_aux = mpi_helper.allreduce(eta_aux)
             for x in range(q1 - q0):
                 Lp = self.integrals.Lpx[:, :, x]
-                eta[x, n] = lib.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux) * 2.0
-        cput1 = lib.logger.timer(self.gw, "rotating DD moments", *cput0)
+                eta[x] = lib.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux) * 2.0
 
-        # Construct the self-energy moments
-        moments_occ, moments_vir = self.convolve(eta)
-        cput1 = lib.logger.timer(self.gw, "constructing SE moments", *cput1)
+            # Construct the self-energy moments for this order only
+            # to save memory
+            moments_occ_n, moments_vir_n = self.convolve(eta[:, None], eta_orders=[n])
+            moments_occ += moments_occ_n
+            moments_vir += moments_vir_n
+
+        cput1 = lib.logger.timer(self.gw, "constructing SE moments", *cput0)
 
         return moments_occ, moments_vir
 

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -264,7 +264,7 @@ class dTDA:
             moments_occ += moments_occ_n
             moments_vir += moments_vir_n
 
-        cput1 = lib.logger.timer(self.gw, "constructing SE moments", *cput0)
+        lib.logger.timer(self.gw, "constructing SE moments", *cput0)
 
         return moments_occ, moments_vir
 

--- a/momentGW/uhf/tda.py
+++ b/momentGW/uhf/tda.py
@@ -170,7 +170,7 @@ class dTDA(RdTDA):
             moments_occ[1] += moments_occ_n
             moments_vir[1] += moments_vir_n
 
-        cput1 = lib.logger.timer(self.gw, "constructing SE moments", *cput0)
+        lib.logger.timer(self.gw, "constructing SE moments", *cput0)
 
         return tuple(moments_occ), tuple(moments_vir)
 

--- a/momentGW/uhf/tda.py
+++ b/momentGW/uhf/tda.py
@@ -109,14 +109,14 @@ class dTDA(RdTDA):
         b0, b1 = self.mpi_slice(self.mo_energy_g[1].size)
         if self.gw.diagonal_se:
             eta = [
-                np.zeros((a1 - a0, self.nmom_max + 1, self.nmo[0])),
-                np.zeros((b1 - b0, self.nmom_max + 1, self.nmo[1])),
+                np.zeros((a1 - a0, self.nmo[0])),
+                np.zeros((b1 - b0, self.nmo[1])),
             ]
             pq = p = q = "p"
         else:
             eta = [
-                np.zeros((a1 - a0, self.nmom_max + 1, self.nmo[0], self.nmo[0])),
-                np.zeros((b1 - b0, self.nmom_max + 1, self.nmo[1], self.nmo[1])),
+                np.zeros((a1 - a0, self.nmo[0], self.nmo[0])),
+                np.zeros((b1 - b0, self.nmo[1], self.nmo[1])),
             ]
             pq, p, q = "pq", "p", "q"
 
@@ -128,6 +128,16 @@ class dTDA(RdTDA):
             axis=1,
         )
 
+        # Initialise output moments
+        moments_occ = [
+            np.zeros((self.nmom_max + 1, self.nmo[0], self.nmo[0])),
+            np.zeros((self.nmom_max + 1, self.nmo[1], self.nmo[1])),
+        ]
+        moments_vir = [
+            np.zeros((self.nmom_max + 1, self.nmo[0], self.nmo[0])),
+            np.zeros((self.nmom_max + 1, self.nmo[1], self.nmo[1])),
+        ]
+
         # Get the moments in (aux|aux) and rotate to (mo|mo)
         for n in range(self.nmom_max + 1):
             eta_aux = np.dot(moments_dd[n], Lia.T)
@@ -135,24 +145,32 @@ class dTDA(RdTDA):
 
             for x in range(a1 - a0):
                 Lp = self.integrals[0].Lpx[:, :, x]
-                eta[0][x, n] = lib.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux)
+                eta[0][x] = lib.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux)
 
             for x in range(b1 - b0):
                 Lp = self.integrals[1].Lpx[:, :, x]
-                eta[1][x, n] = lib.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux)
+                eta[1][x] = lib.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux)
 
-        cput1 = lib.logger.timer(self.gw, "rotating DD moments", *cput0)
+            # Construct the self-energy moments for this order only
+            # to save memory
+            moments_occ_n, moments_vir_n = self.convolve(
+                eta[0][:, None],
+                eta_orders=[n],
+                mo_energy_g=self.mo_energy_g[0],
+                mo_occ_g=self.mo_occ_g[0],
+            )
+            moments_occ[0] += moments_occ_n
+            moments_vir[0] += moments_vir_n
+            moments_occ_n, moments_vir_n = self.convolve(
+                eta[1][:, None],
+                eta_orders=[n],
+                mo_energy_g=self.mo_energy_g[1],
+                mo_occ_g=self.mo_occ_g[1],
+            )
+            moments_occ[1] += moments_occ_n
+            moments_vir[1] += moments_vir_n
 
-        # Construct the self-energy moments
-        moments_occ = [None, None]
-        moments_vir = [None, None]
-        moments_occ[0], moments_vir[0] = self.convolve(
-            eta[0], mo_energy_g=self.mo_energy_g[0], mo_occ_g=self.mo_occ_g[0]
-        )
-        moments_occ[1], moments_vir[1] = self.convolve(
-            eta[1], mo_energy_g=self.mo_energy_g[1], mo_occ_g=self.mo_occ_g[1]
-        )
-        cput1 = lib.logger.timer(self.gw, "constructing SE moments", *cput1)
+        cput1 = lib.logger.timer(self.gw, "constructing SE moments", *cput0)
 
         return tuple(moments_occ), tuple(moments_vir)
 


### PR DESCRIPTION
Previously we constructed the entire `eta` array with shape `(nmo, nmom, nmo, nmo)` in the memory before the convolution with the moments of the Green's function. This is a huge waste of memory, as each slice in second axis (`nmom`) can be treated separably.

- Adds `eta_orders` argument to `convolve` function to specify which orders of `eta` it's being called for.
- Changes `build_se_moments` to construct the moments for each order of `eta` instead of globally.

This depends on #43, please merge after that. As with #43, I have not propagated these changes to the k-space implementation yet, in case things change before the RPA is merged.