### PR TITLE
Optimisations and fixes for PBC ints

### DIFF
--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -259,7 +259,7 @@ class KIntegrals(Integrals):
                         _ao2mo_e2(block, coeffs, orb_slice, out=Lpq_k[b0:b1])
 
                     # Compress the block
-                    block_comp = lib.einsum("L...,LQ->Q...", block, rot[q][b0:b1].conj())
+                    block_comp = np.dot(rot[q][b0:b1].conj().T, block)
 
                     # Build the compressed (L|px) array
                     if do_Lpx:
@@ -315,7 +315,7 @@ class KIntegrals(Integrals):
                     logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
 
                     # Compress the block
-                    block_comp = lib.einsum("L...,LQ->Q...", block, rot[q][b0:b1].conj())
+                    block_comp = np.dot(rot[q][b0:b1].conj().T, block)
 
                     # Build the compressed (L|ai) array
                     logger.debug(

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -468,7 +468,7 @@ class KIntegrals(Integrals):
                     if block[2] == -1:
                         raise NotImplementedError("Low dimensional integrals")
                     block = block[0] + block[1] * 1.0j
-                    block = block.reshape(self.naux_full, self.nmo, self.nmo)
+                    block = block.reshape(block.shape[0], self.nmo, self.nmo)
                     b0, b1 = b1, b1 + block.shape[0]
                     buf[b0:b1] += lib.einsum("Lpq,pq->L", block, dm[kk].conj())
 
@@ -480,7 +480,7 @@ class KIntegrals(Integrals):
                     if block[2] == -1:
                         raise NotImplementedError("Low dimensional integrals")
                     block = block[0] + block[1] * 1.0j
-                    block = block.reshape(self.naux_full, self.nmo, self.nmo)
+                    block = block.reshape(block.shape[0], self.nmo, self.nmo)
                     b0, b1 = b1, b1 + block.shape[0]
                     vj[ki] += lib.einsum("Lpq,L->pq", block, buf[b0:b1])
 
@@ -550,7 +550,7 @@ class KIntegrals(Integrals):
                         if block[2] == -1:
                             raise NotImplementedError("Low dimensional integrals")
                         block = block[0] + block[1] * 1.0j
-                        block = block.reshape(self.naux_full, self.nmo, self.nmo)
+                        block = block.reshape(block.shape[0], self.nmo, self.nmo)
                         b0, b1 = b1, b1 + block.shape[0]
                         buf[ki, b0:b1] = lib.einsum("Lpq,qr->Lrp", block, dm[kk])
 
@@ -562,7 +562,7 @@ class KIntegrals(Integrals):
                         if block[2] == -1:
                             raise NotImplementedError("Low dimensional integrals")
                         block = block[0] + block[1] * 1.0j
-                        block = block.reshape(self.naux_full, self.nmo, self.nmo)
+                        block = block.reshape(block.shape[0], self.nmo, self.nmo)
                         b0, b1 = b1, b1 + block.shape[0]
                         vk[ki] += lib.einsum("Lrp,Lrs->ps", buf[ki, b0:b1], block)
 

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -87,6 +87,18 @@ class KIntegrals(Integrals):
 
         prod = np.zeros((len(self.kpts), self.naux_full, self.naux_full), dtype=complex)
 
+        # ao2mo function for both real and complex integrals
+        tao = np.empty([], dtype=np.int32)
+        ao_loc = self.with_df.cell.ao_loc_nr()
+
+        def _ao2mo_e2(Lpq, mo_coeff, orb_slice, out=None):
+            mo_coeff = np.asarray(mo_coeff, order="F")
+            if np.iscomplexobj(Lpq):
+                out = _ao2mo.r_e2(Lpq, mo_coeff, orb_slice, tao, ao_loc, aosym="s1", out=out)
+            else:
+                out = _ao2mo.nr_e2(Lpq, mo_coeff, orb_slice, aosym="s1", mosym="s1")
+            return out
+
         # Loop over required blocks
         for key in sorted(compression):
             logger.debug(self, f"Transforming {key} block")
@@ -107,7 +119,7 @@ class KIntegrals(Integrals):
 
                 Lxy = np.zeros((self.naux_full, ni[ki] * nj[kj]), dtype=complex)
                 b1 = 0
-                for block in self.with_df.sr_loop((ki, kj), compact=False):
+                for block in self.with_df.sr_loop((ki, kj), compact=False):  # TODO lock I/O
                     if block[2] == -1:
                         raise NotImplementedError("Low dimensional integrals")
                     block = block[0] + block[1] * 1.0j
@@ -115,10 +127,9 @@ class KIntegrals(Integrals):
                     b0, b1 = b1, b1 + block.shape[0]
                     logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
 
-                    # TODO optimise
-                    tmp = lib.einsum("Lpq,pi,qj->Lij", block, ci[ki].conj(), cj[kj])
-                    tmp = tmp.reshape(b1 - b0, -1)
-                    Lxy[b0:b1] = tmp
+                    coeffs = np.concatenate((ci[ki], cj[kj]), axis=1)
+                    orb_slice = (0, self.nmo, self.nmo, self.nmo + self.nmo)
+                    _ao2mo_e2(block, coeffs, orb_slice, out=Lxy[b0:b1])
 
                 prod[q] += np.dot(Lxy, Lxy.T.conj()) / len(self.kpts)
 

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -198,12 +198,11 @@ class KIntegrals(Integrals):
 
         # ao2mo function for both real and complex integrals
         tao = np.empty([], dtype=np.int32)
-        ao_loc = self.with_df.cell.ao_loc_nr()
 
         def _ao2mo_e2(Lpq, mo_coeff, orb_slice, out=None):
             mo_coeff = np.asarray(mo_coeff, order="F")
             if np.iscomplexobj(Lpq):
-                out = _ao2mo.r_e2(Lpq, mo_coeff, orb_slice, tao, ao_loc, aosym="s1", out=out)
+                out = _ao2mo.r_e2(Lpq, mo_coeff, orb_slice, tao, ao_loc=None, aosym="s1", out=out)
             else:
                 out = _ao2mo.nr_e2(Lpq, mo_coeff, orb_slice, aosym="s1", mosym="s1")
             return out

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -123,12 +123,12 @@ class KIntegrals(Integrals):
                     if block[2] == -1:
                         raise NotImplementedError("Low dimensional integrals")
                     block = block[0] + block[1] * 1.0j
-                    block = block.reshape(self.naux_full, self.nmo, self.nmo)
+                    block = block.reshape(block.shape[0], self.nmo, self.nmo)
                     b0, b1 = b1, b1 + block.shape[0]
                     logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
 
                     coeffs = np.concatenate((ci[ki], cj[kj]), axis=1)
-                    orb_slice = (0, self.nmo, self.nmo, self.nmo + self.nmo)
+                    orb_slice = (0, ni[ki], ni[ki], ni[ki] + nj[kj])
                     _ao2mo_e2(block, coeffs, orb_slice, out=Lxy[b0:b1])
 
                 prod[q] += np.dot(Lxy, Lxy.T.conj()) / len(self.kpts)


### PR DESCRIPTION
- Fixes bug in `pbc.ints.KIntegrals.get_j` and `pbc.ints.KIntegrals.get_k` where full auxiliary size was used for arrays that may be blocked over or compressed.
- Performs some optimisations to `pbc.ints.KIntegrals` to match #42 and #43 

This code is getting a bit messy, once the solids stuff is in a nice place we should look into cleaning it up