### PR TITLE
Optimisations to Galitskii-Migdal energy

### DIFF
--- a/momentGW/energy.py
+++ b/momentGW/energy.py
@@ -49,10 +49,13 @@ def galitskii_migdal(gf, se, flip=False):
         gf = gf.occupied()
         se = se.virtual()
 
-    vu = lib.einsum("pk,px->kx", se.couplings, gf.couplings)
-    denom = lib.direct_sum("x-k->kx", gf.energies, se.energies)
+    e_2b = 0.0
+    for p0, p1 in lib.prange(0, se.naux, 256):
+        vu = lib.einsum("pk,px->kx", se.couplings[:, p0:p1], gf.couplings)
+        denom = lib.direct_sum("x-k->kx", gf.energies, se.energies[p0:p1])
 
-    e_2b = np.ravel(lib.einsum("kx,kx,kx->", vu, vu.conj(), 1.0 / denom))[0]
+        e_2b += np.ravel(lib.einsum("kx,kx,kx->", vu, vu.conj(), 1.0 / denom))[0]
+
     e_2b *= 2.0
 
     return e_2b

--- a/momentGW/energy.py
+++ b/momentGW/energy.py
@@ -49,15 +49,10 @@ def galitskii_migdal(gf, se, flip=False):
         gf = gf.occupied()
         se = se.virtual()
 
-    e_2b = 0.0
-    for i in range(gf.naux):
-        v_gf = gf.couplings[:, i]
-        v_se = se.couplings
-        v = v_se * v_gf[:, None]
-        denom = gf.energies[i] - se.energies
+    vu = lib.einsum("pk,px->kx", se.couplings, gf.couplings)
+    denom = lib.direct_sum("x-k->kx", gf.energies, se.energies)
 
-        e_2b += np.ravel(lib.einsum("xk,yk,k->", v, v.conj(), 1.0 / denom))[0]
-
+    e_2b = np.ravel(lib.einsum("kx,kx,kx->", vu, vu.conj(), 1.0 / denom))[0]
     e_2b *= 2.0
 
     return e_2b

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -304,14 +304,12 @@ class GW(BaseGW):  # noqa: D101
         # Calculate energies
         e_1b = self.energy_hf(gf=gf, integrals=integrals) + self.energy_nuc()
         e_2b_g0 = self.energy_gm(se=se, g0=True)
+        e_2b = self.energy_gm(gf=gf, se=se, g0=False)
         logger.info(self, "Energies:")
         logger.info(self, "  One-body (G0):         %15.10g", self._scf.e_tot)
         logger.info(self, "  One-body (G):          %15.10g", e_1b)
         logger.info(self, "  Galitskii-Migdal (G0): %15.10g", e_2b_g0)
-        if not self.polarizability.lower().startswith("thc"):
-            # This is N^4
-            e_2b = self.energy_gm(gf=gf, se=se, g0=False)
-            logger.info(self, "  Galitskii-Migdal (G):  %15.10g", e_2b)
+        logger.info(self, "  Galitskii-Migdal (G):  %15.10g", e_2b)
 
         return gf, se
 

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -186,14 +186,12 @@ class KGW(BaseKGW, GW):  # noqa: D101
         # Calculate energies
         e_1b = self.energy_hf(gf=gf, integrals=integrals) + self.energy_nuc()
         e_2b_g0 = self.energy_gm(se=se, g0=True)
+        e_2b = self.energy_gm(gf=gf, se=se, g0=False)
         logger.info(self, "Energies:")
         logger.info(self, "  One-body (G0):         %15.10g", self._scf.e_tot)
         logger.info(self, "  One-body (G):          %15.10g", e_1b)
         logger.info(self, "  Galitskii-Migdal (G0): %15.10g", e_2b_g0)
-        if not self.polarizability.lower().startswith("thc"):
-            # This is N^4
-            e_2b = self.energy_gm(gf=gf, se=se, g0=False)
-            logger.info(self, "  Galitskii-Migdal (G):  %15.10g", e_2b)
+        logger.info(self, "  Galitskii-Migdal (G):  %15.10g", e_2b)
 
         return gf, se
 

--- a/momentGW/pbc/uhf/gw.py
+++ b/momentGW/pbc/uhf/gw.py
@@ -204,14 +204,12 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
         # Calculate energies
         e_1b = self.energy_hf(gf=gf, integrals=integrals) + self.energy_nuc()
         e_2b_g0 = self.energy_gm(se=se, g0=True)
+        e_2b = self.energy_gm(gf=gf, se=se, g0=False)
         logger.info(self, "Energies:")
         logger.info(self, "  One-body (G0):         %15.10g", self._scf.e_tot)
         logger.info(self, "  One-body (G):          %15.10g", e_1b)
         logger.info(self, "  Galitskii-Migdal (G0): %15.10g", e_2b_g0)
-        if not self.polarizability.lower().startswith("thc"):
-            # This is N^4
-            e_2b = self.energy_gm(gf=gf, se=se, g0=False)
-            logger.info(self, "  Galitskii-Migdal (G):  %15.10g", e_2b)
+        logger.info(self, "  Galitskii-Migdal (G):  %15.10g", e_2b)
 
         return gf, se
 

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -206,14 +206,12 @@ class UGW(BaseUGW, GW):  # noqa: D101
         # Calculate energies
         e_1b = self.energy_hf(gf=gf, integrals=integrals) + self.energy_nuc()
         e_2b_g0 = self.energy_gm(se=se, g0=True)
+        e_2b = self.energy_gm(gf=gf, se=se, g0=False)
         logger.info(self, "Energies:")
         logger.info(self, "  One-body (G0):         %15.10g", self._scf.e_tot)
         logger.info(self, "  One-body (G):          %15.10g", e_1b)
         logger.info(self, "  Galitskii-Migdal (G0): %15.10g", e_2b_g0)
-        if not self.polarizability.lower().startswith("thc"):
-            # This is N^4
-            e_2b = self.energy_gm(gf=gf, se=se, g0=False)
-            logger.info(self, "  Galitskii-Migdal (G):  %15.10g", e_2b)
+        logger.info(self, "  Galitskii-Migdal (G):  %15.10g", e_2b)
 
         return gf, se
 


### PR DESCRIPTION
The GM energy with a correlated G can be done in N^3 rather than N^4:

- Reimplements GM energy at N^3
- Enables GM energy with correlated G to be reported for all methods