### PR TITLE
Fock self-consistent GW

### DIFF
--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -52,20 +52,24 @@ from momentGW.rpa import dRPA
 from momentGW.gw import GW
 from momentGW.bse import BSE, cpBSE
 from momentGW.evgw import evGW
-from momentGW.scgw import scGW
 from momentGW.qsgw import qsGW
+from momentGW.fsgw import fsGW
+from momentGW.scgw import scGW
 
 from momentGW.pbc.gw import KGW
 from momentGW.pbc.evgw import evKGW
 from momentGW.pbc.qsgw import qsKGW
+from momentGW.pbc.fsgw import fsKGW
 from momentGW.pbc.scgw import scKGW
 
 from momentGW.uhf.gw import UGW
 from momentGW.uhf.evgw import evUGW
 from momentGW.uhf.qsgw import qsUGW
+from momentGW.uhf.fsgw import fsUGW
 from momentGW.uhf.scgw import scUGW
 
 from momentGW.pbc.uhf.gw import KUGW
 from momentGW.pbc.uhf.evgw import evKUGW
 from momentGW.pbc.uhf.qsgw import qsKUGW
+from momentGW.pbc.uhf.fsgw import fsKUGW
 from momentGW.pbc.uhf.scgw import scKUGW

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -1,0 +1,192 @@
+"""
+Spin-restricted Fock matrix self-consistent GW via self-energy moment
+constraints for molecular systems.
+"""
+
+import numpy as np
+from pyscf import lib
+from pyscf.lib import logger
+
+from momentGW import util, mpi_helper
+from momentGW.base import BaseGW
+from momentGW.gw import GW
+from momentGW.qsgw import qsGW
+
+
+def kernel(
+    gw,
+    nmom_max,
+    mo_energy,
+    mo_coeff,
+    moments=None,
+    integrals=None,
+):
+    """
+    Moment-constrained Fock matrix self-consistent GW.
+
+    Parameters
+    ----------
+    gw : BaseGW
+        GW object.
+    nmom_max : int
+        Maximum moment number to calculate.
+    mo_energy : numpy.ndarray
+        Molecular orbital energies.
+    mo_coeff : numpy.ndarray
+        Molecular orbital coefficients.
+    moments : tuple of numpy.ndarray, optional
+        Tuple of (hole, particle) moments, if passed then they will
+        be used  as the initial guess instead of calculating them.
+        Default value is `None`.
+    integrals : Integrals, optional
+        Integrals object. If `None`, generate from scratch. Default
+        value is `None`.
+
+    Returns
+    -------
+    conv : bool
+        Convergence flag.
+    gf : dyson.Lehmann
+        Green's function object
+    se : dyson.Lehmann
+        Self-energy object
+    qp_energy : numpy.ndarray
+        Quasiparticle energies.
+    """
+
+    if integrals is None:
+        integrals = gw.ao2mo(transform=False)
+
+    mo_energy = mo_energy.copy()
+    mo_coeff = mo_coeff.copy()
+    mo_coeff_ref = mo_coeff.copy()
+
+    # Get the overlap
+    ovlp = gw._scf.get_ovlp()
+    sc = lib.einsum("...pq,...qi->...pi", ovlp, mo_coeff)
+
+    # Get the core Hamiltonian
+    h1e_ao = gw._scf.get_hcore()
+
+    diis = util.DIIS()
+    diis.space = gw.diis_space
+
+    # Get the solver
+    solver_options = {} if not gw.solver_options else gw.solver_options.copy()
+    if "fock_loop" not in solver_options:
+        solver_options["fock_loop"] = gw.fock_loop
+    if "optimise_chempot" not in solver_options:
+        solver_options["optimise_chempot"] = gw.optimise_chempot
+    subgw = gw.solver(gw._scf, **solver_options)
+    subgw.verbose = 4
+
+    conv = False
+    mo_energy_prev = np.zeros_like(mo_energy)
+    th_prev = tp_prev = np.zeros((nmom_max, gw.nmo, gw.nmo))
+    for cycle in range(1, gw.max_cycle + 1):
+        logger.info(gw, "%s iteration %d", gw.name, cycle)
+
+        # Transform the integrals
+        integrals.update_coeffs(mo_coeff, mo_coeff, gw._scf.get_occ(mo_energy, mo_coeff))
+
+        # Update the Fock matrix and get the MOs
+        h1e = lib.einsum("...pq,...pi,...qj->...ij", h1e_ao, np.conj(mo_coeff), mo_coeff)
+        dm = subgw.make_rdm1()
+        fock = integrals.get_fock(dm, h1e)
+        fock = gw.project_basis(fock, ovlp, mo_coeff, mo_coeff_ref)
+        fock = diis.update(fock)
+        mo_energy, u = np.linalg.eigh(fock)
+        u = mpi_helper.bcast(mo_coeff, root=0)
+        mo_coeff = lib.einsum("...pi,...ij->...pj", mo_coeff_ref, u)
+        np.set_printoptions(linewidth=1000, edgeitems=1000, precision=2)
+        print(fock)
+        print(mo_energy)
+
+        # Update the self-energy
+        subgw.mo_energy = mo_energy
+        subgw.mo_coeff = mo_coeff
+        subconv, gf, se, _ = subgw.kernel(nmom_max=nmom_max)
+        gf = gw.project_basis(gf, ovlp, mo_coeff, mo_coeff_ref)
+        se = gw.project_basis(se, ovlp, mo_coeff, mo_coeff_ref)
+
+        # Update the moments
+        th, tp = gw.self_energy_to_moments(se, nmom_max)
+
+        # Check for convergence
+        conv = gw.check_convergence(mo_energy, mo_energy_prev, th, th_prev, tp, tp_prev)
+        th_prev = th.copy()
+        tp_prev = tp.copy()
+        if conv:
+            break
+        if cycle == 2:
+            1/0
+
+    return conv, gf, se, mo_energy
+
+
+class fsGW(GW):  # noqa: D101
+    __doc__ = BaseGW.__doc__.format(
+        description="Spin-restricted Fock matrix self-consistent GW via self-energy moment "
+        + "constraints for molecules.",
+        extra_parameters="""max_cycle : int, optional
+        Maximum number of iterations. Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    conv_logical : callable, optional
+        Function that takes an iterable of booleans as input indicating
+        whether the individual `conv_tol`, `conv_tol_moms` have been
+        satisfied, respectively, and returns a boolean indicating
+        overall convergence. For example, the function `all` requires
+        both metrics to be met, and `any` requires just one. Default
+        value is `all`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space. Default value is `8`.
+    solver : BaseGW, optional
+        Solver to use to obtain the self-energy. Compatible with any
+        `BaseGW`-like class. Default value is `momentGW.gw.GW`.
+    solver_options : dict, optional
+        Keyword arguments to pass to the solver. Default value is an
+        empty `dict`.
+    """,
+    )
+
+    # --- Default fsGW options
+
+    fock_loop = True
+    optimise_chempot = True
+
+    # --- Extra fsGW options
+
+    max_cycle = 50
+    conv_tol = 1e-8
+    conv_tol_moms = 1e-8
+    conv_logical = all
+    diis_space = 8
+    solver = GW
+    solver_options = {}
+
+    _opts = GW._opts + [
+        "max_cycle",
+        "conv_tol",
+        "conv_tol_moms",
+        "conv_logical",
+        "diis_space",
+        "solver",
+        "solver_options",
+    ]
+
+    @property
+    def name(self):
+        """Method name."""
+        polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
+        return f"{polarizability}-fsGW"
+
+    _kernel = kernel
+
+    project_basis = staticmethod(qsGW.project_basis)
+    self_energy_to_moments = staticmethod(qsGW.self_energy_to_moments)
+    check_convergence = qsGW.check_convergence

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -71,10 +71,8 @@ def kernel(
 
     # Get the solver
     solver_options = {} if not gw.solver_options else gw.solver_options.copy()
-    if "fock_loop" not in solver_options:
-        solver_options["fock_loop"] = gw.fock_loop
-    if "optimise_chempot" not in solver_options:
-        solver_options["optimise_chempot"] = gw.optimise_chempot
+    for key in gw.solver._opts:
+        solver_options[key] = solver_options.get(key, getattr(gw, key, getattr(gw.solver, key)))
     subgw = gw.solver(gw._scf, **solver_options)
     subgw.verbose = 0
     integrals = subgw.ao2mo()

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -6,7 +6,7 @@ constraints for molecular systems.
 import numpy as np
 from pyscf.lib import logger
 
-from momentGW import util, mpi_helper
+from momentGW import mpi_helper, util
 from momentGW.base import BaseGW
 from momentGW.gw import GW
 from momentGW.qsgw import qsGW
@@ -62,7 +62,6 @@ def kernel(
 
     # Get the overlap
     ovlp = gw._scf.get_ovlp()
-    sc = util.einsum("...pq,...qi->...pi", ovlp, mo_coeff)
 
     # Get the core Hamiltonian
     h1e_ao = gw._scf.get_hcore()

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -4,7 +4,6 @@ constraints for molecular systems.
 """
 
 import numpy as np
-from pyscf import lib
 from pyscf.lib import logger
 
 from momentGW import util, mpi_helper
@@ -63,7 +62,7 @@ def kernel(
 
     # Get the overlap
     ovlp = gw._scf.get_ovlp()
-    sc = lib.einsum("...pq,...qi->...pi", ovlp, mo_coeff)
+    sc = util.einsum("...pq,...qi->...pi", ovlp, mo_coeff)
 
     # Get the core Hamiltonian
     h1e_ao = gw._scf.get_hcore()
@@ -91,7 +90,7 @@ def kernel(
         integrals = subgw.ao2mo()
 
         # Update the Fock matrix and get the MOs
-        h1e = lib.einsum("...pq,...pi,...qj->...ij", h1e_ao, np.conj(mo_coeff), mo_coeff)
+        h1e = util.einsum("...pq,...pi,...qj->...ij", h1e_ao, np.conj(mo_coeff), mo_coeff)
         dm = subgw.make_rdm1()
         fock = integrals.get_fock(dm, h1e)
         fock = gw.project_basis(fock, ovlp, mo_coeff, mo_coeff_ref)
@@ -99,7 +98,7 @@ def kernel(
         mo_energy_prev = mo_energy.copy()
         mo_energy, u = np.linalg.eigh(fock)
         u = mpi_helper.bcast(u, root=0)
-        mo_coeff = lib.einsum("...pi,...ij->...pj", mo_coeff_ref, u)
+        mo_coeff = util.einsum("...pi,...ij->...pj", mo_coeff_ref, u)
 
         # Update the self-energy
         subgw.mo_energy = mo_energy

--- a/momentGW/pbc/__init__.py
+++ b/momentGW/pbc/__init__.py
@@ -5,4 +5,5 @@ from momentGW.pbc.tda import dTDA
 from momentGW.pbc.gw import KGW
 from momentGW.pbc.evgw import evKGW
 from momentGW.pbc.qsgw import qsKGW
+from momentGW.pbc.fsgw import fsKGW
 from momentGW.pbc.scgw import scKGW

--- a/momentGW/pbc/fsgw.py
+++ b/momentGW/pbc/fsgw.py
@@ -1,0 +1,31 @@
+"""
+Spin-restricted Fock matrix self-consistent GW via self-energy moment
+constraints for periodic systems.
+"""
+
+import numpy as np
+
+from momentGW import util
+from momentGW.fsgw import fsGW
+from momentGW.pbc.gw import KGW
+from momentGW.pbc.qsgw import qsKGW
+
+
+class fsKGW(KGW, fsGW):  # noqa: D101
+    __doc__ = fsGW.__doc__.replace("molecules", "periodic systems", 1)
+
+    # --- Default fsKGW options
+
+    solver = KGW
+
+    _opts = util.list_union(KGW._opts, fsGW._opts)
+
+    @property
+    def name(self):
+        """Method name."""
+        polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
+        return f"{polarizability}-fsKGW"
+
+    project_basis = staticmethod(qsKGW.project_basis)
+    self_energy_to_moments = staticmethod(qsKGW.self_energy_to_moments)
+    check_convergence = qsKGW.check_convergence

--- a/momentGW/pbc/fsgw.py
+++ b/momentGW/pbc/fsgw.py
@@ -3,8 +3,6 @@ Spin-restricted Fock matrix self-consistent GW via self-energy moment
 constraints for periodic systems.
 """
 
-import numpy as np
-
 from momentGW import util
 from momentGW.fsgw import fsGW
 from momentGW.pbc.gw import KGW

--- a/momentGW/pbc/uhf/__init__.py
+++ b/momentGW/pbc/uhf/__init__.py
@@ -5,4 +5,5 @@ from momentGW.pbc.uhf.tda import dTDA
 from momentGW.pbc.uhf.gw import KUGW
 from momentGW.pbc.uhf.evgw import evKUGW
 from momentGW.pbc.uhf.qsgw import qsKUGW
+from momentGW.pbc.uhf.fsgw import fsKUGW
 from momentGW.pbc.uhf.scgw import scKUGW

--- a/momentGW/pbc/uhf/fsgw.py
+++ b/momentGW/pbc/uhf/fsgw.py
@@ -3,13 +3,11 @@ Spin-unrestricted Fock matrix self-consistent GW via self-energy moment
 constraints for periodic systems.
 """
 
-import numpy as np
-
 from momentGW import util
 from momentGW.pbc.fsgw import fsKGW
 from momentGW.pbc.uhf.gw import KUGW
-from momentGW.uhf.fsgw import fsUGW
 from momentGW.pbc.uhf.qsgw import qsKUGW
+from momentGW.uhf.fsgw import fsUGW
 
 
 class fsKUGW(KUGW, fsKGW, fsUGW):  # noqa: D101

--- a/momentGW/pbc/uhf/fsgw.py
+++ b/momentGW/pbc/uhf/fsgw.py
@@ -1,0 +1,32 @@
+"""
+Spin-unrestricted Fock matrix self-consistent GW via self-energy moment
+constraints for periodic systems.
+"""
+
+import numpy as np
+
+from momentGW import util
+from momentGW.pbc.fsgw import fsKGW
+from momentGW.pbc.uhf.gw import KUGW
+from momentGW.uhf.fsgw import fsUGW
+from momentGW.pbc.uhf.qsgw import qsKUGW
+
+
+class fsKUGW(KUGW, fsKGW, fsUGW):  # noqa: D101
+    __doc__ = fsKGW.__doc__.replace("Spin-restricted", "Spin-unrestricted", 1)
+
+    # --- Default fsKUGW options
+
+    solver = KUGW
+
+    _opts = util.list_union(KUGW._opts, fsKGW._opts, fsUGW._opts)
+
+    @property
+    def name(self):
+        """Method name."""
+        polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
+        return f"{polarizability}-fsKUGW"
+
+    project_basis = staticmethod(qsKUGW.project_basis)
+    self_energy_to_moments = staticmethod(qsKUGW.self_energy_to_moments)
+    check_convergence = qsKUGW.check_convergence

--- a/momentGW/uhf/__init__.py
+++ b/momentGW/uhf/__init__.py
@@ -6,4 +6,5 @@ from momentGW.uhf.rpa import dRPA
 from momentGW.uhf.gw import UGW
 from momentGW.uhf.evgw import evUGW
 from momentGW.uhf.qsgw import qsUGW
+from momentGW.uhf.fsgw import fsUGW
 from momentGW.uhf.scgw import scUGW

--- a/momentGW/uhf/fsgw.py
+++ b/momentGW/uhf/fsgw.py
@@ -3,8 +3,6 @@ Spin-unrestricted Fock matrix self-consistent GW via self-energy moment
 constraints for molecular systems.
 """
 
-import numpy as np
-
 from momentGW import util
 from momentGW.fsgw import fsGW
 from momentGW.uhf.gw import UGW

--- a/momentGW/uhf/fsgw.py
+++ b/momentGW/uhf/fsgw.py
@@ -1,0 +1,31 @@
+"""
+Spin-unrestricted Fock matrix self-consistent GW via self-energy moment
+constraints for molecular systems.
+"""
+
+import numpy as np
+
+from momentGW import util
+from momentGW.fsgw import fsGW
+from momentGW.uhf.gw import UGW
+from momentGW.uhf.qsgw import qsUGW
+
+
+class fsUGW(UGW, fsGW):  # noqa: D101
+    __doc__ = fsGW.__doc__.replace("Spin-restricted", "Spin-unrestricted", 1)
+
+    # --- Default fsUGW options
+
+    solver = UGW
+
+    _opts = util.list_union(UGW._opts, fsGW._opts)
+
+    @property
+    def name(self):
+        """Method name."""
+        polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
+        return f"{polarizability}-fsUGW"
+
+    project_basis = staticmethod(qsUGW.project_basis)
+    self_energy_to_moments = staticmethod(qsUGW.self_energy_to_moments)
+    check_convergence = qsUGW.check_convergence

--- a/momentGW/uhf/qsgw.py
+++ b/momentGW/uhf/qsgw.py
@@ -56,7 +56,7 @@ class qsUGW(UGW, qsGW):  # noqa: D101
 
         if isinstance(matrix, np.ndarray):
             projected_matrix = util.einsum(
-                "...pq,s...pi,s...qj->s...ij", matrix, np.conj(proj), proj
+                "s...pq,s...pi,s...qj->s...ij", matrix, np.conj(proj), proj
             )
         else:
             projected_matrix = []

--- a/tests/test_fsgw.py
+++ b/tests/test_fsgw.py
@@ -1,0 +1,63 @@
+"""
+Tests for `fsgw.py`.
+"""
+
+import unittest
+
+import numpy as np
+from pyscf import dft, gto
+from pyscf.agf2 import mpi_helper
+
+from momentGW import fsGW
+
+
+class Test_fsGW(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def _test_regression(self, xc, kwargs, nmom_max, ip, ea, ip_full, ea_full, name=""):
+        mol = gto.M(atom="H 0 0 0; Li 0 0 1.64", basis="6-31g", verbose=0)
+        mf = dft.RKS(mol, xc=xc).density_fit().run()
+        mf.mo_coeff = mpi_helper.bcast_dict(mf.mo_coeff, root=0)
+        mf.mo_energy = mpi_helper.bcast_dict(mf.mo_energy, root=0)
+        gw = fsGW(mf, **kwargs)
+        gw.max_cycle = 200
+        gw.conv_tol = 1e-10
+        gw.conv_tol_qp = 1e-10
+        gw.damping = 0.5
+        gw.kernel(nmom_max)
+        gf = gw.gf.physical(weight=0.5)
+        qp_energy = gw.qp_energy
+        self.assertTrue(gw.converged)
+        self.assertAlmostEqual(np.max(qp_energy[mf.mo_occ > 0]), ip, 7, msg=name)
+        self.assertAlmostEqual(np.min(qp_energy[mf.mo_occ == 0]), ea, 7, msg=name)
+        self.assertAlmostEqual(gf.occupied().energies[-1], ip_full, 7, msg=name)
+        self.assertAlmostEqual(gf.virtual().energies[0], ea_full, 7, msg=name)
+
+    def test_regression_simple(self):
+        # Quasiparticle energies:
+        ip = -0.298368381748
+        ea = 0.009241657362
+        # GF poles:
+        ip_full = -0.285192929632
+        ea_full = 0.006413219011
+        self._test_regression("hf", dict(), 1, ip, ea, ip_full, ea_full, "simple")
+
+    def test_regression_pbe(self):
+        # Quasiparticle energies:
+        ip = -0.298634443617
+        ea = 0.009231958865
+        # GF poles:
+        ip_full = -0.279442462661
+        ea_full = 0.006197011695
+        self._test_regression("pbe", dict(), 3, ip, ea, ip_full, ea_full, "pbe srg")
+
+
+if __name__ == "__main__":
+    print("Running tests for fsGW")
+    unittest.main()

--- a/tests/test_fskgw.py
+++ b/tests/test_fskgw.py
@@ -82,7 +82,6 @@ class Test_fsKGW(unittest.TestCase):
 
         kgw = fsKGW(self.mf)
         kgw.polarizability = "dtda"
-        kgw.solver_options["polarizability"] = "dtda"
         kgw.compression = None
         kgw.conv_tol_qp = 1e-10
         kgw.conv_tol = 1e-10
@@ -90,7 +89,6 @@ class Test_fsKGW(unittest.TestCase):
 
         gw = fsGW(self.smf)
         gw.polarizability = "dtda"
-        gw.solver_options["polarizability"] = "dtda"
         gw.compression = None
         gw.conv_tol_qp = 1e-10
         gw.conv_tol = 1e-10

--- a/tests/test_fskgw.py
+++ b/tests/test_fskgw.py
@@ -1,0 +1,104 @@
+"""
+Tests for `pbc/fsgw.py`
+"""
+
+import unittest
+
+import numpy as np
+from pyscf.agf2 import mpi_helper
+from pyscf.pbc import dft, gto
+from pyscf.pbc.tools import k2gamma
+
+from momentGW import fsGW, fsKGW
+
+
+class Test_fsKGW(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cell = gto.Cell()
+        cell.atom = "He 0 0 0; He 1 1 1"
+        cell.basis = "6-31g"
+        cell.a = np.eye(3) * 3
+        cell.verbose = 0
+        cell.precision = 1e-12
+        cell.build()
+
+        kmesh = [3, 1, 1]
+        kpts = cell.make_kpts(kmesh)
+
+        mf = dft.KRKS(cell, kpts, xc="hf")
+        mf = mf.density_fit(auxbasis="weigend")
+        mf.conv_tol = 1e-11
+        mf.kernel()
+
+        for k in range(len(kpts)):
+            mf.mo_coeff[k] = mpi_helper.bcast_dict(mf.mo_coeff[k], root=0)
+            mf.mo_energy[k] = mpi_helper.bcast_dict(mf.mo_energy[k], root=0)
+
+        smf = k2gamma.k2gamma(mf, kmesh=kmesh)
+        smf = smf.density_fit(auxbasis="weigend")
+
+        cls.cell, cls.kpts, cls.mf, cls.smf = cell, kpts, mf, smf
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.cell, cls.kpts, cls.mf, cls.smf
+
+    def test_supercell_valid(self):
+        # Require real MOs for supercell comparison
+
+        scell, phase = k2gamma.get_phase(self.cell, self.kpts)
+        nk, nao, nmo = np.shape(self.mf.mo_coeff)
+        nr, _ = np.shape(phase)
+
+        k_conj_groups = k2gamma.group_by_conj_pairs(self.cell, self.kpts, return_kpts_pairs=False)
+        k_phase = np.eye(nk, dtype=np.complex128)
+        r2x2 = np.array([[1., 1j], [1., -1j]]) * .5**.5
+        pairs = [[k, k_conj] for k, k_conj in k_conj_groups
+                 if k_conj is not None and k != k_conj]
+        for idx in np.array(pairs):
+            k_phase[idx[:, None], idx] = r2x2
+
+        c_gamma = np.einsum('Rk,kum,kh->Ruhm', phase, self.mf.mo_coeff, k_phase)
+        c_gamma = c_gamma.reshape(nao*nr, nk*nmo)
+        c_gamma[:, abs(c_gamma.real).max(axis=0) < 1e-5] *= -1j
+
+        self.assertAlmostEqual(np.max(np.abs(np.array(c_gamma).imag)), 0, 8)
+
+    def _test_vs_supercell(self, gw, kgw, full=False, check_convergence=True):
+        if check_convergence:
+            self.assertTrue(gw.converged)
+            self.assertTrue(kgw.converged)
+        if full:
+            e1 = np.sort(np.concatenate([gf.energy for gf in kgw.gf]))
+            e2 = gw.gf.energy
+        else:
+            e1 = np.sort(kgw.qp_energy.ravel())
+            e2 = gw.qp_energy
+        np.testing.assert_allclose(e1, e2, atol=1e-8)
+
+    def test_dtda_vs_supercell(self):
+        nmom_max = 3
+
+        kgw = fsKGW(self.mf)
+        kgw.polarizability = "dtda"
+        kgw.solver_options["polarizability"] = "dtda"
+        kgw.compression = None
+        kgw.conv_tol_qp = 1e-10
+        kgw.conv_tol = 1e-10
+        kgw.kernel(nmom_max)
+
+        gw = fsGW(self.smf)
+        gw.polarizability = "dtda"
+        gw.solver_options["polarizability"] = "dtda"
+        gw.compression = None
+        gw.conv_tol_qp = 1e-10
+        gw.conv_tol = 1e-10
+        gw.kernel(nmom_max)
+
+        self._test_vs_supercell(gw, kgw)
+
+
+if __name__ == "__main__":
+    print("Running tests for fsKGW")
+    unittest.main()

--- a/tests/test_fskugw.py
+++ b/tests/test_fskugw.py
@@ -1,0 +1,78 @@
+"""
+Tests for `pbc/uhf/fsgw.py`
+"""
+
+import unittest
+
+import numpy as np
+from pyscf.agf2 import mpi_helper
+from pyscf.pbc import dft, gto
+from pyscf.pbc.tools import k2gamma
+
+from momentGW import fsKGW, fsKUGW
+
+
+class Test_fsKUGW_vs_fsKGW(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cell = gto.Cell()
+        cell.atom = "He 0 0 0; He 1 1 1"
+        cell.basis = "6-31g"
+        cell.a = np.eye(3) * 3
+        cell.max_memory = 1e10
+        cell.verbose = 0
+        cell.build()
+
+        kmesh = [3, 1, 1]
+        kpts = cell.make_kpts(kmesh)
+
+        mf = dft.KRKS(cell, kpts, xc="hf")
+        mf = mf.density_fit(auxbasis="weigend")
+        mf.with_df._prefer_ccdf = True
+        mf.with_df.force_dm_kbuild = True
+        mf.exxdiv = None
+        mf.conv_tol = 1e-10
+        mf.kernel()
+
+        for k in range(len(kpts)):
+            mf.mo_coeff[k] = mpi_helper.bcast_dict(mf.mo_coeff[k], root=0)
+            mf.mo_energy[k] = mpi_helper.bcast_dict(mf.mo_energy[k], root=0)
+
+        smf = k2gamma.k2gamma(mf, kmesh=kmesh)
+        smf = smf.density_fit(auxbasis="weigend")
+        smf.exxdiv = None
+        smf.with_df._prefer_ccdf = True
+        smf.with_df.force_dm_kbuild = True
+
+        cls.cell, cls.kpts, cls.mf, cls.smf = cell, kpts, mf, smf
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.cell, cls.kpts, cls.mf, cls.smf
+
+    def test_dtda(self):
+        krgw = fsKGW(self.mf)
+        krgw.compression = None
+        krgw.polarizability = "dtda"
+        krgw.solver_options["polarizability"] = "dtda"
+        krgw.kernel(3)
+
+        uhf = self.mf.to_uhf()
+        uhf.with_df = self.mf.with_df
+
+        kugw = fsKUGW(uhf)
+        kugw.compression = None
+        kugw.polarizability = "dtda"
+        kugw.solver_options["polarizability"] = "dtda"
+        kugw.kernel(3)
+
+        self.assertTrue(krgw.converged)
+        self.assertTrue(kugw.converged)
+
+        np.testing.assert_allclose(krgw.qp_energy, kugw.qp_energy[0])
+        np.testing.assert_allclose(krgw.qp_energy, kugw.qp_energy[1])
+
+
+if __name__ == "__main__":
+    print("Running tests for fsKUGW")
+    unittest.main()

--- a/tests/test_fskugw.py
+++ b/tests/test_fskugw.py
@@ -54,7 +54,6 @@ class Test_fsKUGW_vs_fsKGW(unittest.TestCase):
         krgw = fsKGW(self.mf)
         krgw.compression = None
         krgw.polarizability = "dtda"
-        krgw.solver_options["polarizability"] = "dtda"
         krgw.kernel(3)
 
         uhf = self.mf.to_uhf()
@@ -63,7 +62,6 @@ class Test_fsKUGW_vs_fsKGW(unittest.TestCase):
         kugw = fsKUGW(uhf)
         kugw.compression = None
         kugw.polarizability = "dtda"
-        kugw.solver_options["polarizability"] = "dtda"
         kugw.kernel(3)
 
         self.assertTrue(krgw.converged)

--- a/tests/test_fsugw.py
+++ b/tests/test_fsugw.py
@@ -42,7 +42,6 @@ class Test_fsUGW_vs_fsRGW(unittest.TestCase):
         rgw = fsGW(self.mf)
         rgw.compression = None
         rgw.polarizability = "dtda"
-        rgw.solver_options["polarizability"] = "dtda"
         rgw.kernel(1)
 
         uhf = self.mf.to_uks()
@@ -51,7 +50,6 @@ class Test_fsUGW_vs_fsRGW(unittest.TestCase):
         ugw = fsUGW(uhf)
         ugw.compression = None
         ugw.polarizability = "dtda"
-        ugw.solver_options["polarizability"] = "dtda"
         ugw.kernel(1)
 
         self.assertTrue(rgw.converged)
@@ -85,7 +83,6 @@ class Test_fsUGW_vs_fsRGW(unittest.TestCase):
         rgw.compression = "ov,oo"
         rgw.compression_tol = 1e-4
         rgw.polarizability = "dtda"
-        rgw.solver_options["polarizability"] = "dtda"
         rgw.kernel(3)
 
         uhf = self.mf.to_uks()
@@ -95,7 +92,6 @@ class Test_fsUGW_vs_fsRGW(unittest.TestCase):
         ugw.compression = "ov,oo"
         ugw.compression_tol = 1e-4
         ugw.polarizability = "dtda"
-        ugw.solver_options["polarizability"] = "dtda"
         ugw.kernel(3)
 
         self.assertTrue(rgw.converged)
@@ -175,7 +171,6 @@ class Test_fsUGW(unittest.TestCase):
     def test_dtda_regression(self):
         ugw = fsUGW(self.mf)
         ugw.polarizability = "dtda"
-        ugw.solver_options["polarizability"] = "dtda"
         ugw.compression = None
         conv, gf, se, _ = ugw.kernel(nmom_max=3)
         self.assertTrue(conv)
@@ -222,7 +217,6 @@ class Test_fsUGW_no_beta(unittest.TestCase):
     def test_dtda_regression(self):
         ugw = fsUGW(self.mf)
         ugw.polarizability = "dtda"
-        ugw.solver_options["polarizability"] = "dtda"
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)

--- a/tests/test_fsugw.py
+++ b/tests/test_fsugw.py
@@ -1,0 +1,235 @@
+"""
+Tests for `uhf/fsgw.py`.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+from pyscf import dft, gto, gw, lib, tdscf
+from pyscf.agf2 import mpi_helper
+
+from momentGW import fsGW
+from momentGW.uhf import fsUGW
+
+
+class Test_fsUGW_vs_fsRGW(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.atom = "Li 0 0 0; H 0 0 1.64"
+        mol.basis = "6-31g"
+        mol.verbose = 0
+        mol.build()
+
+        mf = dft.RKS(mol)
+        mf.xc = "hf"
+        mf.conv_tol = 1e-12
+        mf = mf.density_fit()
+        mf.with_df.build()
+        mf.kernel()
+
+        mf.mo_coeff = mpi_helper.bcast_dict(mf.mo_coeff, root=0)
+        mf.mo_energy = mpi_helper.bcast_dict(mf.mo_energy, root=0)
+
+        cls.mol, cls.mf = mol, mf
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mol, cls.mf
+
+    def test_dtda(self):
+        rgw = fsGW(self.mf)
+        rgw.compression = None
+        rgw.polarizability = "dtda"
+        rgw.solver_options["polarizability"] = "dtda"
+        rgw.kernel(1)
+
+        uhf = self.mf.to_uks()
+        uhf.with_df = self.mf.with_df
+
+        ugw = fsUGW(uhf)
+        ugw.compression = None
+        ugw.polarizability = "dtda"
+        ugw.solver_options["polarizability"] = "dtda"
+        ugw.kernel(1)
+
+        self.assertTrue(rgw.converged)
+        self.assertTrue(ugw.converged)
+
+        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[0])
+        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[1])
+
+    def test_drpa(self):
+        rgw = fsGW(self.mf)
+        rgw.compression = None
+        rgw.polarizability = "drpa"
+        rgw.kernel(1)
+
+        uhf = self.mf.to_uks()
+        uhf.with_df = self.mf.with_df
+
+        ugw = fsUGW(uhf)
+        ugw.compression = None
+        ugw.polarizability = "drpa"
+        ugw.kernel(1)
+
+        self.assertTrue(rgw.converged)
+        self.assertTrue(ugw.converged)
+
+        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[0])
+        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[1])
+
+    def test_dtda_compression(self):
+        rgw = fsGW(self.mf)
+        rgw.compression = "ov,oo"
+        rgw.compression_tol = 1e-4
+        rgw.polarizability = "dtda"
+        rgw.solver_options["polarizability"] = "dtda"
+        rgw.kernel(3)
+
+        uhf = self.mf.to_uks()
+        uhf.with_df = self.mf.with_df
+
+        ugw = fsUGW(uhf)
+        ugw.compression = "ov,oo"
+        ugw.compression_tol = 1e-4
+        ugw.polarizability = "dtda"
+        ugw.solver_options["polarizability"] = "dtda"
+        ugw.kernel(3)
+
+        self.assertTrue(rgw.converged)
+        self.assertTrue(ugw.converged)
+
+        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[0])
+        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[1])
+
+    def test_drpa_compression(self):
+        rgw = fsGW(self.mf)
+        rgw.compression = "ia,oo"
+        rgw.compression_tol = 1e-4
+        rgw.polarizability = "drpa"
+        rgw.kernel(1)
+
+        uhf = self.mf.to_uks()
+        uhf.with_df = self.mf.with_df
+
+        ugw = fsUGW(uhf)
+        ugw.compression = "ia,oo"
+        ugw.compression_tol = 1e-4
+        ugw.polarizability = "drpa"
+        ugw.kernel(1)
+
+        self.assertTrue(rgw.converged)
+        self.assertTrue(ugw.converged)
+
+        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[0], atol=1e-8, rtol=1e-6)
+        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[1], atol=1e-8, rtol=1e-6)
+
+
+class Test_fsUGW(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.atom = "Be 0 0 0; H 0 0 1"
+        mol.basis = "sto3g"
+        mol.spin = 1
+        mol.verbose = 0
+        mol.build()
+
+        mf = dft.UKS(mol)
+        mf.xc = "hf"
+        mf.conv_tol = 1e-12
+        mf.kernel()
+
+        mf.mo_coeff = (
+            mpi_helper.bcast_dict(mf.mo_coeff[0], root=0),
+            mpi_helper.bcast_dict(mf.mo_coeff[1], root=0),
+        )
+        mf.mo_energy = (
+            mpi_helper.bcast_dict(mf.mo_energy[0], root=0),
+            mpi_helper.bcast_dict(mf.mo_energy[1], root=0),
+        )
+
+        mf = mf.density_fit(auxbasis="cc-pv5z-ri")
+        mf.with_df.build()
+
+        cls.mol, cls.mf = mol, mf
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mol, cls.mf
+
+    def test_drpa_regression(self):
+        ugw = fsUGW(self.mf)
+        ugw.polarizability = "drpa"
+        ugw.compression = None
+        ugw.npoints = 128
+        conv, gf, se, _ = ugw.kernel(nmom_max=3)
+        self.assertTrue(conv)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2757015698, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4761722709, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1862852956, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.2014835291, 6)
+
+    def test_dtda_regression(self):
+        ugw = fsUGW(self.mf)
+        ugw.polarizability = "dtda"
+        ugw.solver_options["polarizability"] = "dtda"
+        ugw.compression = None
+        conv, gf, se, _ = ugw.kernel(nmom_max=3)
+        self.assertTrue(conv)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2755846029, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4758147734, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1862675078, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.2013907084, 6)
+
+
+class Test_fsUGW_no_beta(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.atom = "H 0 0 0; H 0 0 1"
+        mol.basis = "sto3g"
+        mol.spin = 1
+        mol.charge = 1
+        mol.verbose = 0
+        mol.build()
+
+        mf = dft.UKS(mol)
+        mf.xc = "hf"
+        mf.conv_tol = 1e-12
+        mf.kernel()
+
+        mf.mo_coeff = (
+            mpi_helper.bcast_dict(mf.mo_coeff[0], root=0),
+            mpi_helper.bcast_dict(mf.mo_coeff[1], root=0),
+        )
+        mf.mo_energy = (
+            mpi_helper.bcast_dict(mf.mo_energy[0], root=0),
+            mpi_helper.bcast_dict(mf.mo_energy[1], root=0),
+        )
+
+        mf = mf.density_fit(auxbasis="cc-pv5z-ri")
+        mf.with_df.build()
+
+        cls.mol, cls.mf = mol, mf
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.mol, cls.mf
+
+    def test_dtda_regression(self):
+        ugw = fsUGW(self.mf)
+        ugw.polarizability = "dtda"
+        ugw.solver_options["polarizability"] = "dtda"
+        ugw.compression = None
+        ugw.npoints = 128
+        conv, gf, se, _ = ugw.kernel(nmom_max=9)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.1978538038)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.4667283798)
+
+
+if __name__ == "__main__":
+    print("Running tests for fsUGW")
+    unittest.main()


### PR DESCRIPTION
This PR implements a flavour of self-consistent GW that self-consistently solves for the density using a Fock matrix accompanied by a self-energy calculated at the level of GW, and then finds a new GW self-energy using the updated MOs defining that density.

- [x] Implement `fsgw.fsGW`
- [x] Implement `pbc.fsgw.fsKGW`
- [x] Implement `uhf.fsgw.fsUGW`
- [x] Implement `pbc.uhf.fsgw.fsKUGW`
- [x] Write unit tests
- [ ] Benchmark...

