### PR TITLE
Changes to handling of `einsum`

### DIFF
--- a/momentGW/energy.py
+++ b/momentGW/energy.py
@@ -5,10 +5,12 @@ Energy functionals.
 import numpy as np
 from pyscf import lib
 
+from momentGW import util
+
 
 def hartree_fock(rdm1, fock, h1e):
     """Hartree--Fock energy functional."""
-    return lib.einsum("ij,ji->", rdm1, h1e + fock) * 0.5
+    return util.einsum("ij,ji->", rdm1, h1e + fock) * 0.5
 
 
 def galitskii_migdal(gf, se, flip=False):
@@ -51,10 +53,10 @@ def galitskii_migdal(gf, se, flip=False):
 
     e_2b = 0.0
     for p0, p1 in lib.prange(0, se.naux, 256):
-        vu = lib.einsum("pk,px->kx", se.couplings[:, p0:p1], gf.couplings)
+        vu = util.einsum("pk,px->kx", se.couplings[:, p0:p1], gf.couplings)
         denom = lib.direct_sum("x-k->kx", gf.energies, se.energies[p0:p1])
 
-        e_2b += np.ravel(lib.einsum("kx,kx,kx->", vu, vu.conj(), 1.0 / denom))[0]
+        e_2b += np.ravel(util.einsum("kx,kx,kx->", vu, vu.conj(), 1.0 / denom))[0]
 
     e_2b *= 2.0
 
@@ -109,7 +111,7 @@ def galitskii_migdal_g0(mo_energy, mo_occ, se, flip=False):
 
     denom = lib.direct_sum("i-j->ij", mo, se.energies)
 
-    e_2b = np.ravel(lib.einsum("xk,xk,xk->", se.couplings, se.couplings.conj(), 1.0 / denom))[0]
+    e_2b = np.ravel(util.einsum("xk,xk,xk->", se.couplings, se.couplings.conj(), 1.0 / denom))[0]
     e_2b *= 2.0
 
     return e_2b

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -31,7 +31,7 @@ def _gradient(x, se, fock, nelec, occupancy=2, buf=None):
 
     h1 = -np.dot(v[nmo:, nocc:].T.conj(), v[nmo:, :nocc])
     zai = -h1 / lib.direct_sum("i-a->ai", w[:nocc], w[nocc:])
-    ddm = lib.einsum("ai,pa,pi->", zai, v[:nmo, nocc:], v[:nmo, :nocc].conj()).real * 4
+    ddm = util.einsum("ai,pa,pi->", zai, v[:nmo, nocc:], v[:nmo, :nocc].conj()).real * 4
     grad = occupancy * error * ddm
 
     return error**2, grad

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -5,7 +5,6 @@ molecular systems.
 
 import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE, NullLogger
-from pyscf import lib
 from pyscf.lib import logger
 
 from momentGW import energy, mpi_helper, thc, util
@@ -138,14 +137,14 @@ class GW(BaseGW):  # noqa: D101
                 vk = integrals.get_k(dm, basis="ao")
 
             se_static = vmf - vk * 0.5
-            se_static = lib.einsum(
+            se_static = util.einsum(
                 "...pq,...pi,...qj->...ij", se_static, np.conj(mo_coeff), mo_coeff
             )
 
         if self.diagonal_se:
-            se_static = lib.einsum("...pq,pq->...pq", se_static, np.eye(se_static.shape[-1]))
+            se_static = util.einsum("...pq,pq->...pq", se_static, np.eye(se_static.shape[-1]))
 
-        se_static += lib.einsum("...p,...pq->...pq", mo_energy, np.eye(se_static.shape[-1]))
+        se_static += util.einsum("...p,...pq->...pq", mo_energy, np.eye(se_static.shape[-1]))
 
         return se_static
 
@@ -393,7 +392,9 @@ class GW(BaseGW):  # noqa: D101
         if integrals is None:
             integrals = self.ao2mo()
 
-        h1e = lib.einsum("pq,pi,qj->ij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff)
+        h1e = util.einsum(
+            "pq,pi,qj->ij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff
+        )
         rdm1 = self.make_rdm1(gf=gf)
         fock = integrals.get_fock(rdm1, h1e)
 

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -10,7 +10,7 @@ from pyscf import lib
 from pyscf.ao2mo import _ao2mo
 from pyscf.lib import logger
 
-from momentGW import mpi_helper
+from momentGW import mpi_helper, util
 
 
 @contextlib.contextmanager
@@ -359,9 +359,9 @@ class Integrals:
         vj = np.zeros_like(dm, dtype=np.result_type(dm, self.dtype, other.dtype))
 
         if self.store_full and basis == "mo":
-            tmp = lib.einsum("Qkl,lk->Q", other.Lpq, dm[p0:p1])
+            tmp = util.einsum("Qkl,lk->Q", other.Lpq, dm[p0:p1])
             tmp = mpi_helper.allreduce(tmp)
-            vj[:, p0:p1] = lib.einsum("Qij,Q->ij", self.Lpq, tmp)
+            vj[:, p0:p1] = util.einsum("Qij,Q->ij", self.Lpq, tmp)
             vj = mpi_helper.allreduce(vj)
 
         else:
@@ -375,8 +375,8 @@ class Integrals:
                         block = lib.unpack_tril(block)
                     block = block.reshape(naux, self.nmo, self.nmo)
 
-                    tmp = lib.einsum("Qkl,lk->Q", block, dm)
-                    vj += lib.einsum("Qij,Q->ij", block, tmp)
+                    tmp = util.einsum("Qkl,lk->Q", block, dm)
+                    vj += util.einsum("Qij,Q->ij", block, tmp)
 
             vj = mpi_helper.allreduce(vj)
             if basis == "mo":
@@ -413,9 +413,9 @@ class Integrals:
         vk = np.zeros_like(dm, dtype=np.result_type(dm, self.dtype))
 
         if self.store_full and basis == "mo":
-            tmp = lib.einsum("Qik,kl->Qil", self.Lpq, dm[p0:p1])
+            tmp = util.einsum("Qik,kl->Qil", self.Lpq, dm[p0:p1])
             tmp = mpi_helper.allreduce(tmp)
-            vk[:, p0:p1] = lib.einsum("Qil,Qlj->ij", tmp, self.Lpq)
+            vk[:, p0:p1] = util.einsum("Qil,Qlj->ij", tmp, self.Lpq)
             vk = mpi_helper.allreduce(vk)
 
         else:
@@ -429,8 +429,8 @@ class Integrals:
                         block = lib.unpack_tril(block)
                     block = block.reshape(naux, self.nmo, self.nmo)
 
-                    tmp = lib.einsum("Qik,kl->Qil", block, dm)
-                    vk += lib.einsum("Qil,Qlj->ij", tmp, block)
+                    tmp = util.einsum("Qik,kl->Qil", block, dm)
+                    vk += util.einsum("Qil,Qlj->ij", tmp, block)
 
             vk = mpi_helper.allreduce(vk)
             if basis == "mo":

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -32,7 +32,7 @@ def _gradient(x, se, fock, nelec, occupancy=2, buf=None):
         nocc = np.sum(w < chempot)
         h1 = -np.dot(v[nmo:, nocc:].T.conj(), v[nmo:, :nocc])
         zai = -h1 / lib.direct_sum("i-a->ai", w[:nocc], w[nocc:])
-        ddm += lib.einsum("ai,pa,pi->", zai, v[:nmo, nocc:], v[:nmo, :nocc].conj()).real * 4
+        ddm += util.einsum("ai,pa,pi->", zai, v[:nmo, nocc:], v[:nmo, :nocc].conj()).real * 4
 
     ddm = mpi_helper.allreduce(ddm)
     grad = occupancy * error * ddm
@@ -222,7 +222,7 @@ def fock_loop(
     if integrals is None:
         integrals = gw.ao2mo()
 
-    h1e = lib.einsum("kpq,kpi,kqj->kij", gw._scf.get_hcore(), np.conj(gw.mo_coeff), gw.mo_coeff)
+    h1e = util.einsum("kpq,kpi,kqj->kij", gw._scf.get_hcore(), np.conj(gw.mo_coeff), gw.mo_coeff)
     nmo = gw.nmo
     nocc = gw.nocc
     naux = [s.naux for s in se]

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -5,7 +5,6 @@ periodic systems.
 
 import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE, NullLogger
-from pyscf import lib
 from pyscf.lib import logger
 
 from momentGW import energy, util
@@ -242,7 +241,7 @@ class KGW(BaseKGW, GW):  # noqa: D101
         if integrals is None:
             integrals = self.ao2mo()
 
-        h1e = lib.einsum(
+        h1e = util.einsum(
             "kpq,kpi,kqj->kij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff
         )
         rdm1 = self.make_rdm1()
@@ -318,16 +317,16 @@ class KGW(BaseKGW, GW):  # noqa: D101
 
         other = self.__class__(mf)
         other.__dict__.update({key: getattr(self, key) for key in self._opts})
-        sc = lib.einsum("kpq,kqi->kpi", mf.get_ovlp(), mf.mo_coeff)
+        sc = util.einsum("kpq,kqi->kpi", mf.get_ovlp(), mf.mo_coeff)
 
         def interp(m):
             # Interpolate part of the moments via the AO basis
-            m = lib.einsum("knij,kpi,kqj->knpq", m, self.mo_coeff, self.mo_coeff.conj())
+            m = util.einsum("knij,kpi,kqj->knpq", m, self.mo_coeff, self.mo_coeff.conj())
             m = np.stack(
                 [self.kpts.interpolate(other.kpts, m[:, n]) for n in range(nmom_max + 1)],
                 axis=1,
             )
-            m = lib.einsum("knpq,kpi,kqj->knij", m, sc.conj(), sc)
+            m = util.einsum("knpq,kpi,kqj->knij", m, sc.conj(), sc)
             return m
 
         # Get the moments of the self-energy on the small k-point grid

--- a/momentGW/pbc/kpts.py
+++ b/momentGW/pbc/kpts.py
@@ -9,7 +9,7 @@ import scipy.linalg
 from pyscf import lib
 from pyscf.pbc.lib import kpts_helper
 
-from momentGW import mpi_helper
+from momentGW import mpi_helper, util
 
 # TODO make sure this is rigorous
 
@@ -319,7 +319,7 @@ class KPoints:
         kL = np.exp(1.0j * np.dot(other._kpts, r_vec_abs.T)) / np.sqrt(len(r_vec_abs))
 
         # k -> bvk
-        fg = lib.einsum("kR,kij,kS->RiSj", kR, fk, kR.conj())
+        fg = util.einsum("kR,kij,kS->RiSj", kR, fk, kR.conj())
         if np.max(np.abs(fg.imag)) > 1e-6:
             raise ValueError("Interpolated function has non-zero imaginary part.")
         fg = fg.real
@@ -330,7 +330,7 @@ class KPoints:
 
         # bvk -> k
         fg = fg.reshape(len(other), nao, len(other), nao)
-        fl = lib.einsum("kR,RiSj,kS->kij", kL.conj(), fg, kL)
+        fl = util.einsum("kR,RiSj,kS->kij", kL.conj(), fg, kL)
 
         return fl
 

--- a/momentGW/pbc/qsgw.py
+++ b/momentGW/pbc/qsgw.py
@@ -4,7 +4,6 @@ constraints for periodic systems.
 """
 
 import numpy as np
-from pyscf import lib
 
 from momentGW import util
 from momentGW.pbc.evgw import evKGW
@@ -53,16 +52,16 @@ class qsKGW(KGW, qsGW):  # noqa: D101
             Matrix projected into the desired basis at each k-point.
         """
 
-        proj = lib.einsum("k...pq,k...pi,k...qj->k...ij", ovlp, np.conj(mo1), mo2)
+        proj = util.einsum("k...pq,k...pi,k...qj->k...ij", ovlp, np.conj(mo1), mo2)
 
         if isinstance(matrix, np.ndarray):
-            projected_matrix = lib.einsum(
+            projected_matrix = util.einsum(
                 "k...pq,k...pi,k...qj->k...ij", matrix, np.conj(proj), proj
             )
         else:
             projected_matrix = []
             for k, m in enumerate(matrix):
-                coupling = lib.einsum("pk,pi->ik", m.couplings, np.conj(proj[k]))
+                coupling = util.einsum("pk,pi->ik", m.couplings, np.conj(proj[k]))
                 projected_m = m.copy()
                 projected_m.couplings = coupling
                 projected_matrix.append(projected_m)

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -155,11 +155,11 @@ class dTDA(MoldTDA):
                     subscript = f"t,kt,kt{pqchar}->{pqchar}"
 
                     eo = np.power.outer(mo_energy_g[kx][mo_occ_g[kx] > 0], n - moms)
-                    to = lib.einsum(subscript, fh, eo, eta[kp, q][mo_occ_g[kx] > 0])
+                    to = util.einsum(subscript, fh, eo, eta[kp, q][mo_occ_g[kx] > 0])
                     moments_occ[kp, n] += fproc(to)
 
                     ev = np.power.outer(mo_energy_g[kx][mo_occ_g[kx] == 0], n - moms)
-                    tv = lib.einsum(subscript, fp, ev, eta[kp, q][mo_occ_g[kx] == 0])
+                    tv = util.einsum(subscript, fp, ev, eta[kp, q][mo_occ_g[kx] == 0])
                     moments_vir[kp, n] += fproc(tv)
 
         # Numerical integration can lead to small non-hermiticity
@@ -225,7 +225,7 @@ class dTDA(MoldTDA):
                     for x in range(self.mo_energy_g[kx].size):
                         Lp = self.integrals.Lpx[kp, kx][:, :, x]
                         subscript = f"P{pchar},Q{qchar},PQ->{pqchar}"
-                        eta[kp, q][x, n] += lib.einsum(subscript, Lp, Lp.conj(), eta_aux)
+                        eta[kp, q][x, n] += util.einsum(subscript, Lp, Lp.conj(), eta_aux)
 
         cput1 = lib.logger.timer(self.gw, "rotating DD moments", *cput0)
 

--- a/momentGW/pbc/uhf/fock.py
+++ b/momentGW/pbc/uhf/fock.py
@@ -5,7 +5,6 @@ conditions and unrestricted references.
 
 import numpy as np
 from dyson import Lehmann
-from pyscf import lib
 from pyscf.lib import logger
 
 from momentGW import mpi_helper, util
@@ -59,7 +58,7 @@ def fock_loop(
     if integrals is None:
         integrals = gw.ao2mo()
 
-    h1e = lib.einsum("kpq,skpi,skqj->skij", gw._scf.get_hcore(), np.conj(gw.mo_coeff), gw.mo_coeff)
+    h1e = util.einsum("kpq,skpi,skqj->skij", gw._scf.get_hcore(), np.conj(gw.mo_coeff), gw.mo_coeff)
     nmo = gw.nmo
     nocc = gw.nocc
     naux = (

--- a/momentGW/pbc/uhf/gw.py
+++ b/momentGW/pbc/uhf/gw.py
@@ -5,7 +5,6 @@ periodic systems.
 
 import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE, NullLogger
-from pyscf import lib
 from pyscf.lib import logger
 
 from momentGW import energy, util
@@ -261,7 +260,7 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
         if integrals is None:
             integrals = self.ao2mo()
 
-        h1e = lib.einsum(
+        h1e = util.einsum(
             "kpq,skpi,skqj->skij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff
         )
         rdm1 = self.make_rdm1()

--- a/momentGW/pbc/uhf/ints.py
+++ b/momentGW/pbc/uhf/ints.py
@@ -4,10 +4,9 @@ reference.
 """
 
 import numpy as np
-from pyscf import lib
 from pyscf.lib import logger
 
-from momentGW import mpi_helper
+from momentGW import mpi_helper, util
 from momentGW.pbc.ints import KIntegrals
 from momentGW.uhf.ints import UIntegrals
 
@@ -157,7 +156,7 @@ class KUIntegrals(UIntegrals, KIntegrals):
                         b0, b1 = b1, b1 + block.shape[0]
                         logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
 
-                        tmp = lib.einsum("Lpq,pi,qj->Lij", block, ci[ki].conj(), cj[kj])
+                        tmp = util.einsum("Lpq,pi,qj->Lij", block, ci[ki].conj(), cj[kj])
                         tmp = tmp.reshape(b1 - b0, -1)
                         Lxy[b0:b1] = tmp
 

--- a/momentGW/pbc/uhf/qsgw.py
+++ b/momentGW/pbc/uhf/qsgw.py
@@ -4,7 +4,6 @@ moment constraints for periodic systems.
 """
 
 import numpy as np
-from pyscf import lib
 
 from momentGW import qsGW, util
 from momentGW.pbc.qsgw import qsKGW
@@ -56,17 +55,17 @@ class qsKUGW(KUGW, qsKGW, qsUGW):  # noqa: D101
             for each spin channel.
         """
 
-        proj = lib.einsum("k...pq,sk...pi,sk...qj->sk...ij", ovlp, np.conj(mo1), mo2)
+        proj = util.einsum("k...pq,sk...pi,sk...qj->sk...ij", ovlp, np.conj(mo1), mo2)
 
         if isinstance(matrix, np.ndarray):
-            projected_matrix = lib.einsum(
+            projected_matrix = util.einsum(
                 "sk...pq,sk...pi,sk...qj->sk...ij", matrix, np.conj(proj), proj
             )
         else:
             projected_matrix = [[], []]
             for s, ms in enumerate(matrix):
                 for k, m in enumerate(ms):
-                    coupling = lib.einsum("pk,pi->ik", m.couplings, np.conj(proj[s][k]))
+                    coupling = util.einsum("pk,pi->ik", m.couplings, np.conj(proj[s][k]))
                     projected_m = m.copy()
                     projected_m.couplings = coupling
                     projected_matrix[s].append(projected_m)

--- a/momentGW/pbc/uhf/tda.py
+++ b/momentGW/pbc/uhf/tda.py
@@ -190,7 +190,7 @@ class dTDA(KdTDA, MolUdTDA):
                         for x in range(self.mo_energy_g[s][kx].size):
                             Lp = self.integrals[s].Lpx[kp, kx][:, :, x]
                             subscript = f"P{pchar},Q{qchar},PQ->{pqchar}"
-                            eta[s, kp, q][x, n] += lib.einsum(subscript, Lp, Lp.conj(), eta_aux)
+                            eta[s, kp, q][x, n] += util.einsum(subscript, Lp, Lp.conj(), eta_aux)
 
         cput1 = lib.logger.timer(self.gw, "rotating DD moments", *cput0)
 

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -51,7 +51,7 @@ class dRPA(dTDA):
 
         # Calculate diagonal part of ERI
         diag_eri = np.zeros((self.nov,))
-        diag_eri[p0:p1] = lib.einsum("np,np->p", self.integrals.Lia, self.integrals.Lia)
+        diag_eri[p0:p1] = util.einsum("np,np->p", self.integrals.Lia, self.integrals.Lia)
         diag_eri = mpi_helper.allreduce(diag_eri)
 
         # Get the offset integral quadrature
@@ -168,7 +168,7 @@ class dRPA(dTDA):
         rot = np.concatenate([self.integrals.Lia, self.integrals.Lia], axis=-1)
 
         moments = rpa.gen_moms(self.nmom_max)
-        moments = lib.einsum("nij,Pi->nPj", moments, rot)
+        moments = util.einsum("nij,Pi->nPj", moments, rot)
 
         return moments[:, :, : self.nov]
 

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -200,12 +200,12 @@ class dTDA:
 
             if np.any(mo_occ_g[q0:q1] > 0):
                 eo = np.power.outer(mo_energy_g[q0:q1][mo_occ_g[q0:q1] > 0], n - eta_orders)
-                to = lib.einsum(f"t,kt,kt{pq}->{pq}", fh, eo, eta[mo_occ_g[q0:q1] > 0])
+                to = util.einsum(f"t,kt,kt{pq}->{pq}", fh, eo, eta[mo_occ_g[q0:q1] > 0])
                 moments_occ[n] += fproc(to)
 
             if np.any(mo_occ_g[q0:q1] == 0):
                 ev = np.power.outer(mo_energy_g[q0:q1][mo_occ_g[q0:q1] == 0], n - eta_orders)
-                tv = lib.einsum(f"t,ct,ct{pq}->{pq}", fp, ev, eta[mo_occ_g[q0:q1] == 0])
+                tv = util.einsum(f"t,ct,ct{pq}->{pq}", fp, ev, eta[mo_occ_g[q0:q1] == 0])
                 moments_vir[n] += fproc(tv)
 
         moments_occ = mpi_helper.allreduce(moments_occ)
@@ -256,7 +256,7 @@ class dTDA:
             eta_aux = mpi_helper.allreduce(eta_aux)
             for x in range(q1 - q0):
                 Lp = self.integrals.Lpx[:, :, x]
-                eta[x] = lib.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux) * 2.0
+                eta[x] = util.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux) * 2.0
 
             # Construct the self-energy moments for this order only
             # to save memory
@@ -292,14 +292,14 @@ class dTDA:
         # Rotate into ia basis
         ci = self.integrals.mo_coeff_w[:, self.integrals.mo_occ_w > 0]
         ca = self.integrals.mo_coeff_w[:, self.integrals.mo_occ_w == 0]
-        dip = lib.einsum("xpq,pi,qa->xia", dip, ci.conj(), ca)
+        dip = util.einsum("xpq,pi,qa->xia", dip, ci.conj(), ca)
         dip = dip.reshape(3, -1)
 
         # Get the density-density response moments
         moments_dd = self.build_dd_moments(m0=dip[:, p0:p1])
 
         # Get the moments of the dynamic polarizability
-        moments_dp = lib.einsum("px,nqx->npq", dip[:, p0:p1], moments_dd)
+        moments_dp = util.einsum("px,nqx->npq", dip[:, p0:p1], moments_dd)
 
         lib.logger.timer(self.gw, "moments", *cput0)
 

--- a/momentGW/uhf/fock.py
+++ b/momentGW/uhf/fock.py
@@ -4,7 +4,6 @@ Fock matrix self-consistent loop for unrestricted references.
 
 import numpy as np
 from dyson import Lehmann
-from pyscf import lib
 from pyscf.lib import logger
 
 from momentGW import mpi_helper, util
@@ -58,7 +57,7 @@ def fock_loop(
     if integrals is None:
         integrals = gw.ao2mo()
 
-    h1e = lib.einsum("pq,spi,sqj->sij", gw._scf.get_hcore(), gw.mo_coeff, gw.mo_coeff)
+    h1e = util.einsum("pq,spi,sqj->sij", gw._scf.get_hcore(), gw.mo_coeff, gw.mo_coeff)
     nmo = gw.nmo
     nocc = gw.nocc
     naux = (se[0].naux, se[1].naux)

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -5,10 +5,9 @@ molecular systems.
 
 import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE, NullLogger
-from pyscf import lib
 from pyscf.lib import logger
 
-from momentGW import energy, mpi_helper
+from momentGW import energy, mpi_helper, util
 from momentGW.base import BaseGW
 from momentGW.fock import minimize_chempot, search_chempot
 from momentGW.gw import GW
@@ -263,7 +262,7 @@ class UGW(BaseUGW, GW):  # noqa: D101
             integrals = self.ao2mo()
 
         h1e = tuple(
-            lib.einsum("pq,pi,qj->ij", self._scf.get_hcore(), c.conj(), c) for c in self.mo_coeff
+            util.einsum("pq,pi,qj->ij", self._scf.get_hcore(), c.conj(), c) for c in self.mo_coeff
         )
         rdm1 = self.make_rdm1(gf=gf)
         fock = integrals.get_fock(rdm1, h1e)

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -6,7 +6,7 @@ import numpy as np
 from pyscf import lib
 from pyscf.lib import logger
 
-from momentGW import mpi_helper
+from momentGW import mpi_helper, util
 from momentGW.ints import Integrals
 
 
@@ -142,7 +142,7 @@ class UIntegrals(Integrals):
                         b0, b1 = b1, b1 + block.shape[0]
                         logger.debug(self, f"  Block [{p0}:{p1}, {b0}:{b1}]")
 
-                        tmp = lib.einsum("Lpq,pi,qj->Lij", block, ci[:, i0 : i1 + 1], cj)
+                        tmp = util.einsum("Lpq,pi,qj->Lij", block, ci[:, i0 : i1 + 1], cj)
                         tmp = tmp.reshape(b1 - b0, -1)
                         Lxy[b0:b1] = tmp[:, j0 : j0 + (p1 - p0)]
 

--- a/momentGW/uhf/qsgw.py
+++ b/momentGW/uhf/qsgw.py
@@ -4,7 +4,6 @@ moment constraints for molecular systems.
 """
 
 import numpy as np
-from pyscf import lib
 
 from momentGW import util
 from momentGW.qsgw import qsGW
@@ -53,16 +52,16 @@ class qsUGW(UGW, qsGW):  # noqa: D101
             channel.
         """
 
-        proj = lib.einsum("pq,spi,sqj->sij", ovlp, np.conj(mo1), mo2)
+        proj = util.einsum("pq,spi,sqj->sij", ovlp, np.conj(mo1), mo2)
 
         if isinstance(matrix, np.ndarray):
-            projected_matrix = lib.einsum(
+            projected_matrix = util.einsum(
                 "...pq,s...pi,s...qj->s...ij", matrix, np.conj(proj), proj
             )
         else:
             projected_matrix = []
             for s, m in enumerate(matrix):
-                coupling = lib.einsum("pk,pi->ik", m.couplings, np.conj(proj[s]))
+                coupling = util.einsum("pk,pi->ik", m.couplings, np.conj(proj[s]))
                 projected_m = m.copy()
                 projected_m.couplings = coupling
                 projected_matrix.append(projected_m)

--- a/momentGW/uhf/rpa.py
+++ b/momentGW/uhf/rpa.py
@@ -60,10 +60,10 @@ class dRPA(dTDA, RdRPA):
 
         # Calculate diagonal part of ERI
         diag_eri_α = np.zeros((self.nov[0],))
-        diag_eri_α[a0:a1] = lib.einsum("np,np->p", self.integrals[0].Lia, self.integrals[0].Lia)
+        diag_eri_α[a0:a1] = util.einsum("np,np->p", self.integrals[0].Lia, self.integrals[0].Lia)
         diag_eri_α = mpi_helper.allreduce(diag_eri_α)
         diag_eri_β = np.zeros((self.nov[1],))
-        diag_eri_β[b0:b1] = lib.einsum("np,np->p", self.integrals[1].Lia, self.integrals[1].Lia)
+        diag_eri_β[b0:b1] = util.einsum("np,np->p", self.integrals[1].Lia, self.integrals[1].Lia)
         diag_eri_β = mpi_helper.allreduce(diag_eri_β)
         diag_eri = (diag_eri_α, diag_eri_β)
 

--- a/momentGW/uhf/tda.py
+++ b/momentGW/uhf/tda.py
@@ -145,11 +145,11 @@ class dTDA(RdTDA):
 
             for x in range(a1 - a0):
                 Lp = self.integrals[0].Lpx[:, :, x]
-                eta[0][x] = lib.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux)
+                eta[0][x] = util.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux)
 
             for x in range(b1 - b0):
                 Lp = self.integrals[1].Lpx[:, :, x]
-                eta[1][x] = lib.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux)
+                eta[1][x] = util.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux)
 
             # Construct the self-energy moments for this order only
             # to save memory

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -5,7 +5,6 @@ import numpy as np
 import scipy.linalg
 from pyscf import lib
 
-
 # Define the size of problem to fall back on NumPy
 NUMPY_EINSUM_SIZE = 2000
 

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -6,6 +6,10 @@ import scipy.linalg
 from pyscf import lib
 
 
+# Define the size of problem to fall back on NumPy
+NUMPY_EINSUM_SIZE = 2000
+
+
 class DIIS(lib.diis.DIIS):
     """
     Direct inversion of the iterative subspace (DIIS).
@@ -255,3 +259,206 @@ def build_1h1p_energies(mo_energy, mo_occ):
     d = lib.direct_sum("a-i->ia", e_vir, e_occ)
 
     return d
+
+
+def _contract(subscript, *args, **kwargs):
+    """Contract a pair of terms in an `einsum`-like fashion.
+
+    Parameters
+    ----------
+    subscript : str
+        Subscript notation for the contraction.
+    args : list of numpy.ndarray
+        Arrays to contract.
+    kwargs : dict
+        Additional arguments to pass to `numpy.einsum`.
+
+    Returns
+    -------
+    out : numpy.ndarray
+        Contracted array.
+    """
+
+    # Unpack the arguments
+    a, b = args
+    a = np.asarray(a)
+    b = np.asarray(b)
+
+    # Fall back function
+    def _fallback():
+        kwargs = kwargs.copy()
+        if "optimize" not in kwargs:
+            kwargs["optimize"] = True
+        return np.einsum(subscript, a, b, **kwargs)
+
+    # Check if the problem is small enough to use NumPy
+    if min(a.size, b.size) < NUMPY_EINSUM_SIZE:
+        return _fallback()
+
+    # Make sure the problem can be dispatched as a DGEMM
+    indices = subscript.replace(",", "").replace("->", "")
+    if any(indices.count(x) != 2 for x in set(indices)):
+        return _fallback()
+
+    # Get the characters for each input and output
+    inp, out, args = np.core.einsumfunc._parse_einsum_input((subscript, a, b))
+    inp_a, inp_b = inps = inp.split(",")
+    assert len(inps) == len(args) == 2
+    assert all(len(inp) == arg.ndim for inp, arg in zip(inps, args))
+
+    # Check for internal traces
+    if any(len(inp) != len(set(inp)) for inp in inps):
+        # FIXME this can be consumed and then re-call _contract
+        return _fallback()
+
+    # Find the dummy indices
+    dummy = set(inp_a) & set(inp_b)
+    if not dummy or inp_a == dummy or inp_b == dummy:
+        return _fallback()
+
+    # Find the index sizes
+    ranges = {}
+    for inp, arg in zip(inps, args):
+        for i, s in zip(inp, arg.shape):
+            if i in ranges:
+                if ranges[i] != s:
+                    raise ValueError(
+                        f"Index size mismatch: {subscript} with A={a.shape} and B={b.shape}."
+                    )
+            ranges[i] = s
+
+    # Align indices for DGEMM
+    inp_at = list(inp_a)
+    inp_bt = list(inp_b)
+    inner_shape = 1
+    for i, n in enumerate(sorted(dummy)):
+        j = len(inp_at) - 1
+        inp_at.insert(j, inp_at.pop(inp_at.index(n)))
+        inp_bt.insert(i, inp_bt.pop(inp_bt.index(n)))
+        inner_shape *= ranges[n]
+
+    # Find transposes
+    order_a = [inp_a.index(idx) for idx in inp_at]
+    order_b = [inp_b.index(idx) for idx in inp_bt]
+
+    # Get the shape and transpose for the output
+    shape_ct = []
+    inp_ct = []
+    for idx in inp_at:
+        if idx in dummy:
+            break
+        shape_ct.append(ranges[idx])
+        inp_ct.append(idx)
+    for idx in inp_bt:
+        if idx in dummy:
+            break
+        shape_ct.append(ranges[idx])
+        inp_ct.append(idx)
+    order_ct = [inp_ct.index(idx) for idx in out]
+
+    # If any dimension has size zero, return here
+    if a.size == 0 or b.size == 0:
+        shape_c = [shape_ct[i] for i in order_ct]
+        if kwargs.get("out", None):
+            return kwargs["out"].reshape(shape_c)
+        else:
+            return np.zeros(shape_c, dtype=np.result_type(a, b))
+
+    # Apply transposes
+    at = a.transpose(order_a)
+    bt = b.transpose(order_b)
+
+    # Find optimal memory layout
+    at = np.asarray(at.reshape(-1, inner_shape), order="F" if at.flags.f_contiguous else "C")
+    bt = np.asarray(bt.reshape(inner_shape, -1), order="F" if bt.flags.f_contiguous else "C")
+
+    # Get the output buffer
+    shape_ct_flat = (at.shape[0], bt.shape[1])
+    if kwargs.get("out", None):
+        order_c = [out.index(idx) for idx in inp_ct]
+        out = kwargs["out"].transpose(order_c)
+        out = np.asarray(out.reshape(shape_ct_flat), order="F" if out.flags.f_contiguous else "C")
+    else:
+        out = np.empty(shape_ct_flat, dtype=np.result_type(a, b), order="F")
+
+    # Perform the contraction
+    ct = lib.dot(at, bt, c=out)
+
+    # Reshape and transpose the output
+    ct = ct.reshape(shape_ct, order="A")
+    c = ct.transpose(order_ct)
+
+    return c
+
+
+def einsum(*operands, **kwargs):
+    """
+    Evaluate an Einstein summation convention on the operands.
+
+    Using the Einstein summation convention, many common
+    multi-dimensional, linear algebraic array operations can be
+    represented in a simple fashion. In *implicit* mode `einsum`
+    computes these values.
+
+    In *explicit* mode, `einsum` provides further flexibility to compute
+    other array operations that might not be considered classical
+    Einstein summation operations, by disabling, or forcing summation
+    over specified subscript labels.
+
+    See the `numpy.einsum` documentation for clarification.
+
+    Parameters
+    ----------
+    operands : list
+        Any valid input to `numpy.einsum`.
+    out : ndarray, optional
+        If provided, the calculation is done into this array.
+    contract : callable, optional
+        The function to use for contraction. Default value is
+        `_contract`.
+    optimize : bool, optional
+        If `True`, use the `numpy.einsum_path` to optimize the
+        contraction. Default value is `True`.
+
+    Returns
+    -------
+    output : ndarray
+        The calculation based on the Einstein summation convention.
+    """
+
+    # Parse the input
+    inp, out, args = np.core.einsumfunc._parse_einsum_input(operands)
+    subscript = f"{inp}->{out}"
+    contract = kwargs.pop("contract", _contract)
+
+    # If it's just a transpose, fallback to NumPy
+    if len(args) < 2:
+        return np.einsum(subscript, *args, **kwargs)
+
+    # If it's a single contraction, call the contract function directly
+    if len(args) == 2:
+        return contract(subscript, *args, **kwargs)
+
+    # Otherwise, use the `einsum_path` to optimize the contraction
+    contractions = np.einsum_path(
+        subscript,
+        *args,
+        optimize=kwargs.get("optimize", True),
+        einsum_call=True,
+    )[1]
+
+    # Execute the contractions in order
+    args = list(args)
+    for i, (inds, idx_rm, einsum_str, remaining, _) in enumerate(contractions):
+        operands = [arg.pop(x) for x in inds]
+
+        # Output should only be provided for the last contraction
+        tmp_kwargs = kwargs.copy()
+        if i != len(contractions) - 1:
+            tmp_kwargs["out"] = None
+
+        # Execute the contraction
+        out = contract(einsum_str, *operands, **tmp_kwargs)
+        args.append(out)
+
+    return out


### PR DESCRIPTION
- Implements internal `einsum` that always optimises contraction order and dispatches via `DGEMM` where possible
- Swaps out all `einsum` calls for the new internal function

Note: unlike `pyscf.lib.einsum`, this function calls `np.core.einsumfunc._parse_einsum_input` to parse the input arguments. This means that any `Ellipsis` in the subscripts are swapped out internally. This will prevent the problem we had where `einsums` written to be agnostic w.r.t spin or k-space won't just be dispatched via unoptimised `numpy.einsum` calls any more.