### PR TITLE
Logging overhaul

### DIFF
--- a/examples/14-numerical_integration.py
+++ b/examples/14-numerical_integration.py
@@ -24,9 +24,11 @@ mf.kernel()
 # multiple of 4. This controls the number of points used in the
 # integrand. Larger values of `nmom_max` tend to require larger values
 # of `npoints` to converge.
+out = ""
 for npoints in [4, 8, 16, 32, 64]:
     gw = GW(mf)
     gw.polarizability = "dRPA"
     gw.npoints = npoints
     gw.kernel(nmom_max=7)
-    print(f"npoints = {npoints:#3d}, IP = {gw.qp_energy[mf.mo_occ > 0].max() * HARTREE2EV:#8.8f} eV")
+    out += f"npoints = {npoints:#3d}, IP = {gw.qp_energy[mf.mo_occ > 0].max() * HARTREE2EV:#8.8f} eV\n"
+print(out)

--- a/examples/15-compression.py
+++ b/examples/15-compression.py
@@ -21,32 +21,35 @@ mf.kernel()
 
 # The parameter `compression_tol` controls the threshold for eigenvalues
 # in the inner product of the interaction.
+out = ""
 for compression_tol in [1e-2, 1e-4, 1e-6, 1e-8, 1e-10]:
     gw = GW(mf)
     gw.polarizability = "dRPA"
     gw.compression_tol = compression_tol
     gw.kernel(nmom_max=5)
-    print(f"compression_tol = {compression_tol:#7.1g}, IP = {gw.qp_energy[mf.mo_occ > 0].max() * HARTREE2EV:#8.8f} eV")
+    out += f"compression_tol = {compression_tol:#7.1g}, IP = {gw.qp_energy[mf.mo_occ > 0].max() * HARTREE2EV:#8.8f} eV\n"
 
 # The parameter `compression` controls the blocks of the interaction that
 # are used to construct the inner product.
-print()
+out += "\n"
 for compression in ["oo", "ov", "ov,oo", "ov,oo,vv", None]:
     gw = GW(mf)
     gw.polarizability = "dRPA"
     gw.compression = compression
     gw.compression_tol = 1e-6
     gw.kernel(nmom_max=5)
-    print(f"compression = %8s, IP = {gw.qp_energy[mf.mo_occ > 0].max() * HARTREE2EV:#8.8f} eV" % compression)
+    out += f"compression = %8s, IP = {gw.qp_energy[mf.mo_occ > 0].max() * HARTREE2EV:#8.8f} eV\n" % compression
 
 # For self-consistent GW, one can also use `compression="ia"` which is
 # equivalent to `compression="ov"`, but updates the compression metric
 # between iterations.
-print()
+out += "\n"
 for compression in ["ov", "ia", None]:
     gw = scGW(mf)
     gw.polarizability = "dTDA"
     gw.compression = compression
     gw.compression_tol = 1e-4
     gw.kernel(nmom_max=1)
-    print(f"compression = %8s, IP = {gw.qp_energy[mf.mo_occ > 0].max() * HARTREE2EV:#8.8f} eV" % compression)
+    out += f"compression = %8s, IP = {gw.qp_energy[mf.mo_occ > 0].max() * HARTREE2EV:#8.8f} eV\n" % compression
+
+print(out)

--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -48,7 +48,7 @@ except ImportError:
 # --- Imports
 
 from momentGW import logging
-from momentGW.logging import default_log, init_logging, NullLogger
+from momentGW.logging import init_logging, set_log_level, console, dump_times
 
 from momentGW.tda import dTDA
 from momentGW.rpa import dRPA

--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -48,7 +48,7 @@ except ImportError:
 # --- Imports
 
 from momentGW import logging
-from momentGW.logging import init_logging, set_log_level, console, dump_times
+from momentGW.logging import init_logging, console, dump_times
 
 from momentGW.tda import dTDA
 from momentGW.rpa import dRPA

--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -27,6 +27,7 @@ Clone the momentGW repository:
 """
 
 import sys
+import logging
 
 __version__ = "1.0.0"
 
@@ -47,6 +48,7 @@ except ImportError:
 # --- Imports
 
 from momentGW import logging
+from momentGW.logging import default_log, init_logging, NullLogger
 
 from momentGW.tda import dTDA
 from momentGW.rpa import dRPA

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -47,10 +47,24 @@ class Base:
             if self._opt_is_used(key):
                 val = getattr(self, key)
                 if isinstance(val, dict):
-                    for k, v in val.items():
-                        table.add_row(f"{key}.{k}", str(v))
+                    keys, vals = zip(*val.items())
+                    keys = [f"{key}.{k}" for k in keys]
                 else:
-                    table.add_row(key, str(val))
+                    keys = [key]
+                    vals = [val]
+                for key, val in zip(keys, vals):
+                    if isinstance(val, np.ndarray):
+                        arr = np.array2string(
+                            val,
+                            precision=6,
+                            separator=", ",
+                            edgeitems=1,
+                            threshold=0,
+                        )
+                        arr = f"np.array({arr})"
+                        table.add_row(key, arr)
+                    else:
+                        table.add_row(key, repr(val))
         logging.info(table)
         logging.debug("")
 
@@ -293,7 +307,7 @@ class BaseGW(Base):
         logging.debug(table)
 
     def _print_excitations(self):
-        """Print the moments as a table."""
+        """Print the excitations as a table."""
 
         # Separate the occupied and virtual GFs
         gf_occ = self.gf.occupied().physical(weight=1e-1)

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -39,7 +39,7 @@ class Base:
         # Logging
         init_logging()
         logging.write("")
-        logging.write(f"[bold underline]{self.name}[/]", comment=f"Initialisation of solver")
+        logging.write(f"[bold underline]{self.name}[/]", comment="Initialisation of solver")
         table = logging.Table(title="Options")
         table.add_column("Option", justify="right")
         table.add_column("Value", justify="right", style="option")
@@ -117,6 +117,11 @@ class Base:
             return self._scf.mo_energy
         return self._mo_energy
 
+    @mo_energy.setter
+    def mo_energy(self, value):
+        """Set the molecular orbital energies."""
+        self._mo_energy = value
+
     @property
     def mo_coeff(self):
         """Molecular orbital coefficients."""
@@ -124,12 +129,22 @@ class Base:
             return self._scf.mo_coeff
         return self._mo_coeff
 
+    @mo_coeff.setter
+    def mo_coeff(self, value):
+        """Set the molecular orbital coefficients."""
+        self._mo_coeff = value
+
     @property
     def mo_occ(self):
         """Molecular orbital occupation numbers."""
         if self._mo_occ is None:
             return self._scf.mo_occ
         return self._mo_occ
+
+    @mo_occ.setter
+    def mo_occ(self, value):
+        """Set the molecular orbital occupation numbers."""
+        self._mo_occ = value
 
 
 class BaseGW(Base):

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -61,10 +61,9 @@ class Base:
                 val = getattr(self, key)
                 if isinstance(val, dict):
                     keys, vals = zip(*val.items()) if val else ((), ())
+                    old = getattr(self.__class__, key)
                     keys = [f"{key}.{k}" for k in keys]
-                    mods = [
-                        _check_modified(v, getattr(self.__class__, key)[k]) for k, v in val.items()
-                    ]
+                    mods = [old and _check_modified(v, old[k]) for k, v in val.items()]
                 else:
                     keys = [key]
                     vals = [val]

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -375,7 +375,7 @@ class BaseGW(Base):
         table.add_column("Dominant MOs", justify="right")
 
         # Add IPs
-        for n in range(min(5, gf_occ.naux)):
+        for n in range(min(3, gf_occ.naux)):
             en = -gf_occ.energies[-(n + 1)]
             weights = gf_occ.couplings[:, -(n + 1)] ** 2
             weight = np.sum(weights)
@@ -384,8 +384,11 @@ class BaseGW(Base):
             mo_string = ", ".join([f"{i} ({100 * weights[i] / weight:5.1f}%)" for i in dominant])
             table.add_row(f"IP {n:>2}", f"{en:.10f}", f"{weight:.5f}", mo_string)
 
+        # Add a break
+        table.add_section()
+
         # Add EAs
-        for n in range(min(5, gf_vir.naux)):
+        for n in range(min(3, gf_vir.naux)):
             en = gf_vir.energies[n]
             weights = gf_vir.couplings[:, n] ** 2
             weight = np.sum(weights)

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -74,19 +74,6 @@ class Base:
     def _kernel(self, *args, **kwargs):
         raise NotImplementedError
 
-    def _opt_is_used(self, key):
-        """
-        Check if an option is used by the solver. This is useful for
-        determining whether to print the option in the table.
-        """
-        if key == "fock_opts":
-            return self.fock_loop
-        if key == "thc_opts":
-            return self.polarizability.lower().startswith("thc")
-        if key == "npoints":
-            return self.polarizability.lower().endswith("drpa")
-        return True
-
     @property
     def mol(self):
         """Molecule object."""
@@ -308,6 +295,23 @@ class BaseGW(Base):
         """Alias for `kernel`, instead returning `self`."""
         self.kernel(*args, **kwargs)
         return self
+
+    def _opt_is_used(self, key):
+        """
+        Check if an option is used by the solver. This is useful for
+        determining whether to print the option in the table.
+        """
+        if key == "fock_opts":
+            return self.fock_loop
+        if key == "thc_opts":
+            return self.polarizability.lower().startswith("thc")
+        if key == "npoints":
+            return self.polarizability.lower().endswith("drpa")
+        if key == "eta":
+            return self.srg == 0.0
+        if key == "srg":
+            return self.srg != 0.0
+        return True
 
     @staticmethod
     def _moment_error(t, t_prev):

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -260,8 +260,6 @@ class BaseGW(Base):
     def kernel(
         self,
         nmom_max,
-        mo_energy=None,
-        mo_coeff=None,
         moments=None,
         integrals=None,
     ):
@@ -271,10 +269,6 @@ class BaseGW(Base):
         ----------
         nmom_max : int
             Maximum moment number to calculate.
-        mo_energy : numpy.ndarray
-            Molecular orbital energies.
-        mo_coeff : numpy.ndarray
-            Molecular orbital coefficients.
         moments : tuple of numpy.ndarray, optional
             Tuple of (hole, particle) moments, if passed then they will
             be used instead of calculating them. Default value is
@@ -285,12 +279,6 @@ class BaseGW(Base):
         """
 
         timer = util.Timer()
-
-        if mo_coeff is None:
-            mo_coeff = self.mo_coeff
-        if mo_energy is None:
-            mo_energy = self.mo_energy
-
         logging.write("")
         logging.write(f"[bold underline]{self.name}[/]", comment="Solver options")
         logging.write("")
@@ -304,8 +292,6 @@ class BaseGW(Base):
         with logging.with_status(f"Running {self.name} kernel"):
             self.converged, self.gf, self.se, self._qp_energy = self._kernel(
                 nmom_max,
-                mo_energy,
-                mo_coeff,
                 integrals=integrals,
                 moments=moments,
             )

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -266,7 +266,7 @@ class BaseGW(Base):
             integrals = self.ao2mo()
 
         logging.debug("")
-        with logging.Status(f"Running {self.name} kernel"):
+        with logging.with_status(f"Running {self.name} kernel"):
             self.converged, self.gf, self.se, self._qp_energy = self._kernel(
                 nmom_max,
                 mo_energy,

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -39,7 +39,7 @@ class Base:
         # Logging
         init_logging()
         logging.write("")
-        logging.write("[bold underline]{self.name}[/]", comment=f"Initialisation of solver")
+        logging.write(f"[bold underline]{self.name}[/]", comment=f"Initialisation of solver")
         table = logging.Table(title="Options")
         table.add_column("Option", justify="right")
         table.add_column("Value", justify="right", style="option")
@@ -262,14 +262,13 @@ class BaseGW(Base):
         if mo_energy is None:
             mo_energy = self.mo_energy
 
-        logging.write("")
+        logging.write("", comment=f"Start of {self.name} kernel")
         logging.write(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
 
         if integrals is None:
             integrals = self.ao2mo()
 
         with logging.with_status(f"Running {self.name} kernel"):
-            logging.write("", comment=f"Start of {self.name} kernel")
             self.converged, self.gf, self.se, self._qp_energy = self._kernel(
                 nmom_max,
                 mo_energy,
@@ -277,7 +276,7 @@ class BaseGW(Base):
                 integrals=integrals,
                 moments=moments,
             )
-            logging.write("", comment=f"End of {self.name} kernel")
+        logging.write("", comment=f"End of {self.name} kernel")
 
         # Print the summary in a panel
         logging.write(self._get_summary_panel(integrals, timer))
@@ -361,7 +360,7 @@ class BaseGW(Base):
         table.add_column("Dominant MOs", justify="right")
 
         # Add IPs
-        for n in range(min(5 if logging.level >= 2 else 3, gf_occ.naux)):
+        for n in range(min(5, gf_occ.naux)):
             en = -gf_occ.energies[-(n + 1)]
             weights = gf_occ.couplings[:, -(n + 1)] ** 2
             weight = np.sum(weights)
@@ -371,7 +370,7 @@ class BaseGW(Base):
             table.add_row(f"IP {n:>2}", f"{en:.10f}", f"{weight:.5f}", mo_string)
 
         # Add EAs
-        for n in range(min(5 if logging.level >= 2 else 3, gf_vir.naux)):
+        for n in range(min(5, gf_vir.naux)):
             en = gf_vir.energies[n]
             weights = gf_vir.couplings[:, n] ** 2
             weight = np.sum(weights)

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -40,7 +40,6 @@ class Base:
         init_logging()
         logging.info(f"\n[bold underline]{self.name}[/]")
         logging.debug("")
-        # logging.info("[bold]Options:[/]")
         table = logging.Table(title="Options")
         table.add_column("Option", justify="right")
         table.add_column("Value", justify="right", style="yellow")
@@ -252,6 +251,7 @@ class BaseGW(Base):
         if integrals is None:
             integrals = self.ao2mo()
 
+        logging.debug("")
         with logging.Status(f"Running {self.name} kernel"):
             self.converged, self.gf, self.se, self._qp_energy = self._kernel(
                 nmom_max,

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -53,7 +53,7 @@ class Base:
             if self._opt_is_used(key):
                 val = getattr(self, key)
                 if isinstance(val, dict):
-                    keys, vals = zip(*val.items())
+                    keys, vals = zip(*val.items()) if val else ((), ())
                     keys = [f"{key}.{k}" for k in keys]
                 else:
                     keys = [key]

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -23,12 +23,15 @@ class Base:
     ):
         # Parameters
         self._scf = mf
-        self._mo_energy = mpi_helper.bcast(np.asarray(mo_energy)) if mo_energy is not None else None
-        self._mo_coeff = mpi_helper.bcast(np.asarray(mo_coeff)) if mo_coeff is not None else None
-        self._mo_occ = mpi_helper.bcast(np.asarray(mo_occ)) if mo_occ is not None else None
+        self._mo_energy = None
+        self._mo_coeff = None
+        self._mo_occ = None
         self._nmo = None
         self._nocc = None
         self.frozen = None
+        self.mo_energy = mo_energy
+        self.mo_coeff = mo_coeff
+        self.mo_occ = mo_occ
 
         # Options
         for key, val in kwargs.items():
@@ -114,37 +117,40 @@ class Base:
     def mo_energy(self):
         """Molecular orbital energies."""
         if self._mo_energy is None:
-            return self._scf.mo_energy
+            self.mo_energy = self._scf.mo_energy
         return self._mo_energy
 
     @mo_energy.setter
     def mo_energy(self, value):
         """Set the molecular orbital energies."""
-        self._mo_energy = value
+        if value is not None:
+            self._mo_energy = mpi_helper.bcast(np.asarray(value))
 
     @property
     def mo_coeff(self):
         """Molecular orbital coefficients."""
         if self._mo_coeff is None:
-            return self._scf.mo_coeff
+            self.mo_coeff = self._scf.mo_coeff
         return self._mo_coeff
 
     @mo_coeff.setter
     def mo_coeff(self, value):
         """Set the molecular orbital coefficients."""
-        self._mo_coeff = value
+        if value is not None:
+            self._mo_coeff = mpi_helper.bcast(np.asarray(value))
 
     @property
     def mo_occ(self):
         """Molecular orbital occupation numbers."""
         if self._mo_occ is None:
-            return self._scf.mo_occ
+            self.mo_occ = self._scf.mo_occ
         return self._mo_occ
 
     @mo_occ.setter
     def mo_occ(self, value):
         """Set the molecular orbital occupation numbers."""
-        self._mo_occ = value
+        if value is not None:
+            self._mo_occ = mpi_helper.bcast(np.asarray(value))
 
 
 class BaseGW(Base):

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -70,7 +70,7 @@ class Base:
                     mods = [_check_modified(val, getattr(self.__class__, key))]
 
                 for key, val, mod in zip(keys, vals, mods):
-                    style = "dim" if not mod else ""
+                    key = f"[dim]{key}[/]" if mod else key
                     if isinstance(val, np.ndarray):
                         # Format numpy arrays
                         arr = np.array2string(
@@ -81,13 +81,13 @@ class Base:
                             threshold=0,
                         )
                         arr = f"np.array({arr})"
-                        table.add_row(key, arr, style=style)
+                        table.add_row(key, arr)
                     elif callable(val) or isinstance(val, type):
                         # Format functions and classes
-                        table.add_row(key, val.__name__, style=style)
+                        table.add_row(key, val.__name__)
                     else:
                         # Format everything else using repr
-                        table.add_row(key, repr(val), style=style)
+                        table.add_row(key, repr(val))
 
         return table
 

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -42,7 +42,7 @@ class Base:
         logging.debug("")
         table = logging.Table(title="Options")
         table.add_column("Option", justify="right")
-        table.add_column("Value", justify="right", style="yellow")
+        table.add_column("Value", justify="right", style="option")
         for key in self._opts:
             if self._opt_is_used(key):
                 val = getattr(self, key)
@@ -260,7 +260,7 @@ class BaseGW(Base):
         if mo_energy is None:
             mo_energy = self.mo_energy
 
-        logging.info(f"Solving for nmom_max = [yellow]{nmom_max}[/] ({nmom_max + 1} moments)")
+        logging.info(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
 
         if integrals is None:
             integrals = self.ao2mo()
@@ -293,14 +293,14 @@ class BaseGW(Base):
         # Build table
         table = logging.Table(title="Energies")
         table.add_column("Functional", justify="right")
-        table.add_column("Energy (G0)", justify="right")
-        table.add_column("Energy (G)", justify="right")
+        table.add_column("Energy (G0)", justify="right", style="output")
+        table.add_column("Energy (G)", justify="right", style="output")
         for name, e_g0, e_g in zip(
             ["One-body", "Galitskii-Migdal", "Total"],
             [e_1b_g0, e_2b_g0, e_1b_g0 + e_2b_g0],
             [e_1b, e_2b, e_1b + e_2b],
         ):
-            table.add_row(name, f"[blue]{e_g0:.10f}[/]", f"[blue]{e_g:.10f}[/]")
+            table.add_row(name, f"{e_g0:.10f}", f"{e_g:.10f}")
 
         # Print table
         logging.debug("")
@@ -316,7 +316,7 @@ class BaseGW(Base):
         # Build table
         table = logging.Table(title="Quasiparticle energies")
         table.add_column("Excitation", justify="right")
-        table.add_column("Energy", justify="right")
+        table.add_column("Energy", justify="right", style="output")
         table.add_column("QP weight", justify="right")
         table.add_column("Dominant MOs", justify="right")
 
@@ -328,7 +328,7 @@ class BaseGW(Base):
             dominant = np.argsort(weights)[::-1]
             dominant = dominant[weights[dominant] > 0.1][:3]
             mo_string = ", ".join([f"{i} ({100 * weights[i] / weight:5.1f}%)" for i in dominant])
-            table.add_row(f"IP {n:>2}", f"[blue]{en:.10f}[/]", f"{weight:.5f}", mo_string)
+            table.add_row(f"IP {n:>2}", f"{en:.10f}", f"{weight:.5f}", mo_string)
 
         # Add EAs
         for n in range(min(5 if logging.level >= 2 else 3, gf_vir.naux)):
@@ -338,7 +338,7 @@ class BaseGW(Base):
             dominant = np.argsort(weights)[::-1]
             dominant = dominant[weights[dominant] > 0.1][:3]
             mo_string = ", ".join([f"{i} ({100 * weights[i] / weight:5.1f}%)" for i in dominant])
-            table.add_row(f"EA {n:>2}", f"[blue]{en:.10f}[/]", f"{weight:.5f}", mo_string)
+            table.add_row(f"EA {n:>2}", f"{en:.10f}", f"{weight:.5f}", mo_string)
 
         # Print table
         logging.debug("")
@@ -414,7 +414,7 @@ class BaseGW(Base):
 
         if len(check) != gf.nphys:
             # TODO improve this warning
-            logging.warn("Inconsistent quasiparticle weights!")
+            logging.warn("[bad]Inconsistent quasiparticle weights![/]")
 
         return mo_energy
 

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -336,6 +336,31 @@ class BaseGW(Base):
 
         return error
 
+    def _get_header(self):
+        """
+        Get the header for the solver, with the name, options, and
+        problem size.
+        """
+
+        # Get the options table
+        options = super()._get_header()
+
+        # Get the problem size table
+        sizes = logging.Table(title="Sizes")
+        sizes.add_column("Space", justify="right")
+        sizes.add_column("Size", justify="right")
+        sizes.add_row("MOs", f"{self.nmo}")
+        sizes.add_row("Occupied MOs", f"{self.nocc}")
+        sizes.add_row("Virtual MOs", f"{self.nmo - self.nocc}")
+
+        # Combine the tables
+        panel = logging.Table.grid()
+        panel.add_row(options)
+        panel.add_row("")
+        panel.add_row(sizes)
+
+        return panel
+
     def _get_summary_panel(self, integrals, timer):
         """Return the summary as a panel."""
 

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -61,6 +61,7 @@ class Base:
 
                 for key, val in zip(keys, vals):
                     if isinstance(val, np.ndarray):
+                        # Format numpy arrays
                         arr = np.array2string(
                             val,
                             precision=6,
@@ -70,7 +71,11 @@ class Base:
                         )
                         arr = f"np.array({arr})"
                         table.add_row(key, arr)
+                    elif callable(val) or isinstance(val, type):
+                        # Format functions and classes
+                        table.add_row(key, val.__name__)
                     else:
+                        # Format everything else using repr
                         table.add_row(key, repr(val))
 
         return table

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -61,11 +61,10 @@ class Base:
                 val = getattr(self, key)
                 if isinstance(val, dict):
                     keys, vals = zip(*val.items()) if val else ((), ())
-                    mods = [
-                        _check_modified(v, getattr(self.__class__, key))[k]
-                        for k, v in zip(keys, vals)
-                    ]
                     keys = [f"{key}.{k}" for k in keys]
+                    mods = [
+                        _check_modified(v, getattr(self.__class__, key)[k]) for k, v in val.items()
+                    ]
                 else:
                     keys = [key]
                     vals = [val]

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -41,11 +41,14 @@ class Base:
 
         # Logging
         init_logging()
-        logging.write("")
-        logging.write(f"[bold underline]{self.name}[/]", comment="Initialisation of solver")
+
+    def _get_header(self):
+        """Get the header for the solver, with the name and options."""
+
         table = logging.Table(title="Options")
         table.add_column("Option", justify="right")
         table.add_column("Value", justify="right", style="option")
+
         for key in self._opts:
             if self._opt_is_used(key):
                 val = getattr(self, key)
@@ -55,6 +58,7 @@ class Base:
                 else:
                     keys = [key]
                     vals = [val]
+
                 for key, val in zip(keys, vals):
                     if isinstance(val, np.ndarray):
                         arr = np.array2string(
@@ -68,8 +72,8 @@ class Base:
                         table.add_row(key, arr)
                     else:
                         table.add_row(key, repr(val))
-        logging.write("")
-        logging.write(table)
+
+        return table
 
     def _kernel(self, *args, **kwargs):
         raise NotImplementedError
@@ -270,6 +274,10 @@ class BaseGW(Base):
         if mo_energy is None:
             mo_energy = self.mo_energy
 
+        logging.write("")
+        logging.write(f"[bold underline]{self.name}[/]", comment="Solver options")
+        logging.write("")
+        logging.write(self._get_header())
         logging.write("", comment=f"Start of {self.name} kernel")
         logging.write(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
 

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -124,7 +124,7 @@ class BSE(Base):
 
         compression = integrals._parse_compression()
         if compression and compression != {"oo", "vv", "ov"}:
-            logging.warning(
+            logging.warn(
                 "[bad]Running BSE with compression without including all integral blocks "
                 "is not recommended[/]. See example 17.",
             )
@@ -191,7 +191,7 @@ class BSE(Base):
 
         # Construct the energy differences
         if not self.gw.converged:
-            logging.warning("[red]GW calculation has not converged[/] - using MO energies for BSE")
+            logging.warn("[red]GW calculation has not converged[/] - using MO energies for BSE")
             qp_energy = self.mo_energy
         else:
             # Just use the QP energies - we could do the entire BSE in
@@ -363,9 +363,9 @@ class BSE(Base):
         if mo_energy is None:
             mo_energy = self.mo_energy
 
-        logging.info(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
+        logging.write(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
 
-        logging.debug("")
+        logging.write("")
         with logging.with_status(f"Running {self.name} kernel"):
             self.gf = self._kernel(
                 nmom_max,
@@ -408,8 +408,8 @@ class BSE(Base):
             )
 
         # Print table
-        logging.debug("")
-        logging.output(table)
+        logging.write("")
+        logging.write(table)
 
 
 class cpBSE(BSE):
@@ -574,9 +574,9 @@ class cpBSE(BSE):
         if mo_energy is None:
             mo_energy = self.mo_energy
 
-        logging.info(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
+        logging.write(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
 
-        logging.debug("")
+        logging.write("")
         with logging.with_status(f"Running {self.name} kernel"):
             self.gf = self._kernel(
                 nmom_max,

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -81,7 +81,8 @@ class BSE(Base):
     _opts = Base._opts + ["excitation", "polarizability"]
 
     def __init__(self, gw, **kwargs):
-        kwargs["polarizability"] = kwargs.get("polarizability", gw.polarizability)
+        if kwargs.get("polariability") is None:
+            kwargs["polarizability"] = gw.polarizability
         super().__init__(gw._scf, **kwargs)
 
         # Parameters
@@ -126,8 +127,8 @@ class BSE(Base):
         compression = integrals._parse_compression()
         if compression and compression != {"oo", "vv", "ov"}:
             logging.warning(
-                "Running BSE with compression [red]without including all integral blocks[/] "
-                "is not recommended. See example 17.",
+                "[bad]Running BSE with compression without including all integral blocks "
+                "is not recommended[/]. See example 17.",
             )
 
         if transform:
@@ -192,7 +193,7 @@ class BSE(Base):
 
         # Construct the energy differences
         if not self.gw.converged:
-            logging.warning("GW calculation has [red]not converged[/] - using MO energies for BSE")
+            logging.warning("[red]GW calculation has not converged[/] - using MO energies for BSE")
             qp_energy = self.mo_energy
         else:
             # Just use the QP energies - we could do the entire BSE in
@@ -364,7 +365,7 @@ class BSE(Base):
         if mo_energy is None:
             mo_energy = self.mo_energy
 
-        logging.info(f"Solving for nmom_max = [yellow]{nmom_max}[/] ({nmom_max + 1} moments)")
+        logging.info(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
 
         logging.debug("")
         with logging.Status(f"Running {self.name} kernel"):
@@ -388,7 +389,7 @@ class BSE(Base):
         # Build table
         table = logging.Table(title="Optical excitation energies")
         table.add_column("Excitation", justify="right")
-        table.add_column("Energy", justify="right")
+        table.add_column("Energy", justify="right", style="output")
         table.add_column("Dipole", justify="right")
         table.add_column("X", justify="right")
         table.add_column("Y", justify="right")
@@ -399,7 +400,7 @@ class BSE(Base):
             en = self.gf.energies[n]
             vn = self.gf.couplings[:, n]
             weight = np.sum(vn ** 2)
-            table.add_row(f"EE {n:>2}", f"[blue]{en:.10f}[/]", f"{weight:.5f}", f"{vn[0]:.5f}", f"{vn[1]:.5f}", f"{vn[2]:.5f}")
+            table.add_row(f"EE {n:>2}", f"{en:.10f}", f"{weight:.5f}", f"{vn[0]:.5f}", f"{vn[1]:.5f}", f"{vn[2]:.5f}")
 
         # Print table
         logging.debug("")
@@ -568,7 +569,7 @@ class cpBSE(BSE):
         if mo_energy is None:
             mo_energy = self.mo_energy
 
-        logging.info(f"Solving for nmom_max = [yellow]{nmom_max}[/] ({nmom_max + 1} moments)")
+        logging.info(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
 
         logging.debug("")
         with logging.Status(f"Running {self.name} kernel"):

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -366,7 +366,7 @@ class BSE(Base):
         logging.info(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
 
         logging.debug("")
-        with logging.Status(f"Running {self.name} kernel"):
+        with logging.with_status(f"Running {self.name} kernel"):
             self.gf = self._kernel(
                 nmom_max,
                 mo_energy,
@@ -577,7 +577,7 @@ class cpBSE(BSE):
         logging.info(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
 
         logging.debug("")
-        with logging.Status(f"Running {self.name} kernel"):
+        with logging.with_status(f"Running {self.name} kernel"):
             self.gf = self._kernel(
                 nmom_max,
                 mo_energy,

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -17,8 +17,6 @@ from momentGW.tda import dTDA
 def kernel(
     bse,
     nmom_max,
-    mo_energy,
-    mo_coeff,
     moments=None,
     integrals=None,
 ):
@@ -30,10 +28,6 @@ def kernel(
         GW object.
     nmom_max : int
         Maximum moment number to calculate.
-    mo_energy : numpy.ndarray
-        Molecular orbital energies.
-    mo_coeff : numpy.ndarray
-        Molecular orbital coefficients.
     moments : numpy.ndarray, optional
         Moments of the dynamic polarizability, if passed then they will
         be used instead of calculating them. Default value is `None`.
@@ -334,8 +328,6 @@ class BSE(Base):
     def kernel(
         self,
         nmom_max,
-        mo_energy=None,
-        mo_coeff=None,
         moments=None,
         integrals=None,
     ):
@@ -345,10 +337,6 @@ class BSE(Base):
         ----------
         nmom_max : int
             Maximum moment number to calculate.
-        mo_energy : numpy.ndarray
-            Molecular orbital energies.
-        mo_coeff : numpy.ndarray
-            Molecular orbital coefficients.
         moments : tuple of numpy.ndarray, optional
             Chebyshev moments of the dynamic polarizability, if passed
             then they will be used instead of calculating them. Default
@@ -359,12 +347,6 @@ class BSE(Base):
         """
 
         timer = util.Timer()
-
-        if mo_coeff is None:
-            mo_coeff = self.mo_coeff
-        if mo_energy is None:
-            mo_energy = self.mo_energy
-
         logging.write("")
         logging.write(f"[bold underline]{self.name}[/]", comment="Solver options")
         logging.write("")
@@ -376,8 +358,6 @@ class BSE(Base):
         with logging.with_status(f"Running {self.name} kernel"):
             self.gf = self._kernel(
                 nmom_max,
-                mo_energy,
-                mo_coeff,
                 integrals=integrals,
                 moments=moments,
             )

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -394,7 +394,7 @@ class BSE(Base):
         table.add_column("Z", justify="right")
 
         # Add EEs
-        for n in range(min(10 if logging.level >= 2 else 5, self.gf.naux)):
+        for n in range(min(5, self.gf.naux)):
             en = self.gf.energies[n]
             vn = self.gf.couplings[:, n]
             weight = np.sum(vn**2)

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -3,13 +3,11 @@ Spin-restricted Bethe-Salpeter equation (BSE) via self-energy moment
 constraints for molecular systems.
 """
 
-import warnings
-
 import numpy as np
 from dyson import CPGF, MBLGF, NullLogger
 from pyscf import lib
 
-from momentGW import mpi_helper, util, logging
+from momentGW import logging, mpi_helper, util
 from momentGW.base import Base
 from momentGW.ints import Integrals
 from momentGW.rpa import dRPA
@@ -399,8 +397,15 @@ class BSE(Base):
         for n in range(min(10 if logging.level >= 2 else 5, self.gf.naux)):
             en = self.gf.energies[n]
             vn = self.gf.couplings[:, n]
-            weight = np.sum(vn ** 2)
-            table.add_row(f"EE {n:>2}", f"{en:.10f}", f"{weight:.5f}", f"{vn[0]:.5f}", f"{vn[1]:.5f}", f"{vn[2]:.5f}")
+            weight = np.sum(vn**2)
+            table.add_row(
+                f"EE {n:>2}",
+                f"{en:.10f}",
+                f"{weight:.5f}",
+                f"{vn[0]:.5f}",
+                f"{vn[1]:.5f}",
+                f"{vn[2]:.5f}",
+            )
 
         # Print table
         logging.debug("")

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -74,7 +74,7 @@ def kernel(
     conv = False
     th_prev = tp_prev = None
     for cycle in range(1, gw.max_cycle + 1):
-        with logging.Status(f"Iteration {cycle}"):
+        with logging.with_status(f"Iteration {cycle}"):
             # Update the moments of the SE
             if moments is not None and cycle == 1:
                 th, tp = moments

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -92,7 +92,7 @@ def kernel(
             try:
                 th, tp = diis.update_with_scaling(np.array((th, tp)), (-2, -1))
             except Exception:
-                logging.debug(f"DIIS step [red]failed[/] at iteration {cycle}")
+                logging.write(f"DIIS step [red]failed[/] at iteration {cycle}")
 
             # Damp the moments
             if gw.damping != 0.0 and cycle > 1:
@@ -112,7 +112,7 @@ def kernel(
             th_prev = th.copy()
             tp_prev = tp.copy()
             with logging.with_comment(f"End of iteration {cycle}"):
-                logging.debug("")
+                logging.write("")
             if conv:
                 break
 
@@ -226,10 +226,6 @@ class evGW(GW):  # noqa: D101
         style_lumo = logging.rate(error_lumo, self.conv_tol, self.conv_tol * 1e2)
         style_th = logging.rate(error_th, self.conv_tol_moms, self.conv_tol_moms * 1e2)
         style_tp = logging.rate(error_tp, self.conv_tol_moms, self.conv_tol_moms * 1e2)
-        # logging.info(f"Change in HOMO: [{style_homo}]{error_homo:.3g}[/]")
-        # logging.info(f"Change in LUMO: [{style_lumo}]{error_lumo:.3g}[/]")
-        # logging.info(f"Change in moments (occ): [{style_th}]{error_th:.3g}[/]")
-        # logging.info(f"Change in moments (vir): [{style_tp}]{error_tp:.3g}[/]")
         table = logging.Table(title="Convergence")
         table.add_column("Sector", justify="right")
         table.add_column("Δ energy", justify="right")
@@ -240,8 +236,8 @@ class evGW(GW):  # noqa: D101
         table.add_row(
             "Particle", f"[{style_lumo}]{error_lumo:.3g}[/]", f"[{style_tp}]{error_tp:.3g}[/]"
         )
-        logging.info("")
-        logging.info(table)
+        logging.write("")
+        logging.write(table)
 
         return self.conv_logical(
             (

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -95,7 +95,7 @@ def kernel(
             try:
                 th, tp = diis.update_with_scaling(np.array((th, tp)), (-2, -1))
             except Exception:
-                logging.write(f"DIIS step [red]failed[/] at iteration {cycle}")
+                logging.warn(f"DIIS step [red]failed[/] at iteration {cycle}")
 
             # Damp the moments
             if gw.damping != 0.0 and cycle > 1:

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -75,6 +75,9 @@ def kernel(
     th_prev = tp_prev = None
     for cycle in range(1, gw.max_cycle + 1):
         with logging.with_status(f"Iteration {cycle}"):
+            with logging.with_comment(f"Start of iteration {cycle}"):
+                logging.write("")
+
             # Update the moments of the SE
             if moments is not None and cycle == 1:
                 th, tp = moments

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -226,10 +226,22 @@ class evGW(GW):  # noqa: D101
         style_lumo = logging.rate(error_lumo, self.conv_tol, self.conv_tol * 1e2)
         style_th = logging.rate(error_th, self.conv_tol_moms, self.conv_tol_moms * 1e2)
         style_tp = logging.rate(error_tp, self.conv_tol_moms, self.conv_tol_moms * 1e2)
-        logging.info(f"Change in HOMO: [{style_homo}]{error_homo:.3g}[/]")
-        logging.info(f"Change in LUMO: [{style_lumo}]{error_lumo:.3g}[/]")
-        logging.info(f"Change in moments (occ): [{style_th}]{error_th:.3g}[/]")
-        logging.info(f"Change in moments (vir): [{style_tp}]{error_tp:.3g}[/]")
+        # logging.info(f"Change in HOMO: [{style_homo}]{error_homo:.3g}[/]")
+        # logging.info(f"Change in LUMO: [{style_lumo}]{error_lumo:.3g}[/]")
+        # logging.info(f"Change in moments (occ): [{style_th}]{error_th:.3g}[/]")
+        # logging.info(f"Change in moments (vir): [{style_tp}]{error_tp:.3g}[/]")
+        table = logging.Table(title="Convergence")
+        table.add_column("Sector", justify="right")
+        table.add_column("Δ energy", justify="right")
+        table.add_column("Δ moments", justify="right")
+        table.add_row(
+            "Hole", f"[{style_homo}]{error_homo:.3g}[/]", f"[{style_th}]{error_th:.3g}[/]"
+        )
+        table.add_row(
+            "Particle", f"[{style_lumo}]{error_lumo:.3g}[/]", f"[{style_tp}]{error_tp:.3g}[/]"
+        )
+        logging.info("")
+        logging.info(table)
 
         return self.conv_logical(
             (

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -13,8 +13,6 @@ from momentGW.gw import GW
 def kernel(
     gw,
     nmom_max,
-    mo_energy,
-    mo_coeff,
     moments=None,
     integrals=None,
 ):
@@ -27,10 +25,6 @@ def kernel(
         GW object.
     nmom_max : int
         Maximum moment number to calculate.
-    mo_energy : numpy.ndarray
-        Molecular orbital energies.
-    mo_coeff : numpy.ndarray
-        Molecular orbital coefficients.
     moments : tuple of numpy.ndarray, optional
         Tuple of (hole, particle) moments, if passed then they will
         be used  as the initial guess instead of calculating them.
@@ -58,18 +52,13 @@ def kernel(
     if integrals is None:
         integrals = gw.ao2mo()
 
-    mo_energy = mo_energy.copy()
-    mo_energy_ref = mo_energy.copy()
+    mo_energy = gw.mo_energy.copy()
 
     diis = util.DIIS()
     diis.space = gw.diis_space
 
     # Get the static part of the SE
-    se_static = gw.build_se_static(
-        integrals,
-        mo_energy=mo_energy,
-        mo_coeff=mo_coeff,
-    )
+    se_static = gw.build_se_static(integrals)
 
     conv = False
     th_prev = tp_prev = None
@@ -86,8 +75,8 @@ def kernel(
                     nmom_max,
                     integrals,
                     mo_energy=dict(
-                        g=mo_energy if not gw.g0 else mo_energy_ref,
-                        w=mo_energy if not gw.w0 else mo_energy_ref,
+                        g=mo_energy if not gw.g0 else gw.mo_energy,
+                        w=mo_energy if not gw.w0 else gw.mo_energy,
                     ),
                 )
 

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -5,7 +5,7 @@ constraints for molecular systems.
 
 import numpy as np
 
-from momentGW import util, logging
+from momentGW import logging, util
 from momentGW.base import BaseGW
 from momentGW.gw import GW
 
@@ -92,7 +92,7 @@ def kernel(
             try:
                 th, tp = diis.update_with_scaling(np.array((th, tp)), (-2, -1))
             except Exception:
-                logger.debug(f"DIIS step [red]failed[/] at iteration {cycle}")
+                logging.debug(f"DIIS step [red]failed[/] at iteration {cycle}")
 
             # Damp the moments
             if gw.damping != 0.0 and cycle > 1:
@@ -220,9 +220,9 @@ class evGW(GW):  # noqa: D101
         error_th = self._moment_error(th, th_prev)
         error_tp = self._moment_error(tp, tp_prev)
 
-        #logger.info(self, "Change in QPs: HOMO = %.6g  LUMO = %.6g", error_homo, error_lumo)
-        #logger.info(self, "Change in moments: occ = %.6g  vir = %.6g", error_th, error_tp)
-        #logger.info(f"Change in HOMO: {error_homo.:.6g}")
+        # logger.info(self, "Change in QPs: HOMO = %.6g  LUMO = %.6g", error_homo, error_lumo)
+        # logger.info(self, "Change in moments: occ = %.6g  vir = %.6g", error_th, error_tp)
+        # logger.info(f"Change in HOMO: {error_homo.:.6g}")
 
         return self.conv_logical(
             (

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -111,6 +111,8 @@ def kernel(
             conv = gw.check_convergence(mo_energy, mo_energy_prev, th, th_prev, tp, tp_prev)
             th_prev = th.copy()
             tp_prev = tp.copy()
+            with logging.with_comment(f"End of iteration {cycle}"):
+                logging.debug("")
             if conv:
                 break
 
@@ -220,9 +222,14 @@ class evGW(GW):  # noqa: D101
         error_th = self._moment_error(th, th_prev)
         error_tp = self._moment_error(tp, tp_prev)
 
-        # logger.info(self, "Change in QPs: HOMO = %.6g  LUMO = %.6g", error_homo, error_lumo)
-        # logger.info(self, "Change in moments: occ = %.6g  vir = %.6g", error_th, error_tp)
-        # logger.info(f"Change in HOMO: {error_homo.:.6g}")
+        style_homo = logging.rate(error_homo, self.conv_tol, self.conv_tol * 1e2)
+        style_lumo = logging.rate(error_lumo, self.conv_tol, self.conv_tol * 1e2)
+        style_th = logging.rate(error_th, self.conv_tol_moms, self.conv_tol_moms * 1e2)
+        style_tp = logging.rate(error_tp, self.conv_tol_moms, self.conv_tol_moms * 1e2)
+        logging.info(f"Change in HOMO: [{style_homo}]{error_homo:.3g}[/]")
+        logging.info(f"Change in LUMO: [{style_lumo}]{error_lumo:.3g}[/]")
+        logging.info(f"Change in moments (occ): [{style_th}]{error_th:.3g}[/]")
+        logging.info(f"Change in moments (vir): [{style_tp}]{error_tp:.3g}[/]")
 
         return self.conv_logical(
             (

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -4,9 +4,8 @@ constraints for molecular systems.
 """
 
 import numpy as np
-from pyscf.lib import logger
 
-from momentGW import util
+from momentGW import util, logging
 from momentGW.base import BaseGW
 from momentGW.gw import GW
 

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -212,6 +212,6 @@ def fock_loop(
                 converged = True
                 break
 
-        logging.debug(table)
+        logging.write(table)
 
     return gf, se, converged

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -199,13 +199,13 @@ def fock_loop(
 
                     rdm1_prev = rdm1.copy()
 
-            nerr_colour = logging.rate(abs(nerr), conv_tol_nelec, conv_tol_nelec * 1e2)
-            derr_colour = logging.rate(derr, conv_tol_rdm1, conv_tol_rdm1 * 1e2)
+            nerr_style = logging.rate(abs(nerr), conv_tol_nelec, conv_tol_nelec * 1e2)
+            derr_style = logging.rate(derr, conv_tol_rdm1, conv_tol_rdm1 * 1e2)
             table.add_row(
                 f"{niter1}",
                 f"{niter2}",
-                f"[{nerr_colour}]{nerr:.3g}[/]",
-                f"[{derr_colour}]{derr:.3g}[/]",
+                f"[{nerr_style}]{nerr:.3g}[/]",
+                f"[{derr_style}]{derr:.3g}[/]",
             )
 
             if derr < conv_tol_rdm1 and abs(nerr) < conv_tol_nelec:

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -148,7 +148,8 @@ def fock_loop(
     if integrals is None:
         integrals = gw.ao2mo()
 
-    h1e = np.linalg.multi_dot((gw.mo_coeff.T, gw._scf.get_hcore(), gw.mo_coeff))
+    with util.SilentSCF(gw._scf):
+        h1e = np.linalg.multi_dot((gw.mo_coeff.T, gw._scf.get_hcore(), gw.mo_coeff))
     nmo = gw.nmo
     nocc = gw.nocc
     naux = se.naux

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -6,9 +6,8 @@ import numpy as np
 import scipy
 from dyson import Lehmann
 from pyscf import lib
-from pyscf.lib import logger
 
-from momentGW import mpi_helper, util
+from momentGW import logging, mpi_helper, util
 
 
 class ChemicalPotentialError(ValueError):
@@ -98,6 +97,8 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
     return se, opt
 
 
+@logging.with_timer("Fock loop")
+@logging.with_status("Running Fock loop")
 def fock_loop(
     gw,
     gf,
@@ -164,46 +165,46 @@ def fock_loop(
     opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner)
     rdm1_prev = 0
 
+    # Initialise the table:
+    table = logging.Table(title="Fock loop")
+    table.add_column("Iter", justify="right")
+    table.add_column("Cycles", justify="right")
+    table.add_column("Error (nelec)", justify="right")
+    table.add_column("Δ (density)", justify="right")
+
     for niter1 in range(1, max_cycle_outer + 1):
-        se, opt = minimize_chempot(se, fock, nelec, x0=se.chempot, **opts)
+        with logging.Status("Optimising chemical potential"):
+            se, opt = minimize_chempot(se, fock, nelec, x0=se.chempot, **opts)
 
         for niter2 in range(1, max_cycle_inner + 1):
-            w, v = se.diagonalise_matrix(fock, chempot=0.0, out=buf)
-            w = mpi_helper.bcast(w, root=0)
-            v = mpi_helper.bcast(v, root=0)
-            se.chempot, nerr = search_chempot(w, v, nmo, nelec)
+            with logging.Status(f"Iteration [{niter1}, {niter2}]"):
+                w, v = se.diagonalise_matrix(fock, chempot=0.0, out=buf)
+                w = mpi_helper.bcast(w, root=0)
+                v = mpi_helper.bcast(v, root=0)
+                se.chempot, nerr = search_chempot(w, v, nmo, nelec)
 
-            w, v = se.diagonalise_matrix(fock, out=buf)
-            w = mpi_helper.bcast(w, root=0)
-            v = mpi_helper.bcast(v, root=0)
-            gf = Lehmann(w, v[:nmo], chempot=se.chempot)
+                w, v = se.diagonalise_matrix(fock, out=buf)
+                w = mpi_helper.bcast(w, root=0)
+                v = mpi_helper.bcast(v, root=0)
+                gf = Lehmann(w, v[:nmo], chempot=se.chempot)
 
-            rdm1 = gf_to_dm(gf)
-            fock = integrals.get_fock(rdm1, h1e)
-            fock = diis.update(fock, xerr=None)
+                rdm1 = gf_to_dm(gf)
+                fock = integrals.get_fock(rdm1, h1e)
+                fock = diis.update(fock, xerr=None)
 
-            if niter2 > 1:
-                derr = np.max(np.absolute(rdm1 - rdm1_prev))
-                if derr < conv_tol_rdm1:
-                    break
+                if niter2 > 1:
+                    derr = np.max(np.absolute(rdm1 - rdm1_prev))
+                    if derr < conv_tol_rdm1:
+                        break
 
-            rdm1_prev = rdm1.copy()
+                rdm1_prev = rdm1.copy()
 
-        logger.debug1(
-            gw, "fock loop %d  cycles = %d  dN = %.3g  |ddm| = %.3g", niter1, niter2, nerr, derr
-        )
+        table.add_row(f"{niter1}", f"{niter2}", f"{nerr:.3g}", f"{derr:.3g}")
 
         if derr < conv_tol_rdm1 and abs(nerr) < conv_tol_nelec:
             converged = True
             break
 
-    logger.info(
-        gw,
-        "fock converged = %s  chempot = %.9g  dN = %.3g  |ddm| = %.3g",
-        converged,
-        se.chempot,
-        nerr,
-        derr,
-    )
+    logging.debug(table)
 
     return gf, se, converged

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -167,7 +167,7 @@ def fock_loop(
     opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner)
     rdm1_prev = 0
 
-    with logging.with_table(title="Fock loop", min_live_level=2) as table:
+    with logging.with_table(title="Fock loop") as table:
         table.add_column("Iter", justify="right")
         table.add_column("Cycles", justify="right")
         table.add_column("Error (nelec)", justify="right")

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -167,7 +167,7 @@ def fock_loop(
     opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner)
     rdm1_prev = 0
 
-    with logging.Table(title="Fock loop", min_live_level=2) as table:
+    with logging.with_table(title="Fock loop", min_live_level=2) as table:
         table.add_column("Iter", justify="right")
         table.add_column("Cycles", justify="right")
         table.add_column("Error (nelec)", justify="right")
@@ -177,7 +177,7 @@ def fock_loop(
             se, opt = minimize_chempot(se, fock, nelec, x0=se.chempot, **opts)
 
             for niter2 in range(1, max_cycle_inner + 1):
-                with logging.Status(f"Iteration [{niter1}, {niter2}]"):
+                with logging.with_status(f"Iteration [{niter1}, {niter2}]"):
                     w, v = se.diagonalise_matrix(fock, chempot=0.0, out=buf)
                     w = mpi_helper.bcast(w, root=0)
                     v = mpi_helper.bcast(v, root=0)

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -201,7 +201,12 @@ def fock_loop(
 
             nerr_colour = logging.rate(abs(nerr), conv_tol_nelec, conv_tol_nelec * 1e2)
             derr_colour = logging.rate(derr, conv_tol_rdm1, conv_tol_rdm1 * 1e2)
-            table.add_row(f"{niter1}", f"{niter2}", f"[{nerr_colour}]{nerr:.3g}[/]", f"[{derr_colour}]{derr:.3g}[/]")
+            table.add_row(
+                f"{niter1}",
+                f"{niter2}",
+                f"[{nerr_colour}]{nerr:.3g}[/]",
+                f"[{derr_colour}]{derr:.3g}[/]",
+            )
 
             if derr < conv_tol_rdm1 and abs(nerr) < conv_tol_nelec:
                 converged = True

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -65,7 +65,7 @@ def kernel(
 
         # Get the core Hamiltonian
         h1e_ao = gw._scf.get_hcore()
-        h1e = util.einsum("...pq,...pi,...qj->...ij", h1e_ao, mo_coeff, np.conj(mo_coeff))
+        h1e = util.einsum("...pq,...pi,...qj->...ij", h1e_ao, np.conj(mo_coeff), mo_coeff)
 
     diis = util.DIIS()
     diis.space = gw.diis_space

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -280,10 +280,9 @@ class GW(BaseGW):  # noqa: D101
 
         error = self.moment_error(se_moments_hole, se_moments_part, se)
         logging.debug(
-            f"Error in moments (occ):  [{logging.rate(error[0], 1e-12, 1e-8)}]{error[0]:.3e}[/]"
-        )
-        logging.debug(
-            f"Error in moments (vir):  [{logging.rate(error[1], 1e-12, 1e-8)}]{error[1]:.3e}[/]"
+            f"Error in moments:  [{logging.rate(sum(error), 1e-12, 1e-8)}]{sum(error):.3e}[/] "
+            f"(hole = [{logging.rate(error[0], 1e-12, 1e-8)}]{error[0]:.3e}[/], "
+            f"particle = [{logging.rate(error[1], 1e-12, 1e-8)}]{error[1]:.3e}[/])"
         )
 
         gf = Lehmann(*se.diagonalise_matrix_with_projection(se_static))

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -371,7 +371,8 @@ class GW(BaseGW):  # noqa: D101
 
     def energy_nuc(self):
         """Calculate the nuclear repulsion energy."""
-        return self._scf.energy_nuc()
+        with util.SilentSCF(self._scf):
+            return self._scf.energy_nuc()
 
     @logging.with_timer("Energy")
     @logging.with_status("Calculating energy")
@@ -398,9 +399,10 @@ class GW(BaseGW):  # noqa: D101
         if integrals is None:
             integrals = self.ao2mo()
 
-        h1e = util.einsum(
-            "pq,pi,qj->ij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff
-        )
+        with util.SilentSCF(self._scf):
+            h1e = util.einsum(
+                "pq,pi,qj->ij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff
+            )
         rdm1 = self.make_rdm1(gf=gf)
         fock = integrals.get_fock(rdm1, h1e)
 

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -301,7 +301,6 @@ class GW(BaseGW):  # noqa: D101
             gf.nphys,
             self.nocc * 2,
         )
-
         se.chempot = cpt
         gf.chempot = cpt
 

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -5,7 +5,6 @@ molecular systems.
 
 import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE, NullLogger
-from pyscf.lib import logger
 
 from momentGW import energy, mpi_helper, thc, util
 from momentGW.base import BaseGW
@@ -261,6 +260,7 @@ class GW(BaseGW):  # noqa: D101
             Self-energy.
         """
 
+        # TODO show output for debug mode
         nlog = NullLogger()
 
         solver_occ = MBLSE(se_static, np.array(se_moments_hole), log=nlog)
@@ -275,8 +275,7 @@ class GW(BaseGW):  # noqa: D101
         if self.optimise_chempot:
             se, opt = minimize_chempot(se, se_static, self.nocc * 2)
 
-        logger.debug(
-            self,
+        self.log.debug(
             "Error in moments: occ = %.6g  vir = %.6g",
             *self.moment_error(se_moments_hole, se_moments_part, se),
         )
@@ -298,17 +297,17 @@ class GW(BaseGW):  # noqa: D101
 
         se.chempot = cpt
         gf.chempot = cpt
-        logger.info(self, "Error in number of electrons: %.5g", error)
+        self.log.info("Error in number of electrons: %.5g", error)
 
         # Calculate energies
         e_1b = self.energy_hf(gf=gf, integrals=integrals) + self.energy_nuc()
         e_2b_g0 = self.energy_gm(se=se, g0=True)
         e_2b = self.energy_gm(gf=gf, se=se, g0=False)
-        logger.info(self, "Energies:")
-        logger.info(self, "  One-body (G0):         %15.10g", self._scf.e_tot)
-        logger.info(self, "  One-body (G):          %15.10g", e_1b)
-        logger.info(self, "  Galitskii-Migdal (G0): %15.10g", e_2b_g0)
-        logger.info(self, "  Galitskii-Migdal (G):  %15.10g", e_2b)
+        self.log.info("Energies:")
+        self.log.info("  One-body (G0):         %15.10g", self._scf.e_tot)
+        self.log.info("  One-body (G):          %15.10g", e_1b)
+        self.log.info("  Galitskii-Migdal (G0): %15.10g", e_2b_g0)
+        self.log.info("  Galitskii-Migdal (G):  %15.10g", e_2b)
 
         return gf, se
 

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -283,8 +283,12 @@ class GW(BaseGW):  # noqa: D101
                 se, opt = minimize_chempot(se, se_static, self.nocc * 2)
 
         error = self.moment_error(se_moments_hole, se_moments_part, se)
-        logging.debug(f"Error in moments (occ):  [{logging.rate(error[0], 1e-12, 1e-8)}]{error[0]:.3e}[/]")
-        logging.debug(f"Error in moments (vir):  [{logging.rate(error[1], 1e-12, 1e-8)}]{error[1]:.3e}[/]")
+        logging.debug(
+            f"Error in moments (occ):  [{logging.rate(error[0], 1e-12, 1e-8)}]{error[0]:.3e}[/]"
+        )
+        logging.debug(
+            f"Error in moments (vir):  [{logging.rate(error[1], 1e-12, 1e-8)}]{error[1]:.3e}[/]"
+        )
 
         gf = Lehmann(*se.diagonalise_matrix_with_projection(se_static))
         gf.energies = mpi_helper.bcast(gf.energies, root=0)

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -190,6 +190,7 @@ class GW(BaseGW):  # noqa: D101
         else:
             raise NotImplementedError
 
+    @logging.with_timer("Integral construction")
     @logging.with_status("Constructing integrals")
     def ao2mo(self, transform=True):
         """Get the integrals object.

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -296,8 +296,10 @@ class GW(BaseGW):  # noqa: D101
         gf.chempot = se.chempot
 
         if self.fock_loop:
+            logging.debug("")
             with logging.Status("Running Fock loop"):
                 gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
+            logging.debug("")
             logging.time("Fock loop", timer())
 
         cpt, error = search_chempot(

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -279,7 +279,7 @@ class GW(BaseGW):  # noqa: D101
                 se, opt = minimize_chempot(se, se_static, self.nocc * 2)
 
         error = self.moment_error(se_moments_hole, se_moments_part, se)
-        logging.debug(
+        logging.write(
             f"Error in moments:  [{logging.rate(sum(error), 1e-12, 1e-8)}]{sum(error):.3e}[/] "
             f"(hole = [{logging.rate(error[0], 1e-12, 1e-8)}]{error[0]:.3e}[/], "
             f"particle = [{logging.rate(error[1], 1e-12, 1e-8)}]{error[1]:.3e}[/])"
@@ -291,10 +291,9 @@ class GW(BaseGW):  # noqa: D101
         gf.chempot = se.chempot
 
         if self.fock_loop:
-            logging.debug("")
+            logging.write("")
             with logging.with_status("Running Fock loop"):
                 gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
-            logging.debug("")
 
         cpt, error = search_chempot(
             gf.energies,
@@ -306,13 +305,14 @@ class GW(BaseGW):  # noqa: D101
         se.chempot = cpt
         gf.chempot = cpt
 
-        logging.info(f"Chemical potential:  {cpt:.6f}")
+        logging.write("")
         color = logging.rate(
             abs(error),
             1e-6,
             1e-6 if self.fock_loop or self.optimise_chempot else 1e-1,
         )
-        logging.info(f"Error in number of electrons:  [{color}]{error:.3e}[/]")
+        logging.write(f"Error in number of electrons:  [{color}]{error:.3e}[/]")
+        logging.write(f"Chemical potential:  {cpt:.6f}")
 
         return gf, se
 

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -264,9 +264,7 @@ class GW(BaseGW):  # noqa: D101
             Self-energy.
         """
 
-        timer = util.Timer()
-
-        with logging.Status("Solving Dyson equation"):
+        with logging.with_modifiers(status="Solving Dyson equation", timer="Dyson equation"):
             solver_occ = MBLSE(se_static, np.array(se_moments_hole), log=NullLogger())
             solver_occ.kernel()
 
@@ -276,10 +274,8 @@ class GW(BaseGW):  # noqa: D101
             solver = MixedMBLSE(solver_occ, solver_vir)
             se = solver.get_self_energy()
 
-            logging.time("Dyson equation", timer())
-
         if self.optimise_chempot:
-            with logging.Status("Optimising chemical potential"):
+            with logging.with_status("Optimising chemical potential"):
                 se, opt = minimize_chempot(se, se_static, self.nocc * 2)
 
         error = self.moment_error(se_moments_hole, se_moments_part, se)
@@ -297,7 +293,7 @@ class GW(BaseGW):  # noqa: D101
 
         if self.fock_loop:
             logging.debug("")
-            with logging.Status("Running Fock loop"):
+            with logging.with_status("Running Fock loop"):
                 gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
             logging.debug("")
 

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -306,12 +306,12 @@ class GW(BaseGW):  # noqa: D101
         gf.chempot = cpt
 
         logging.write("")
-        color = logging.rate(
+        style = logging.rate(
             abs(error),
             1e-6,
             1e-6 if self.fock_loop or self.optimise_chempot else 1e-1,
         )
-        logging.write(f"Error in number of electrons:  [{color}]{error:.3e}[/]")
+        logging.write(f"Error in number of electrons:  [{style}]{error:.3e}[/]")
         logging.write(f"Chemical potential:  {cpt:.6f}")
 
         return gf, se

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -194,9 +194,10 @@ class Integrals:
             rot = None
         else:
             percent = 100 * rot.shape[-1] / self.naux_full
-            percent = f"[{'green' if percent < 80 else 'red'}]{percent:.1f}%[/]"
+            style = logging.rate(percent, 80, 95)
             logging.info(
-                f"Compressed auxiliary space from {self.naux_full} to {rot.shape[1]} ({percent})"
+                f"Compressed auxiliary space from {self.naux_full} to {rot.shape[1]} "
+                f"([{style}]{percent:.1f}%)[/]"
             )
 
         return rot

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -190,12 +190,12 @@ class Integrals:
         rot = mpi_helper.bcast(rot, root=0)
 
         if rot.shape[-1] == self.naux_full:
-            logging.info("No compression found for auxiliary space")
+            logging.write("No compression found for auxiliary space")
             rot = None
         else:
             percent = 100 * rot.shape[-1] / self.naux_full
             style = logging.rate(percent, 80, 95)
-            logging.info(
+            logging.write(
                 f"Compressed auxiliary space from {self.naux_full} to {rot.shape[1]} "
                 f"([{style}]{percent:.1f}%)[/]"
             )

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -123,7 +123,6 @@ class Integrals:
 
         return compression
 
-    @logging.with_timer("Compression metric")
     @logging.with_status("Computing compression metric")
     def get_compression_metric(self):
         """
@@ -203,7 +202,6 @@ class Integrals:
         return rot
 
     @require_compression_metric()
-    @logging.with_timer("Integral transformation")
     @logging.with_status("Transforming integrals")
     def transform(self, do_Lpq=None, do_Lpx=True, do_Lia=True):
         """

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -142,7 +142,7 @@ class Integrals:
 
         # Loop over required blocks
         for key in sorted(compression):
-            with logging.Status(f"{key} sector"):
+            with logging.with_status(f"{key} sector"):
                 ci, cj = [
                     {
                         "o": self.mo_coeff[:, self.mo_occ > 0],
@@ -164,7 +164,7 @@ class Integrals:
                     for block in self.with_df.loop():
                         b0, b1 = b1, b1 + block.shape[0]
                         progress = (p0 * self.naux_full + b0) / (ni * nj * self.naux_full)
-                        with logging.Status(f"block [{p0}:{p1}, {b0}:{b1}] ({progress:.1%})"):
+                        with logging.with_status(f"block [{p0}:{p1}, {b0}:{b1}] ({progress:.1%})"):
                             tmp = _ao2mo.nr_e2(
                                 block,
                                 coeffs,
@@ -245,7 +245,7 @@ class Integrals:
             b0, b1 = b1, b1 + block.shape[0]
 
             progress = b1 / self.naux_full
-            with logging.Status(f"block [{b0}:{b1}] ({progress:.1%})"):
+            with logging.with_status(f"block [{b0}:{b1}] ({progress:.1%})"):
                 # If needed, rotate the full (L|pq) array
                 if do_Lpq:
                     _ao2mo.nr_e2(

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -37,7 +37,7 @@ console = Console(
     theme=theme,
 )
 
-silent = os.environ.get("MOMENTGW_QUIET", "0") == "1"
+silent = os.environ.get("MOMENTGW_SILENT", "0") == "1"
 
 LIVE = None
 STATUS = None

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -3,7 +3,6 @@
 import contextlib
 import os
 import subprocess
-import sys
 
 import rich
 from rich.console import Console
@@ -251,19 +250,6 @@ def init_logging():
             git_hash = "N/A"
         return git_hash
 
-    def get_pip_version(module_name):
-        """Get the version of a module installed with pip."""
-        cmd = [sys.executable, "-m", "pip", "show", module_name]
-        try:
-            pip_version = (
-                subprocess.check_output(cmd, universal_newlines=True, stderr=subprocess.STDOUT)
-                .split("\n")[1]
-                .split(": ")[1]
-            )
-        except subprocess.CalledProcessError:
-            pip_version = "N/A"
-        return pip_version
-
     import dyson
     import h5py
     import numpy
@@ -275,13 +261,7 @@ def init_logging():
 
     for module in (numpy, scipy, h5py, pyscf, dyson, rich, momentGW):
         write(f"[bold]{module.__name__}:[/]")
-        if hasattr(module, "__version__"):
-            write(f" > Version:  {module.__version__}")
-        else:
-            write(
-                " > Version:  %s",
-                get_pip_version(module.__name__.split(".")[0]),
-            )
+        write(f" > Version:  {getattr(module, '__version__', 'N/A')}")
         write(
             " > Git hash: %s",
             get_git_hash(os.path.join(os.path.dirname(module.__file__), "..")),

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -172,6 +172,7 @@ class Table(_Table):
         kwargs["header_style"] = kwargs.get("header_style", "")
         kwargs["box"] = kwargs.get("box", rich.box.SIMPLE)
         kwargs["padding"] = kwargs.get("padding", (0, 2))
+        kwargs["collapse_padding"] = kwargs.get("collapse_padding", True)
 
         super().__init__(*args, **kwargs)
 

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -307,9 +307,40 @@ def with_status(task_name):
 
 
 @contextlib.contextmanager
+def with_table(**kwargs):
+    """Run a function with a table."""
+    table = Table(**kwargs)
+    yield table
+
+
+@contextlib.contextmanager
 def with_comment(comment):
     """Run a function with a comment."""
     global COMMENT
     COMMENT = comment
     yield
     COMMENT = ""
+
+
+@contextlib.contextmanager
+def with_log_level(new_level):
+    """Run a function with a new log level."""
+    old_level = level
+    set_log_level(new_level)
+    yield
+    set_log_level(old_level)
+
+
+@contextlib.contextmanager
+def with_modifiers(**kwargs):
+    """Run a function with modified logging."""
+    functions = {
+        "log_level": with_log_level,
+        "status": with_status,
+        "timer": with_timer,
+        "comment": with_comment,
+    }
+    with contextlib.ExitStack() as stack:
+        for key, value in kwargs.items():
+            stack.enter_context(functions[key](value))
+        yield

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -27,7 +27,7 @@ theme = Theme(
         "bad": "red",
         "option": "bold cyan",
         "output": "bold blue",
-        "comment": "italic dim",
+        "comment": "dim",
     }
 )
 
@@ -61,9 +61,11 @@ def write(msg, *args, **kwargs):
 
     # See if the message has a comment
     if comment := (kwargs.pop("comment", None) or COMMENT):
-        if isinstance(comment, str):
-            space = console.width - len(msg) - len(comment)
-            msg = f"{msg}{space * ' '}[comment]{comment}[/]"
+        table = _Table.grid(expand=True)
+        table.add_column("", justify="left")
+        table.add_column("", justify="right", style="comment")
+        table.add_row(msg, comment)
+        msg = table
 
     # Print the message
     console.print(msg, **kwargs)

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -250,6 +250,8 @@ def init_logging():
             git_hash = "N/A"
         return git_hash
 
+    import momentGW
+
     import dyson
     import h5py
     import numpy
@@ -257,9 +259,12 @@ def init_logging():
     import rich
     import scipy
 
-    import momentGW
+    packages = [numpy, scipy, h5py, pyscf, dyson, rich, momentGW]
+    if mpi_helper.mpi is not None:
+        import mpi4py
+        packages.append(mpi4py)
 
-    for module in (numpy, scipy, h5py, pyscf, dyson, rich, momentGW):
+    for module in packages:
         write(f"[bold]{module.__name__}:[/]")
         write(f" > Version:  {getattr(module, '__version__', 'N/A')}")
         write(

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -3,6 +3,7 @@
 import functools
 import os
 import subprocess
+import contextlib
 
 import rich
 from rich.console import Console
@@ -37,6 +38,13 @@ console = Console(
 
 level = int(os.environ.get("MOMENTGW_LOG_LEVEL", "3"))
 
+LIVE = None
+STATUS = None
+STATUS_MSGS = []
+TABLE = None
+LAYOUT = None
+COMMENT = ""
+
 
 def set_log_level(new_level):
     """Set the logging level."""
@@ -52,7 +60,7 @@ def write(msg, *args, **kwargs):
         msg = msg % args
 
     # See if the message has a comment
-    if comment := kwargs.pop("comment", None):
+    if comment := (kwargs.pop("comment", None) or COMMENT):
         if isinstance(comment, str):
             space = console.width - len(msg) - len(comment)
             msg = f"{msg}{space * ' '}[dim]{comment}[/]"
@@ -101,151 +109,6 @@ def rate(value, good_threshold, ok_threshold, invert=False):
     else:
         rating = "bad" if not invert else "good"
     return rating
-
-
-# Global variables for live logging:
-
-LIVE = None
-STATUS = None
-STATUS_MSGS = []
-TABLE = None
-
-
-def _update_live():
-    """Update the live log.
-
-    Notes
-    -----
-    The live log can have a status spinner and/or an updating table.
-    The `Live` object is created with `transient=True`, so it will be
-    removed from the display after the context manager is exited.
-    """
-
-    global LIVE
-
-    if not LIVE and (STATUS or TABLE):
-        # There is no live log, but there is a status spinner and/or
-        # table waiting to be displayed
-        layout = _Table.grid()
-        if TABLE:
-            layout.add_row(TABLE)
-        if STATUS:
-            layout.add_row(STATUS)
-        LIVE = Live(layout, console=console, transient=True)
-        LIVE.start()
-
-    elif LIVE and (STATUS or TABLE):
-        # There is a live log, but it may need to be updated
-        layout = _Table.grid()
-        if TABLE:
-            layout.add_row(TABLE)
-        if STATUS:
-            layout.add_row(STATUS)
-        console.clear_live()
-        LIVE.update(layout)
-
-    elif LIVE and not (STATUS or TABLE):
-        # There is a live log, but there is no status spinner or table
-        LIVE.refresh()
-        LIVE.stop()
-        LIVE = None
-        console.clear_live()
-
-
-class Status:
-    """A status spinner with nested status messages."""
-
-    def __init__(self, msg, *args, **kwargs):
-        self.msg = msg
-
-    def __enter__(self):
-        """Enter the context manager."""
-        if level >= 1:
-            global LIVE, STATUS, STATUS_MSGS
-            if STATUS is None:
-                STATUS_MSGS = [self.msg]
-                STATUS = _Status(self.msg, console=console)
-            else:
-                STATUS_MSGS.append(self.msg)
-                STATUS.update(" > ".join(STATUS_MSGS))
-            _update_live()
-        return LIVE
-
-    def __exit__(self, *args):
-        """Exit the context manager."""
-        if level >= 1:
-            global LIVE, STATUS, STATUS_MSGS
-            STATUS_MSGS = STATUS_MSGS[:-1]
-            if not STATUS_MSGS:
-                STATUS = None
-            else:
-                STATUS.update(" > ".join(STATUS_MSGS))
-            _update_live()
-
-
-class Table(_Table):
-    """A table with additional context manager methods.
-
-    Notes
-    -----
-    Since the `Live` object is created with `transient=True`, tables
-    using the context manager will be removed from the display after
-    the context manager is exited. Tables should be manually printed
-    to the console if they are required to be displayed afterwards.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs["show_edge"] = kwargs.get("show_edge", False)
-        kwargs["show_header"] = kwargs.get("show_header", True)
-        kwargs["expand"] = kwargs.get("expand", False)
-        kwargs["title_style"] = kwargs.get("title_style", "bold")
-        kwargs["header_style"] = kwargs.get("header_style", "")
-        kwargs["box"] = kwargs.get("box", rich.box.SIMPLE)
-        kwargs["padding"] = kwargs.get("padding", (0, 2))
-
-        self.min_live_level = kwargs.pop("min_live_level", 1)
-
-        super().__init__(*args, **kwargs)
-
-    def __enter__(self):
-        """Enter the context manager."""
-        if level >= self.min_live_level:
-            global LIVE, TABLE
-            TABLE = self
-            _update_live()
-        return self
-
-    def __exit__(self, *args):
-        """Exit the context manager."""
-        if level >= self.min_live_level:
-            global LIVE, TABLE
-            TABLE = None
-            _update_live()
-
-    def add_column(self, *args, **kwargs):
-        """Add a column to the table."""
-        super().add_column(*args, **kwargs)
-        if level >= self.min_live_level and TABLE is self:
-            _update_live()
-
-    add_column.__doc__ = _Table.add_column.__doc__
-
-    def add_row(self, *args, **kwargs):
-        """Add a row to the table."""
-        super().add_row(*args, **kwargs)
-        if level >= self.min_live_level and TABLE is self:
-            _update_live()
-
-    add_row.__doc__ = _Table.add_row.__doc__
-
-
-# Global variables for live logging:
-
-LIVE = None
-STATUS = None
-STATUS_MSGS = []
-TABLE = None
-LAYOUT = None
 
 
 def _update_live():
@@ -428,31 +291,25 @@ def init_logging():
     globals()["_MOMENTGW_LOG_INITIALISED"] = True
 
 
+@contextlib.contextmanager
 def with_timer(task_name):
     """Run a function with a timer."""
-
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            timer = util.Timer()
-            result = func(*args, **kwargs)
-            time(task_name, timer())
-            return result
-
-        return wrapper
-
-    return decorator
+    timer = util.Timer()
+    yield
+    time(task_name, timer())
 
 
+@contextlib.contextmanager
 def with_status(task_name):
     """Run a function with a status spinner."""
+    with Status(task_name):
+        yield
 
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            with Status(task_name):
-                return func(*args, **kwargs)
 
-        return wrapper
-
-    return decorator
+@contextlib.contextmanager
+def with_comment(comment):
+    """Run a function with a comment."""
+    global COMMENT
+    COMMENT = comment
+    yield
+    COMMENT = ""

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -28,6 +28,7 @@ theme = Theme(
         "bad": "red",
         "option": "bold cyan",
         "output": "bold blue",
+        "comment": "italic dim",
     }
 )
 
@@ -63,7 +64,7 @@ def write(msg, *args, **kwargs):
     if comment := (kwargs.pop("comment", None) or COMMENT):
         if isinstance(comment, str):
             space = console.width - len(msg) - len(comment)
-            msg = f"{msg}{space * ' '}[dim]{comment}[/]"
+            msg = f"{msg}{space * ' '}[comment]{comment}[/]"
 
     # Print the message
     console.print(msg, **kwargs)

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -101,7 +101,7 @@ class Status(_Status):
             self.__class__._status.__enter__()
             import time as _time
 
-            _time.sleep(0.1)
+            _time.sleep(0.2)
         return self
 
     def __exit__(self, *args):

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -288,7 +288,8 @@ def init_logging():
         )
 
     # Environment variables
-    write(f"[bold]OpenMP threads[/]: {os.environ.get('OMP_NUM_THREADS', 1)}")
+    threads = os.environ.get("OMP_NUM_THREADS", 1)
+    write(f"[bold]OpenMP threads[/]: {threads if threads else 1}")
     write(f"[bold]MPI rank[/]: {mpi_helper.rank} of {mpi_helper.size}")
 
     globals()["_MOMENTGW_LOG_INITIALISED"] = True

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -179,7 +179,7 @@ class Table(_Table):
             global LIVE, TABLE
             TABLE = self
             _update_live()
-        return LIVE
+        return self
 
     def __exit__(self, *args):
         """Exit the context manager."""

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -305,9 +305,10 @@ def with_comment(comment):
 def with_silent():
     """Run a function silently."""
     global silent
+    old_silent = silent
     silent = True
     yield
-    silent = False
+    silent = old_silent
 
 
 @contextlib.contextmanager

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -2,9 +2,11 @@
 
 import logging
 import os
+import subprocess
+import sys
+from types import SimpleNamespace
 
-from momentGW import __version__
-from momentGW import mpi_helper
+from momentGW import __version__, mpi_helper
 
 HEADER = """                                       _    ______        __
   _ __ ___   ___  _ __ ___   ___ _ __ | |_ / ___\ \      / /
@@ -60,9 +62,9 @@ def init_logging(log):
             git_hash = "N/A"
         return git_hash
 
+    import dyson
     import numpy
     import pyscf
-    import dyson
 
     log.info("numpy:")
     log.info(" > Version:  %s" % numpy.__version__)
@@ -100,7 +102,7 @@ def _check_output(*args, **kwargs):
         return bytes()
 
 
-ANSI = Namespace(
+ANSI = SimpleNamespace(
     B="\x1b[1m",
     H="\x1b[3m",
     R="\x1b[m\x0f",

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -1,9 +1,8 @@
 """Logging."""
 
-import functools
+import contextlib
 import os
 import subprocess
-import contextlib
 
 import rich
 from rich.console import Console

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -33,7 +33,7 @@ Table = functools.partial(
     padding=(0, 2),
 )
 
-level = int(os.environ.get("MOMENTGW_LOG_LEVEL", "1"))
+level = int(os.environ.get("MOMENTGW_LOG_LEVEL", "3"))
 
 
 def set_log_level(new_level):
@@ -57,7 +57,7 @@ def _write(msg, required_level, *args, **kwargs):
 
 def output(msg, *args, **kwargs):
     """Print an output message."""
-    _write(msg, 0, *args, **kwargs)
+    _write(msg, 1, *args, **kwargs)
 
 
 def warning(msg, *args, **kwargs):
@@ -72,12 +72,12 @@ def error(msg, *args, **kwargs):
 
 def info(msg, *args, **kwargs):
     """Print an info message."""
-    _write(msg, 1, *args, **kwargs)
+    _write(msg, 2, *args, **kwargs)
 
 
 def debug(msg, *args, **kwargs):
     """Print a debug message."""
-    _write(msg, 2, *args, **kwargs)
+    _write(msg, 3, *args, **kwargs)
 
 
 class Status(_Status):
@@ -132,7 +132,7 @@ def dump_times():
         table.add_column("Time", justify="right")
         for msg, elapsed in time._times.items():
             table.add_row(msg, util.Timer.format_time(elapsed))
-        output("")
+        debug("")
         output(table)
 
 
@@ -173,8 +173,6 @@ def init_logging():
     # Environment variables
     info("[bold]OMP_NUM_THREADS[/] = %s" % os.environ.get("OMP_NUM_THREADS", ""))
     info("[bold]MPI rank[/] = %d of %d" % (mpi_helper.rank, mpi_helper.size))
-
-    debug("")
 
     globals()["_MOMENTGW_LOG_INITIALISED"] = True
 

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -301,6 +301,15 @@ def with_comment(comment):
 
 
 @contextlib.contextmanager
+def with_silent():
+    """Run a function silently."""
+    global silent
+    silent = True
+    yield
+    silent = False
+
+
+@contextlib.contextmanager
 def with_modifiers(**kwargs):
     """Run a function with modified logging."""
     functions = {

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -4,9 +4,9 @@ conditions.
 """
 
 import numpy as np
-from pyscf.lib import logger
 from pyscf.pbc.mp.kmp2 import get_frozen_mask, get_nmo, get_nocc
 
+from momentGW import logging
 from momentGW.base import BaseGW
 from momentGW.pbc.kpts import KPoints
 
@@ -62,91 +62,52 @@ class BaseKGW(BaseGW):
     ]
 
     def __init__(self, mf, **kwargs):
-        self._scf = mf
-        self.verbose = self.mol.verbose
-        self.stdout = self.mol.stdout
-        self.max_memory = 1e10
+        super().__init__(mf, **kwargs)
 
-        for key, val in kwargs.items():
-            if not hasattr(self, key):
-                raise AttributeError("%s has no attribute %s", self.name, key)
-            setattr(self, key, val)
+        # Options
+        self.fc = False
 
-        # Do not modify:
-        self.mo_energy = np.asarray(mf.mo_energy)
-        self.mo_coeff = np.asarray(mf.mo_coeff)
-        self.mo_occ = np.asarray(mf.mo_occ)
-        self.frozen = None
-        self._nocc = None
-        self._nmo = None
+        # Attributes
         self._kpts = KPoints(self.cell, getattr(mf, "kpts", np.zeros((1, 3))))
-        self.converged = None
-        self.se = None
-        self.gf = None
-        self._qp_energy = None
 
-        self._keys = set(self.__dict__.keys()).union(self._opts)
+    def _get_excitations_table(self):
+        """Return the excitations as a table."""
 
-    def kernel(
-        self,
-        nmom_max,
-        mo_energy=None,
-        mo_coeff=None,
-        moments=None,
-        integrals=None,
-    ):
-        """Driver for the method.
-
-        Parameters
-        ----------
-        nmom_max : int
-            Maximum moment number to calculate.
-        mo_energy : numpy.ndarray
-            Molecular orbital energies at each k-point.
-        mo_coeff : numpy.ndarray
-            Molecular orbital coefficients at each k-point.
-        moments : tuple of numpy.ndarray, optional
-            Tuple of (hole, particle) moments at each k-point, if passed
-            then they will be used instead of calculating them. Default
-            value is `None`.
-        integrals : KIntegrals, optional
-            Integrals object. If `None`, generate from scratch. Default
-            value is `None`.
-        """
-
-        if mo_coeff is None:
-            mo_coeff = self.mo_coeff
-        if mo_energy is None:
-            mo_energy = self.mo_energy
-
-        cput0 = (logger.process_clock(), logger.perf_counter())
-        self.dump_flags()
-        logger.info(self, "nmom_max = %d", nmom_max)
-
-        self.converged, self.gf, self.se, self._qp_energy = self._kernel(
-            nmom_max,
-            mo_energy,
-            mo_coeff,
-            integrals=integrals,
-        )
-
+        # Separate the occupied and virtual GFs
         gf_occ = self.gf[0].occupied().physical(weight=1e-1)
-        for n in range(min(5, gf_occ.naux)):
-            en = -gf_occ.energies[-(n + 1)]
-            vn = gf_occ.couplings[:, -(n + 1)]
-            qpwt = np.linalg.norm(vn) ** 2
-            logger.note(self, "IP energy level (Γ) %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
-
         gf_vir = self.gf[0].virtual().physical(weight=1e-1)
-        for n in range(min(5, gf_vir.naux)):
+
+        # Build table
+        table = logging.Table(title="Green's function poles")
+        table.add_column("Excitation", justify="right")
+        table.add_column("Energy", justify="right", style="output")
+        table.add_column("QP weight", justify="right")
+        table.add_column("Dominant MOs", justify="right")
+
+        # Add IPs
+        for n in range(min(3, gf_occ.naux)):
+            en = -gf_occ.energies[-(n + 1)]
+            weights = np.real(gf_occ.couplings[:, -(n + 1)] * gf_occ.couplings[:, -(n + 1)].conj())
+            weight = np.sum(weights)
+            dominant = np.argsort(weights)[::-1]
+            dominant = dominant[weights[dominant] > 0.1][:3]
+            mo_string = ", ".join([f"{i} ({100 * weights[i] / weight:5.1f}%)" for i in dominant])
+            table.add_row(f"IP (Γ) {n:>2}", f"{en:.10f}", f"{weight:.5f}", mo_string)
+
+        # Add a break
+        table.add_section()
+
+        # Add EAs
+        for n in range(min(3, gf_vir.naux)):
             en = gf_vir.energies[n]
-            vn = gf_vir.couplings[:, n]
-            qpwt = np.linalg.norm(vn) ** 2
-            logger.note(self, "EA energy level (Γ) %d E = %.16g  QP weight = %0.6g", n, en, qpwt)
+            weights = np.real(gf_vir.couplings[:, n] * gf_vir.couplings[:, n].conj())
+            weight = np.sum(weights)
+            dominant = np.argsort(weights)[::-1]
+            dominant = dominant[weights[dominant] > 0.1][:3]
+            mo_string = ", ".join([f"{i} ({100 * weights[i] / weight:5.1f}%)" for i in dominant])
+            table.add_row(f"EA (Γ) {n:>2}", f"{en:.10f}", f"{weight:.5f}", mo_string)
 
-        logger.timer(self, self.name, *cput0)
-
-        return self.converged, self.gf, self.se, self.qp_energy
+        return table
 
     @staticmethod
     def _gf_to_occ(gf):
@@ -186,7 +147,8 @@ class BaseKGW(BaseGW):
                 check.add(arg)
 
             if len(check) != self.nmo:
-                logger.warn(self, f"Inconsistent quasiparticle weights at k-point {k}!")
+                # TODO improve this warning
+                logging.warn(f"[bad]Inconsistent quasiparticle weights at k-point {k}![/]")
 
         return mo_energy
 

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -7,7 +7,7 @@ import numpy as np
 from pyscf.pbc.mp.kmp2 import get_frozen_mask, get_nmo, get_nocc
 
 from momentGW import logging
-from momentGW.base import BaseGW
+from momentGW.base import Base, BaseGW
 from momentGW.pbc.kpts import KPoints
 
 
@@ -69,6 +69,32 @@ class BaseKGW(BaseGW):
 
         # Attributes
         self._kpts = KPoints(self.cell, getattr(mf, "kpts", np.zeros((1, 3))))
+
+    def _get_header(self):
+        """
+        Get the header for the solver, with the name, options, and
+        problem size.
+        """
+
+        # Get the options table
+        options = Base._get_header(self)
+
+        # Get the problem size table
+        sizes = logging.Table(title="Sizes")
+        sizes.add_column("Space", justify="right")
+        sizes.add_column("Size (Γ)", justify="right")
+        sizes.add_row("MOs", f"{self.nmo}")
+        sizes.add_row("Occupied MOs", f"{self.nocc[0]}")
+        sizes.add_row("Virtual MOs", f"{self.nmo - self.nocc[0]}")
+        sizes.add_row("k-points", f"{self.kpts.kmesh} = {self.nkpts}")
+
+        # Combine the tables
+        panel = logging.Table.grid()
+        panel.add_row(options)
+        panel.add_row("")
+        panel.add_row(sizes)
+
+        return panel
 
     def _get_excitations_table(self):
         """Return the excitations as a table."""

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -246,7 +246,7 @@ def fock_loop(
     buf = np.zeros((max(nqmo), max(nqmo)), dtype=complex)
     converged = False
     opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner)
-    rdm1_prev = 0
+    rdm1_prev = rdm1
 
     for niter1 in range(1, max_cycle_outer + 1):
         se, opt = minimize_chempot(se, fock, sum(nelec), x0=se[0].chempot, **opts)
@@ -266,10 +266,9 @@ def fock_loop(
             fock = integrals.get_fock(rdm1, h1e)
             fock = diis.update(fock, xerr=None)
 
-            if niter2 > 1:
-                derr = np.max(np.absolute(rdm1 - rdm1_prev))
-                if derr < conv_tol_rdm1:
-                    break
+            derr = np.max(np.absolute(rdm1 - rdm1_prev))
+            if derr < conv_tol_rdm1:
+                break
 
             rdm1_prev = rdm1.copy()
 

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -222,7 +222,13 @@ def fock_loop(
     if integrals is None:
         integrals = gw.ao2mo()
 
-    h1e = util.einsum("kpq,kpi,kqj->kij", gw._scf.get_hcore(), np.conj(gw.mo_coeff), gw.mo_coeff)
+    with util.SilentSCF(gw._scf):
+        h1e = util.einsum(
+            "kpq,kpi,kqj->kij",
+            gw._scf.get_hcore(),
+            np.conj(gw.mo_coeff),
+            gw.mo_coeff,
+        )
     nmo = gw.nmo
     nocc = gw.nocc
     naux = [s.naux for s in se]

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -241,9 +241,10 @@ class KGW(BaseKGW, GW):  # noqa: D101
         if integrals is None:
             integrals = self.ao2mo()
 
-        h1e = util.einsum(
-            "kpq,kpi,kqj->kij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff
-        )
+        with util.SilentSCF(self._scf):
+            h1e = util.einsum(
+                "kpq,kpi,kqj->kij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff
+            )
         rdm1 = self.make_rdm1()
         fock = integrals.get_fock(rdm1, h1e)
 

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -189,6 +189,9 @@ class KGW(BaseKGW, GW):  # noqa: D101
         w = [g.energies for g in gf]
         v = [g.couplings for g in gf]
         cpt, error = search_chempot(w, v, self.nmo, sum(self.nocc) * 2)
+        for g, s in zip(gf, se):
+            g.chempot = cpt
+            s.chempot = cpt
 
         logging.write("")
         style = logging.rate(
@@ -199,7 +202,7 @@ class KGW(BaseKGW, GW):  # noqa: D101
         logging.write(f"Error in number of electrons:  [{style}]{error:.3e}[/]")
         logging.write(f"Chemical potential (Γ):  {cpt:.6f}")
 
-        return gf, se
+        return tuple(gf), tuple(se)
 
     def make_rdm1(self, gf=None):
         """Get the first-order reduced density matrix.
@@ -302,6 +305,8 @@ class KGW(BaseKGW, GW):  # noqa: D101
 
         return e_2b.real
 
+    @logging.with_timer("Interpolation")
+    @logging.with_status("Interpolating in k-space")
     def interpolate(self, mf, nmom_max):
         """
         Interpolate the object to a new k-point grid, represented by a

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -8,12 +8,11 @@ import h5py
 import numpy as np
 from pyscf import lib
 from pyscf.ao2mo import _ao2mo
-from pyscf.lib import logger
 from pyscf.pbc import tools
 from scipy.linalg import cholesky
 
-from momentGW import mpi_helper, util
-from momentGW.ints import Integrals
+from momentGW import logging, mpi_helper, util
+from momentGW.ints import Integrals, require_compression_metric
 
 
 class KIntegrals(Integrals):
@@ -60,12 +59,14 @@ class KIntegrals(Integrals):
             store_full=store_full,
         )
 
-        self.kpts = kpts
-
-        self._madelung = None
-
+        # Options
         self.input_path = input_path
 
+        # Attributes
+        self.kpts = kpts
+        self._madelung = None
+
+    @logging.with_status("Computing compression metric")
     def get_compression_metric(self):
         """
         Return the compression metric.
@@ -82,45 +83,44 @@ class KIntegrals(Integrals):
         if not compression:
             return None
 
-        cput0 = (logger.process_clock(), logger.perf_counter())
-        logger.info(self, f"Computing compression metric for {self.__class__.__name__}")
-
         prod = np.zeros((len(self.kpts), self.naux_full, self.naux_full), dtype=complex)
 
         # Loop over required blocks
         for key in sorted(compression):
-            logger.debug(self, f"Transforming {key} block")
-            ci, cj = [
-                {
-                    "o": [c[:, o > 0] for c, o in zip(self.mo_coeff, self.mo_occ)],
-                    "v": [c[:, o == 0] for c, o in zip(self.mo_coeff, self.mo_occ)],
-                    "i": [c[:, o > 0] for c, o in zip(self.mo_coeff_w, self.mo_occ_w)],
-                    "a": [c[:, o == 0] for c, o in zip(self.mo_coeff_w, self.mo_occ_w)],
-                }[k]
-                for k in key
-            ]
-            ni = [c.shape[-1] for c in ci]
-            nj = [c.shape[-1] for c in cj]
+            with logging.with_status(f"{key} sector"):
+                ci, cj = [
+                    {
+                        "o": [c[:, o > 0] for c, o in zip(self.mo_coeff, self.mo_occ)],
+                        "v": [c[:, o == 0] for c, o in zip(self.mo_coeff, self.mo_occ)],
+                        "i": [c[:, o > 0] for c, o in zip(self.mo_coeff_w, self.mo_occ_w)],
+                        "a": [c[:, o == 0] for c, o in zip(self.mo_coeff_w, self.mo_occ_w)],
+                    }[k]
+                    for k in key
+                ]
+                ni = [c.shape[-1] for c in ci]
+                nj = [c.shape[-1] for c in cj]
 
-            for q, ki in self.kpts.loop(2):
-                kj = self.kpts.member(self.kpts.wrap_around(self.kpts[ki] - self.kpts[q]))
+                for q, ki in self.kpts.loop(2):
+                    kj = self.kpts.member(self.kpts.wrap_around(self.kpts[ki] - self.kpts[q]))
 
-                Lxy = np.zeros((self.naux_full, ni[ki] * nj[kj]), dtype=complex)
-                b1 = 0
-                for block in self.with_df.sr_loop((ki, kj), compact=False):
-                    if block[2] == -1:
-                        raise NotImplementedError("Low dimensional integrals")
-                    block = block[0] + block[1] * 1.0j
-                    block = block.reshape(self.naux_full, self.nmo, self.nmo)
-                    b0, b1 = b1, b1 + block.shape[0]
-                    logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
+                    Lxy = np.zeros((self.naux_full, ni[ki] * nj[kj]), dtype=complex)
+                    b1 = 0
+                    for block in self.with_df.sr_loop((ki, kj), compact=False):
+                        if block[2] == -1:
+                            raise NotImplementedError("Low dimensional integrals")
+                        block = block[0] + block[1] * 1.0j
+                        block = block.reshape(self.naux_full, self.nmo, self.nmo)
+                        b0, b1 = b1, b1 + block.shape[0]
+                        progress = ki * len(self.kpts) ** 2 + kj * len(self.kpts) + b0
+                        progress /= len(self.kpts) ** 2 + self.naux_full
 
-                    # TODO optimise
-                    tmp = util.einsum("Lpq,pi,qj->Lij", block, ci[ki].conj(), cj[kj])
-                    tmp = tmp.reshape(b1 - b0, -1)
-                    Lxy[b0:b1] = tmp
+                        with logging.with_status(f"block [{ki}, {kj}, {b0}:{b1}] ({progress:.1%})"):
+                            # TODO optimise
+                            tmp = util.einsum("Lpq,pi,qj->Lij", block, ci[ki].conj(), cj[kj])
+                            tmp = tmp.reshape(b1 - b0, -1)
+                            Lxy[b0:b1] = tmp
 
-                prod[q] += np.dot(Lxy, Lxy.T.conj()) / len(self.kpts)
+                    prod[q] += np.dot(Lxy, Lxy.T.conj()) / len(self.kpts)
 
         rot = np.empty((len(self.kpts),), dtype=object)
         if mpi_helper.rank == 0:
@@ -133,22 +133,23 @@ class KIntegrals(Integrals):
                 rot[q] = np.zeros((0,), dtype=complex)
         del prod
 
-        for q in self.kpts.loop(1):
-            rot[q] = mpi_helper.bcast(rot[q], root=0)
-
-            if rot[q].shape[-1] == self.naux_full:
-                logger.info(self, f"No compression found at q-point {q}")
-                rot[q] = None
-            else:
-                logger.info(
-                    self,
-                    f"Compressed auxiliary space from {self.naux_full} to {rot[q].shape[-1]} "
-                    + f"and q-point {q}",
-                )
-        logger.timer(self, "compression metric", *cput0)
+        naux_total = sum(r.shape[-1] for r in rot)
+        naux_full_total = self.naux_full * len(self.kpts)
+        if naux_total == naux_full_total:
+            logging.write("No compression found for auxiliary space")
+            rot = None
+        else:
+            percent = 100 * naux_total / naux_full_total
+            style = logging.rate(percent, 80, 95)
+            logging.write(
+                f"Compressed auxiliary space from {naux_full_total} to {naux_total} "
+                f"([{style}]{percent:.1f}%)[/]"
+            )
 
         return rot
 
+    @require_compression_metric()
+    @logging.with_status("Transforming integrals")
     def transform(self, do_Lpq=None, do_Lpx=True, do_Lia=True):
         """
         Transform the integrals.
@@ -168,8 +169,6 @@ class KIntegrals(Integrals):
         """
 
         # Get the compression metric
-        if self._rot is None:
-            self._rot = self.get_compression_metric()
         rot = self._rot
         if rot is None:
             eye = np.eye(self.naux_full)
@@ -181,9 +180,6 @@ class KIntegrals(Integrals):
         do_Lpq = self.store_full if do_Lpq is None else do_Lpq
         if not any([do_Lpq, do_Lpx, do_Lia]):
             return
-
-        cput0 = (logger.process_clock(), logger.perf_counter())
-        logger.info(self, f"Transforming {self.__class__.__name__}")
 
         # ao2mo function for both real and complex integrals
         tao = np.empty([], dtype=np.int32)
@@ -236,51 +232,45 @@ class KIntegrals(Integrals):
                         raise NotImplementedError("Low dimensional integrals")
                     block = block[0] + block[1] * 1.0j
                     b0, b1 = b1, b1 + block.shape[0]
-                    logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
+                    progress = ki * len(self.kpts) ** 2 + kj * len(self.kpts) + b0
+                    progress /= len(self.kpts) ** 2 + self.naux_full
 
-                    # If needed, rotate the full (L|pq) array
-                    if do_Lpq:
-                        logger.debug(
-                            self, f"(L|pq) size: ({self.naux_full}, {self.nmo}, {self.nmo})"
-                        )
-                        coeffs = np.concatenate((self.mo_coeff[ki], self.mo_coeff[kj]), axis=1)
-                        orb_slice = (0, self.nmo, self.nmo, self.nmo + self.nmo)
-                        _ao2mo_e2(block, coeffs, orb_slice, out=Lpq_k[b0:b1])
+                    with logging.with_status(f"block [{ki}, {kj}, {b0}:{b1}] ({progress:.1%})"):
+                        # If needed, rotate the full (L|pq) array
+                        if do_Lpq:
+                            coeffs = np.concatenate((self.mo_coeff[ki], self.mo_coeff[kj]), axis=1)
+                            orb_slice = (0, self.nmo, self.nmo, self.nmo + self.nmo)
+                            _ao2mo_e2(block, coeffs, orb_slice, out=Lpq_k[b0:b1])
 
-                    # Compress the block
-                    block_comp = util.einsum("L...,LQ->Q...", block, rot[q][b0:b1].conj())
+                        # Compress the block
+                        block_comp = util.einsum("L...,LQ->Q...", block, rot[q][b0:b1].conj())
 
-                    # Build the compressed (L|px) array
-                    if do_Lpx:
-                        logger.debug(
-                            self, f"(L|px) size: ({self.naux[q]}, {self.nmo}, {self.nmo_g[ki]})"
-                        )
-                        coeffs = np.concatenate((self.mo_coeff[ki], self.mo_coeff_g[kj]), axis=1)
-                        orb_slice = (0, self.nmo, self.nmo, self.nmo + self.nmo_g[kj])
-                        tmp = _ao2mo_e2(block_comp, coeffs, orb_slice)
-                        Lpx_k += tmp.reshape(Lpx_k.shape)
+                        # Build the compressed (L|px) array
+                        if do_Lpx:
+                            coeffs = np.concatenate(
+                                (self.mo_coeff[ki], self.mo_coeff_g[kj]), axis=1
+                            )
+                            orb_slice = (0, self.nmo, self.nmo, self.nmo + self.nmo_g[kj])
+                            tmp = _ao2mo_e2(block_comp, coeffs, orb_slice)
+                            Lpx_k += tmp.reshape(Lpx_k.shape)
 
-                    # Build the compressed (L|ia) array
-                    if do_Lia:
-                        logger.debug(
-                            self,
-                            f"(L|ia) size: ({self.naux[q]}, {self.nocc_w[ki] * self.nvir_w[kj]})",
-                        )
-                        coeffs = np.concatenate(
-                            (
-                                self.mo_coeff_w[ki][:, self.mo_occ_w[ki] > 0],
-                                self.mo_coeff_w[kj][:, self.mo_occ_w[kj] == 0],
-                            ),
-                            axis=1,
-                        )
-                        orb_slice = (
-                            0,
-                            self.nocc_w[ki],
-                            self.nocc_w[ki],
-                            self.nocc_w[ki] + self.nvir_w[kj],
-                        )
-                        tmp = _ao2mo_e2(block_comp, coeffs, orb_slice)
-                        Lia_k += tmp.reshape(Lia_k.shape)
+                        # Build the compressed (L|ia) array
+                        if do_Lia:
+                            coeffs = np.concatenate(
+                                (
+                                    self.mo_coeff_w[ki][:, self.mo_occ_w[ki] > 0],
+                                    self.mo_coeff_w[kj][:, self.mo_occ_w[kj] == 0],
+                                ),
+                                axis=1,
+                            )
+                            orb_slice = (
+                                0,
+                                self.nocc_w[ki],
+                                self.nocc_w[ki],
+                                self.nocc_w[ki] + self.nvir_w[kj],
+                            )
+                            tmp = _ao2mo_e2(block_comp, coeffs, orb_slice)
+                            Lia_k += tmp.reshape(Lia_k.shape)
 
                 if do_Lpq:
                     Lpq[ki, kj] = Lpq_k
@@ -301,32 +291,31 @@ class KIntegrals(Integrals):
                         raise NotImplementedError("Low dimensional integrals")
                     block = block[0] + block[1] * 1.0j
                     b0, b1 = b1, b1 + block.shape[0]
-                    logger.debug(self, f"  Block [{ki}, {kj}, {b0}:{b1}]")
+                    progress = ki * len(self.kpts) ** 2 + kj * len(self.kpts) + b0
+                    progress /= len(self.kpts) ** 2 + self.naux_full
 
-                    # Compress the block
-                    block_comp = util.einsum("L...,LQ->Q...", block, rot[q][b0:b1].conj())
+                    with logging.with_status(f"block [{ki}, {kj}, {b0}:{b1}] ({progress:.1%})"):
+                        # Compress the block
+                        block_comp = util.einsum("L...,LQ->Q...", block, rot[q][b0:b1].conj())
 
-                    # Build the compressed (L|ai) array
-                    logger.debug(
-                        self, f"(L|ai) size: ({self.naux[q]}, {self.nvir_w[kj] * self.nocc_w[ki]})"
-                    )
-                    coeffs = np.concatenate(
-                        (
-                            self.mo_coeff_w[kj][:, self.mo_occ_w[kj] == 0],
-                            self.mo_coeff_w[ki][:, self.mo_occ_w[ki] > 0],
-                        ),
-                        axis=1,
-                    )
-                    orb_slice = (
-                        0,
-                        self.nvir_w[kj],
-                        self.nvir_w[kj],
-                        self.nvir_w[kj] + self.nocc_w[ki],
-                    )
-                    tmp = _ao2mo_e2(block_comp, coeffs, orb_slice)
-                    tmp = tmp.reshape(self.naux[q], self.nvir_w[kj], self.nocc_w[ki])
-                    tmp = tmp.swapaxes(1, 2)
-                    Lai_k += tmp.reshape(Lai_k.shape)
+                        # Build the compressed (L|ai) array
+                        coeffs = np.concatenate(
+                            (
+                                self.mo_coeff_w[kj][:, self.mo_occ_w[kj] == 0],
+                                self.mo_coeff_w[ki][:, self.mo_occ_w[ki] > 0],
+                            ),
+                            axis=1,
+                        )
+                        orb_slice = (
+                            0,
+                            self.nvir_w[kj],
+                            self.nvir_w[kj],
+                            self.nvir_w[kj] + self.nocc_w[ki],
+                        )
+                        tmp = _ao2mo_e2(block_comp, coeffs, orb_slice)
+                        tmp = tmp.reshape(self.naux[q], self.nvir_w[kj], self.nocc_w[ki])
+                        tmp = tmp.swapaxes(1, 2)
+                        Lai_k += tmp.reshape(Lai_k.shape)
 
                 Lai[ki, kj] = Lai_k
 
@@ -337,8 +326,6 @@ class KIntegrals(Integrals):
         if do_Lia:
             self._blocks["Lia"] = Lia
             self._blocks["Lai"] = Lai
-
-        logger.timer(self, "transform", *cput0)
 
     def get_cderi_from_thc(self):
         """
@@ -410,6 +397,8 @@ class KIntegrals(Integrals):
         self._blocks["Lia"] = Lia
         self._blocks["Lai"] = Lai
 
+    @logging.with_timer("J matrix")
+    @logging.with_status("Building J matrix")
     def get_j(self, dm, basis="mo", other=None):
         """Build the J matrix.
 
@@ -493,6 +482,8 @@ class KIntegrals(Integrals):
 
         return vj
 
+    @logging.with_timer("K matrix")
+    @logging.with_status("Building K matrix")
     def get_k(self, dm, basis="mo", ewald=False):
         """Build the K matrix.
 
@@ -578,6 +569,8 @@ class KIntegrals(Integrals):
 
         return vk
 
+    @logging.with_timer("Ewald matrix")
+    @logging.with_status("Building Ewald matrix")
     def get_ewald(self, dm, basis="mo"):
         """Build the Ewald exchange divergence matrix.
 

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -4,9 +4,8 @@ Construct TDA moments with periodic boundary conditions.
 
 import numpy as np
 import scipy.special
-from pyscf import lib
 
-from momentGW import mpi_helper, util
+from momentGW import logging, mpi_helper, util
 from momentGW.tda import dTDA as MoldTDA
 
 
@@ -40,6 +39,8 @@ class dTDA(MoldTDA):
         Default value is `None`.
     """
 
+    @logging.with_timer("Density-density moments")
+    @logging.with_status("Constructing density-density moments")
     def build_dd_moments(self):
         """Build the moments of the density-density response.
 
@@ -49,10 +50,6 @@ class dTDA(MoldTDA):
             Moments of the density-density response for each k-point.
         """
 
-        cput0 = (lib.logger.process_clock(), lib.logger.perf_counter())
-        lib.logger.info(self.gw, "Building density-density moments")
-        lib.logger.debug(self.gw, "Memory usage: %.2f GB", self._memory_usage())
-
         kpts = self.kpts
         moments = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
 
@@ -61,7 +58,6 @@ class dTDA(MoldTDA):
             for kj in kpts.loop(1, mpi=True):
                 kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[kj]))
                 moments[q, kb, 0] += self.integrals.Lia[kj, kb] / self.nkpts
-        cput1 = lib.logger.timer(self.gw, "zeroth moment", *cput0)
 
         # Get the higher order moments
         for i in range(1, self.nmom_max + 1):
@@ -90,12 +86,12 @@ class dTDA(MoldTDA):
 
                     moments[q, kb, i] += np.dot(tmp, self.integrals.Lai[kj, kb].conj())
 
-            cput1 = lib.logger.timer(self.gw, "moment %d" % i, *cput1)
-
         return moments
 
     build_dd_moments_exact = build_dd_moments
 
+    @logging.with_timer("Moment convolution")
+    @logging.with_status("Convoluting moments")
     def convolve(self, eta, mo_energy_g=None, mo_occ_g=None):
         """
         Handle the convolution of the moments of the Green's function
@@ -173,6 +169,8 @@ class dTDA(MoldTDA):
 
         return moments_occ, moments_vir
 
+    @logging.with_timer("Self-energy moments")
+    @logging.with_status("Constructing self-energy moments")
     def build_se_moments(self, moments_dd):
         """Build the moments of the self-energy via convolution.
 
@@ -188,10 +186,6 @@ class dTDA(MoldTDA):
         moments_vir : numpy.ndarray
             Moments of the virtual self-energy for each k-point.
         """
-
-        cput0 = (lib.logger.process_clock(), lib.logger.perf_counter())
-        lib.logger.info(self.gw, "Building self-energy moments")
-        lib.logger.debug(self.gw, "Memory usage: %.2f GB", self._memory_usage())
 
         kpts = self.kpts
 
@@ -227,11 +221,8 @@ class dTDA(MoldTDA):
                         subscript = f"P{pchar},Q{qchar},PQ->{pqchar}"
                         eta[kp, q][x, n] += util.einsum(subscript, Lp, Lp.conj(), eta_aux)
 
-        cput1 = lib.logger.timer(self.gw, "rotating DD moments", *cput0)
-
         # Construct the self-energy moments
         moments_occ, moments_vir = self.convolve(eta)
-        cput1 = lib.logger.timer(self.gw, "constructing SE moments", *cput1)
 
         return moments_occ, moments_vir
 

--- a/momentGW/pbc/uhf/base.py
+++ b/momentGW/pbc/uhf/base.py
@@ -7,13 +7,42 @@ import numpy as np
 from pyscf.pbc.mp.kump2 import get_frozen_mask, get_nmo, get_nocc
 
 from momentGW import logging
-from momentGW.base import BaseGW
+from momentGW.base import Base, BaseGW
 from momentGW.pbc.base import BaseKGW
 from momentGW.uhf.base import BaseUGW
 
 
 class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
     __doc__ = BaseKGW.__doc__
+
+    def _get_header(self):
+        """
+        Get the header for the solver, with the name, options, and
+        problem size.
+        """
+
+        # Get the options table
+        options = Base._get_header(self)
+
+        # Get the problem size table
+        sizes = logging.Table(title="Sizes")
+        sizes.add_column("Space", justify="right")
+        sizes.add_column("Size (Γ, α)", justify="right")
+        sizes.add_column("Size (Γ, β)", justify="right")
+        sizes.add_row("MOs", f"{self.nmo[0]}", f"{self.nmo[1]}")
+        sizes.add_row("Occupied MOs", f"{self.nocc[0][0]}", f"{self.nocc[1][0]}")
+        sizes.add_row(
+            "Virtual MOs", f"{self.nmo[0] - self.nocc[0][0]}", f"{self.nmo[1] - self.nocc[1][0]}"
+        )
+        sizes.add_row("k-points", f"{self.kpts.kmesh} = {self.nkpts}")
+
+        # Combine the tables
+        panel = logging.Table.grid()
+        panel.add_row(options)
+        panel.add_row("")
+        panel.add_row(sizes)
+
+        return panel
 
     def _get_excitations_table(self):
         """Return the excitations as a table."""

--- a/momentGW/pbc/uhf/base.py
+++ b/momentGW/pbc/uhf/base.py
@@ -4,9 +4,9 @@ conditions and unrestricted references.
 """
 
 import numpy as np
-from pyscf.lib import logger
 from pyscf.pbc.mp.kump2 import get_frozen_mask, get_nmo, get_nocc
 
+from momentGW import logging
 from momentGW.base import BaseGW
 from momentGW.pbc.base import BaseKGW
 from momentGW.uhf.base import BaseUGW
@@ -15,74 +15,62 @@ from momentGW.uhf.base import BaseUGW
 class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
     __doc__ = BaseKGW.__doc__
 
-    def kernel(
-        self,
-        nmom_max,
-        mo_energy=None,
-        mo_coeff=None,
-        moments=None,
-        integrals=None,
-    ):
-        """Driver for the method.
+    def _get_excitations_table(self):
+        """Return the excitations as a table."""
 
-        Parameters
-        ----------
-        nmom_max : int
-            Maximum moment number to calculate.
-        mo_energy : numpy.ndarray
-            Molecular orbital energies at each k-point for each spin
-            channel.
-        mo_coeff : numpy.ndarray
-            Molecular orbital coefficients at each k-point for each spin
-            channel.
-        moments : tuple of numpy.ndarray, optional
-            Tuple of (hole, particle) moments at each k-point for each
-            spin channel, if passed then they will be used instead of
-            calculating them. Default value is `None`.
-        integrals : KIntegrals, optional
-            Integrals object. If `None`, generate from scratch. Default
-            value is `None`.
-        """
-
-        if mo_coeff is None:
-            mo_coeff = self.mo_coeff
-        if mo_energy is None:
-            mo_energy = self.mo_energy
-
-        cput0 = (logger.process_clock(), logger.perf_counter())
-        self.dump_flags()
-        logger.info(self, "nmom_max = %d", nmom_max)
-
-        self.converged, self.gf, self.se, self._qp_energy = self._kernel(
-            nmom_max,
-            mo_energy,
-            mo_coeff,
-            integrals=integrals,
+        # Separate the occupied and virtual GFs
+        gf_occ = (
+            self.gf[0][0].occupied().physical(weight=1e-1),
+            self.gf[1][0].occupied().physical(weight=1e-1),
+        )
+        gf_vir = (
+            self.gf[0][0].virtual().physical(weight=1e-1),
+            self.gf[1][0].virtual().physical(weight=1e-1),
         )
 
-        for gf, s in zip(self.gf, ["α", "β"]):
-            gf_occ = gf[0].occupied().physical(weight=1e-1)
-            for n in range(min(5, gf_occ.naux)):
-                en = -gf_occ.energies[-(n + 1)]
-                vn = gf_occ.couplings[:, -(n + 1)]
-                qpwt = np.linalg.norm(vn) ** 2
-                logger.note(
-                    self, "IP energy level (Γ, %s) %d E = %.16g  QP weight = %0.6g", s, n, en, qpwt
+        # Build table
+        table = logging.Table(title="Green's function poles")
+        table.add_column("Excitation", justify="right")
+        table.add_column("Energy", justify="right", style="output")
+        table.add_column("QP weight", justify="right")
+        table.add_column("Dominant MOs", justify="right")
+
+        # Add IPs
+        for s, spin in enumerate(["α", "β"]):
+            for n in range(min(3, gf_occ[s].naux)):
+                en = -gf_occ[s].energies[-(n + 1)]
+                weights = np.real(
+                    gf_occ[s].couplings[:, -(n + 1)] * gf_occ[s].couplings[:, -(n + 1)].conj()
                 )
-
-        for gf, s in zip(self.gf, ["α", "β"]):
-            gf_vir = gf[0].virtual().physical(weight=1e-1)
-            for n in range(min(5, gf_vir.naux)):
-                en = gf_vir.energies[n]
-                vn = gf_vir.couplings[:, n]
-                qpwt = np.linalg.norm(vn) ** 2
-                logger.note(
-                    self, "EA energy level (Γ, %s) %d E = %.16g  QP weight = %0.6g", s, n, en, qpwt
+                weight = np.sum(weights)
+                dominant = np.argsort(weights)[::-1]
+                dominant = dominant[weights[dominant] > 0.1][:3]
+                mo_string = ", ".join(
+                    [f"{i} ({100 * weights[i] / weight:5.1f}%)" for i in dominant]
                 )
+                table.add_row(f"IP (Γ, {spin}) {n:>2}", f"{en:.10f}", f"{weight:.5f}", mo_string)
 
-        logger.timer(self, self.name, *cput0)
+            # Add a break
+            table.add_section()
 
-        return self.converged, self.gf, self.se, self.qp_energy
+        for s, spin in enumerate(["α", "β"]):
+            # Add EAs
+            for n in range(min(3, gf_vir[s].naux)):
+                en = gf_vir[s].energies[n]
+                weights = np.real(gf_vir[s].couplings[:, n] * gf_vir[s].couplings[:, n].conj())
+                weight = np.sum(weights)
+                dominant = np.argsort(weights)[::-1]
+                dominant = dominant[weights[dominant] > 0.1][:3]
+                mo_string = ", ".join(
+                    [f"{i} ({100 * weights[i] / weight:5.1f}%)" for i in dominant]
+                )
+                table.add_row(f"EA (Γ, {spin}) {n:>2}", f"{en:.10f}", f"{weight:.5f}", mo_string)
+
+            # Add a break
+            if s != 1:
+                table.add_section()
+
+        return table
 
     @staticmethod
     def _gf_to_occ(gf):
@@ -127,8 +115,9 @@ class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
                     check.add(arg)
 
                 if len(check) != self.nmo[s]:
-                    logger.warn(
-                        self, f"Inconsistent quasiparticle weights for {spin} at k-point {k}!"
+                    # TODO improve this warning
+                    logging.warn(
+                        f"[bad]Inconsistent quasiparticle weights for {spin} at k-point {k}![/]"
                     )
 
         return mo_energy

--- a/momentGW/pbc/uhf/evgw.py
+++ b/momentGW/pbc/uhf/evgw.py
@@ -4,9 +4,8 @@ constraints for periodic systems.
 """
 
 import numpy as np
-from pyscf.lib import logger
 
-from momentGW import util
+from momentGW import logging, util
 from momentGW.pbc.evgw import evKGW
 from momentGW.pbc.uhf.gw import KUGW
 from momentGW.uhf.evgw import evUGW
@@ -94,14 +93,32 @@ class evKUGW(KUGW, evKGW, evUGW):  # noqa: D101
             max(abs(self._moment_error(t, t_prev)) for t, t_prev in zip(tp[1], tp_prev[1])),
         )
 
-        logger.info(
-            self, "Change in QPs (α): HOMO = %.6g  LUMO = %.6g", error_homo[0], error_lumo[0]
+        style_homo = tuple(logging.rate(e, self.conv_tol, self.conv_tol * 1e2) for e in error_homo)
+        style_lumo = tuple(logging.rate(e, self.conv_tol, self.conv_tol * 1e2) for e in error_lumo)
+        style_th = tuple(
+            logging.rate(e, self.conv_tol_moms, self.conv_tol_moms * 1e2) for e in error_th
         )
-        logger.info(
-            self, "Change in QPs (β): HOMO = %.6g  LUMO = %.6g", error_homo[1], error_lumo[1]
+        style_tp = tuple(
+            logging.rate(e, self.conv_tol_moms, self.conv_tol_moms * 1e2) for e in error_tp
         )
-        logger.info(self, "Change in moments (α): occ = %.6g  vir = %.6g", error_th[0], error_tp[0])
-        logger.info(self, "Change in moments (β): occ = %.6g  vir = %.6g", error_th[1], error_tp[1])
+        table = logging.Table(title="Convergence")
+        table.add_column("Sector", justify="right")
+        table.add_column("Δ energy", justify="right")
+        table.add_column("Δ moments", justify="right")
+        for s, spin in enumerate(["α", "β"]):
+            table.add_row(
+                f"Hole ({spin})",
+                f"[{style_homo[s]}]{error_homo[s]:.3g}[/]",
+                f"[{style_th[s]}]{error_th[s]:.3g}[/]",
+            )
+        for s, spin in enumerate(["α", "β"]):
+            table.add_row(
+                f"Particle ({spin})",
+                f"[{style_lumo[s]}]{error_lumo[s]:.3g}[/]",
+                f"[{style_tp[s]}]{error_tp[s]:.3g}[/]",
+            )
+        logging.write("")
+        logging.write(table)
 
         return self.conv_logical(
             (

--- a/momentGW/pbc/uhf/fock.py
+++ b/momentGW/pbc/uhf/fock.py
@@ -88,7 +88,7 @@ def fock_loop(
     buf = np.zeros((np.max(nqmo), np.max(nqmo)), dtype=complex)
     converged = False
     opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner, occupancy=1)
-    rdm1_prev = 0
+    rdm1_prev = rdm1
 
     for niter1 in range(1, max_cycle_outer + 1):
         se_α, opt = minimize_chempot(se[0], fock[0], sum(nelec[0]), x0=se[0][0].chempot, **opts)
@@ -123,10 +123,9 @@ def fock_loop(
             fock = integrals.get_fock(rdm1, h1e)
             fock = diis.update(fock, xerr=None)
 
-            if niter2 > 1:
-                derr = np.max(np.absolute(rdm1 - rdm1_prev))
-                if derr < conv_tol_rdm1:
-                    break
+            derr = np.max(np.absolute(rdm1 - rdm1_prev))
+            if derr < conv_tol_rdm1:
+                break
 
             rdm1_prev = rdm1.copy()
 

--- a/momentGW/pbc/uhf/fock.py
+++ b/momentGW/pbc/uhf/fock.py
@@ -58,7 +58,13 @@ def fock_loop(
     if integrals is None:
         integrals = gw.ao2mo()
 
-    h1e = util.einsum("kpq,skpi,skqj->skij", gw._scf.get_hcore(), np.conj(gw.mo_coeff), gw.mo_coeff)
+    with util.SilentSCF(gw._scf):
+        h1e = util.einsum(
+            "kpq,skpi,skqj->skij",
+            gw._scf.get_hcore(),
+            np.conj(gw.mo_coeff),
+            gw.mo_coeff,
+        )
     nmo = gw.nmo
     nocc = gw.nocc
     naux = (

--- a/momentGW/pbc/uhf/fock.py
+++ b/momentGW/pbc/uhf/fock.py
@@ -5,12 +5,13 @@ conditions and unrestricted references.
 
 import numpy as np
 from dyson import Lehmann
-from pyscf.lib import logger
 
-from momentGW import mpi_helper, util
+from momentGW import logging, mpi_helper, util
 from momentGW.pbc.fock import minimize_chempot, search_chempot
 
 
+@logging.with_timer("Fock loop")
+@logging.with_status("Running Fock loop")
 def fock_loop(
     gw,
     gf,
@@ -90,69 +91,76 @@ def fock_loop(
     opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner, occupancy=1)
     rdm1_prev = rdm1
 
-    for niter1 in range(1, max_cycle_outer + 1):
-        se_α, opt = minimize_chempot(se[0], fock[0], sum(nelec[0]), x0=se[0][0].chempot, **opts)
-        se_β, opt = minimize_chempot(se[1], fock[1], sum(nelec[1]), x0=se[1][0].chempot, **opts)
-        se = [se_α, se_β]
+    with logging.with_table(title="Fock loop") as table:
+        table.add_column("Iter", justify="right")
+        table.add_column("Cycle", justify="right")
+        table.add_column("Error (nα)", justify="right")
+        table.add_column("Error (nβ)", justify="right")
+        table.add_column("Δ (density)", justify="right")
 
-        for niter2 in range(1, max_cycle_inner + 1):
-            w, v = zip(
-                *[s.diagonalise_matrix(f, chempot=0.0, out=buf) for s, f in zip(se[0], fock[0])]
-            )
-            w = [mpi_helper.bcast(wk, root=0) for wk in w]
-            v = [mpi_helper.bcast(vk, root=0) for vk in v]
-            chempot_α, nerr_α = search_chempot(w, v, nmo[0], sum(nelec[0]), occupancy=1)
+        for niter1 in range(1, max_cycle_outer + 1):
+            se_α, opt = minimize_chempot(se[0], fock[0], sum(nelec[0]), x0=se[0][0].chempot, **opts)
+            se_β, opt = minimize_chempot(se[1], fock[1], sum(nelec[1]), x0=se[1][0].chempot, **opts)
+            se = [se_α, se_β]
 
-            w, v = zip(
-                *[s.diagonalise_matrix(f, chempot=0.0, out=buf) for s, f in zip(se[1], fock[1])]
-            )
-            w = [mpi_helper.bcast(wk, root=0) for wk in w]
-            v = [mpi_helper.bcast(vk, root=0) for vk in v]
-            chempot_β, nerr_β = search_chempot(w, v, nmo[1], sum(nelec[1]), occupancy=1)
+            for niter2 in range(1, max_cycle_inner + 1):
+                with logging.with_status(f"Iteration [{niter1}, {niter2}]"):
+                    w, v = zip(
+                        *[
+                            s.diagonalise_matrix(f, chempot=0.0, out=buf)
+                            for s, f in zip(se[0], fock[0])
+                        ]
+                    )
+                    w = [mpi_helper.bcast(wk, root=0) for wk in w]
+                    v = [mpi_helper.bcast(vk, root=0) for vk in v]
+                    chempot_α, nerr_α = search_chempot(w, v, nmo[0], sum(nelec[0]), occupancy=1)
+                    nerr_α = abs(nerr_α)
 
-            for k in kpts.loop(1):
-                se[0][k].chempot = chempot_α
-                w, v = se[0][k].diagonalise_matrix(fock[0][k], out=buf)
-                gf[0][k] = Lehmann(w, v[: nmo[0]], chempot=se[0][k].chempot)
+                    w, v = zip(
+                        *[
+                            s.diagonalise_matrix(f, chempot=0.0, out=buf)
+                            for s, f in zip(se[1], fock[1])
+                        ]
+                    )
+                    w = [mpi_helper.bcast(wk, root=0) for wk in w]
+                    v = [mpi_helper.bcast(vk, root=0) for vk in v]
+                    chempot_β, nerr_β = search_chempot(w, v, nmo[1], sum(nelec[1]), occupancy=1)
+                    nerr_β = abs(nerr_β)
 
-                se[1][k].chempot = chempot_α
-                w, v = se[1][k].diagonalise_matrix(fock[1][k], out=buf)
-                gf[1][k] = Lehmann(w, v[: nmo[1]], chempot=se[1][k].chempot)
+                    for k in kpts.loop(1):
+                        se[0][k].chempot = chempot_α
+                        w, v = se[0][k].diagonalise_matrix(fock[0][k], out=buf)
+                        gf[0][k] = Lehmann(w, v[: nmo[0]], chempot=se[0][k].chempot)
 
-            rdm1 = gf_to_dm(gf)
-            fock = integrals.get_fock(rdm1, h1e)
-            fock = diis.update(fock, xerr=None)
+                        se[1][k].chempot = chempot_α
+                        w, v = se[1][k].diagonalise_matrix(fock[1][k], out=buf)
+                        gf[1][k] = Lehmann(w, v[: nmo[1]], chempot=se[1][k].chempot)
 
-            derr = np.max(np.absolute(rdm1 - rdm1_prev))
-            if derr < conv_tol_rdm1:
+                    rdm1 = gf_to_dm(gf)
+                    fock = integrals.get_fock(rdm1, h1e)
+                    fock = diis.update(fock, xerr=None)
+
+                    derr = np.max(np.absolute(rdm1 - rdm1_prev))
+                    if niter2 in {1, 5, 10, 50, 100, max_cycle_inner} or derr < conv_tol_rdm1:
+                        nerr_α_style = logging.rate(nerr_α, conv_tol_nelec, conv_tol_nelec * 1e2)
+                        nerr_β_style = logging.rate(nerr_β, conv_tol_nelec, conv_tol_nelec * 1e2)
+                        derr_style = logging.rate(derr, conv_tol_rdm1, conv_tol_rdm1 * 1e2)
+                        table.add_row(
+                            f"{niter1}",
+                            f"{niter2}",
+                            f"[{nerr_α_style}]{nerr_α:.3g}[/]",
+                            f"[{nerr_β_style}]{nerr_β:.3g}[/]",
+                            f"[{derr_style}]{derr:.3g}[/]",
+                        )
+                    if derr < conv_tol_rdm1:
+                        break
+
+                    rdm1_prev = rdm1.copy()
+
+            if derr < conv_tol_rdm1 and (nerr_α + nerr_β) < conv_tol_nelec:
+                converged = True
                 break
 
-            rdm1_prev = rdm1.copy()
-
-        logger.debug1(
-            gw,
-            "fock loop %d  cycles = %d  dNα = %.3g  dNβ = %.3g  |ddm| = %.3g",
-            niter1,
-            niter2,
-            nerr_α,
-            nerr_β,
-            derr,
-        )
-
-        if derr < conv_tol_rdm1 and (abs(nerr_α) + abs(nerr_β)) < conv_tol_nelec:
-            converged = True
-            break
-
-    logger.info(
-        gw,
-        "fock converged = %s  chempot (Γ, α) = %.9g  chempot (Γ, β) = %.9g  dNα = %.3g  dNβ = %.3g"
-        + "  |ddm| = %.3g",
-        converged,
-        se[0][0].chempot,
-        se[1][0].chempot,
-        nerr_α,
-        nerr_β,
-        derr,
-    )
+        logging.write(table)
 
     return gf, se, converged

--- a/momentGW/pbc/uhf/gw.py
+++ b/momentGW/pbc/uhf/gw.py
@@ -5,9 +5,8 @@ periodic systems.
 
 import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE, NullLogger
-from pyscf.lib import logger
 
-from momentGW import energy, util
+from momentGW import energy, logging, mpi_helper, util
 from momentGW.pbc.fock import minimize_chempot, search_chempot, search_chempot_unconstrained
 from momentGW.pbc.gw import KGW
 from momentGW.pbc.uhf.base import BaseKUGW
@@ -32,6 +31,8 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-KUG0W0"
 
+    @logging.with_timer("Integral construction")
+    @logging.with_status("Constructing integrals")
     def ao2mo(self, transform=True):
         """Get the integrals object.
 
@@ -130,50 +131,78 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
             Self-energy at each k-point for each spin channel.
         """
 
-        nlog = NullLogger()
-
-        se = [[], []]
-        gf = [[], []]
-        for k in self.kpts.loop(1):
-            solver_occ = MBLSE(se_static[0][k], np.array(se_moments_hole[0][k]), log=nlog)
-            solver_occ.kernel()
-
-            solver_vir = MBLSE(se_static[0][k], np.array(se_moments_part[0][k]), log=nlog)
-            solver_vir.kernel()
-
-            solver = MixedMBLSE(solver_occ, solver_vir)
-            se[0].append(solver.get_self_energy())
-
-            solver_occ = MBLSE(se_static[1][k], np.array(se_moments_hole[1][k]), log=nlog)
-            solver_occ.kernel()
-
-            solver_vir = MBLSE(se_static[1][k], np.array(se_moments_part[1][k]), log=nlog)
-            solver_vir.kernel()
-
-            solver = MixedMBLSE(solver_occ, solver_vir)
-            se[1].append(solver.get_self_energy())
-
-            for s, spin in enumerate(["α", "β"]):
-                logger.debug(
-                    self,
-                    "Error in moments (%s) [kpt %d]: occ = %.6g  vir = %.6g",
-                    spin,
-                    k,
-                    *self.moment_error(se_moments_hole[s][k], se_moments_part[s][k], se[s][k]),
+        with logging.with_modifiers(status="Solving Dyson equation", timer="Dyson equation"):
+            se = [[], []]
+            for k in self.kpts.loop(1):
+                solver_occ = MBLSE(
+                    se_static[0][k], np.array(se_moments_hole[0][k]), log=NullLogger()
                 )
+                solver_occ.kernel()
 
-            gf[0].append(Lehmann(*se[0][k].diagonalise_matrix_with_projection(se_static[0][k])))
-            gf[1].append(Lehmann(*se[1][k].diagonalise_matrix_with_projection(se_static[1][k])))
+                solver_vir = MBLSE(
+                    se_static[0][k], np.array(se_moments_part[0][k]), log=NullLogger()
+                )
+                solver_vir.kernel()
 
-            gf[0][k].chempot = se[0][k].chempot
-            gf[1][k].chempot = se[1][k].chempot
+                solver = MixedMBLSE(solver_occ, solver_vir)
+                se[0].append(solver.get_self_energy())
+
+                solver_occ = MBLSE(
+                    se_static[1][k], np.array(se_moments_hole[1][k]), log=NullLogger()
+                )
+                solver_occ.kernel()
+
+                solver_vir = MBLSE(
+                    se_static[1][k], np.array(se_moments_part[1][k]), log=NullLogger()
+                )
+                solver_vir.kernel()
+
+                solver = MixedMBLSE(solver_occ, solver_vir)
+                se[1].append(solver.get_self_energy())
 
         if self.optimise_chempot:
-            se[0], opt = minimize_chempot(se[0], se_static[0], sum(self.nocc[0]), occupancy=1)
-            se[1], opt = minimize_chempot(se[1], se_static[1], sum(self.nocc[1]), occupancy=1)
+            with logging.with_status("Optimising chemical potential"):
+                se[0], opt = minimize_chempot(se[0], se_static[0], sum(self.nocc[0]), occupancy=1)
+                se[1], opt = minimize_chempot(se[1], se_static[1], sum(self.nocc[1]), occupancy=1)
+
+        error_h, error_p = zip(
+            *(
+                zip(
+                    *(
+                        self.moment_error(th, tp, s)
+                        for th, tp, s in zip(se_moments_hole[0], se_moments_part[0], se[0])
+                    )
+                ),
+                zip(
+                    *(
+                        self.moment_error(th, tp, s)
+                        for th, tp, s in zip(se_moments_hole[1], se_moments_part[1], se[1])
+                    )
+                ),
+            )
+        )
+        error = ((sum(error_h[0]), sum(error_p[0])), (sum(error_h[1]), sum(error_p[1])))
+        for s, spin in enumerate(["α", "β"]):
+            logging.write(
+                f"Error in moments ({spin}):  "
+                f"[{logging.rate(sum(error[s]), 1e-12, 1e-8)}]{sum(error[s]):.3e}[/] "
+                f"(hole = [{logging.rate(error[s][0], 1e-12, 1e-8)}]{error[s][0]:.3e}[/], "
+                f"particle = [{logging.rate(error[s][1], 1e-12, 1e-8)}]{error[s][1]:.3e}[/])"
+            )
+
+        gf = [[], []]
+        for s in range(2):
+            for k in self.kpts.loop(1):
+                g = Lehmann(*se[s][k].diagonalise_matrix_with_projection(se_static[s][k]))
+                g.energies = mpi_helper.bcast(g.energies, root=0)
+                g.couplings = mpi_helper.bcast(g.couplings, root=0)
+                g.chempot = se[s][k].chempot
+                gf[s].append(g)
 
         if self.fock_loop:
-            gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
+            logging.write("")
+            with logging.with_status("Running Fock loop"):
+                gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
 
         cpt_α, error_α = search_chempot(
             [g.energies for g in gf[0]],
@@ -191,26 +220,23 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
         )
         cpt = (cpt_α, cpt_β)
         error = (error_α, error_β)
-
-        for s, spin in enumerate(["α", "β"]):
+        for s in range(2):
             for k in self.kpts.loop(1):
-                se[s][k].chempot = cpt[s]
                 gf[s][k].chempot = cpt[s]
-                logger.info(
-                    self, "Error in number of electrons (%s) [kpt %d]: %.5g", spin, k, error[s]
-                )
+                se[s][k].chempot = cpt[s]
 
-        # Calculate energies
-        e_1b = self.energy_hf(gf=gf, integrals=integrals) + self.energy_nuc()
-        e_2b_g0 = self.energy_gm(se=se, g0=True)
-        e_2b = self.energy_gm(gf=gf, se=se, g0=False)
-        logger.info(self, "Energies:")
-        logger.info(self, "  One-body (G0):         %15.10g", self._scf.e_tot)
-        logger.info(self, "  One-body (G):          %15.10g", e_1b)
-        logger.info(self, "  Galitskii-Migdal (G0): %15.10g", e_2b_g0)
-        logger.info(self, "  Galitskii-Migdal (G):  %15.10g", e_2b)
+        logging.write("")
+        for s, spin in enumerate(["α", "β"]):
+            color = logging.rate(
+                abs(error[s]),
+                1e-6,
+                1e-6 if self.fock_loop or self.optimise_chempot else 1e-1,
+            )
+            logging.write(f"Error in number of electrons ({spin}):  [{color}]{error[s]:.3e}[/]")
+        for s, spin in enumerate(["α", "β"]):
+            logging.write(f"Chemical potential (Γ, {spin}):  {cpt[s]:.6f}")
 
-        return gf, se
+        return tuple(tuple(g) for g in gf), tuple(tuple(s) for s in se)
 
     def make_rdm1(self, gf=None):
         """Get the first-order reduced density matrix.
@@ -236,6 +262,8 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
 
         return np.array([[g.occupied().moment(0) for g in gs] for gs in gf])
 
+    @logging.with_timer("Energy")
+    @logging.with_status("Calculating energy")
     def energy_hf(self, gf=None, integrals=None):
         """Calculate the one-body (Hartree--Fock) energy.
 
@@ -277,6 +305,8 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
 
         return e_1b.real
 
+    @logging.with_timer("Energy")
+    @logging.with_status("Calculating energy")
     def energy_gm(self, gf=None, se=None, g0=True):
         r"""Calculate the two-body (Galitskii--Migdal) energy.
 
@@ -326,6 +356,8 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
 
         return e_2b.real
 
+    @logging.with_timer("Interpolation")
+    @logging.with_status("Interpolating in k-space")
     def interpolate(self, mf, nmom_max):
         """
         Interpolate the object to a new k-point grid, represented by a

--- a/momentGW/pbc/uhf/gw.py
+++ b/momentGW/pbc/uhf/gw.py
@@ -260,9 +260,10 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
         if integrals is None:
             integrals = self.ao2mo()
 
-        h1e = util.einsum(
-            "kpq,skpi,skqj->skij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff
-        )
+        with util.SilentSCF(self._scf):
+            h1e = util.einsum(
+                "kpq,skpi,skqj->skij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff
+            )
         rdm1 = self.make_rdm1()
         fock = integrals.get_fock(rdm1, h1e)
 

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -63,17 +63,18 @@ def kernel(
     mo_coeff = mo_coeff.copy()
     mo_coeff_ref = mo_coeff.copy()
 
-    # Get the overlap
-    ovlp = gw._scf.get_ovlp()
-    sc = util.einsum("...pq,...qi->...pi", ovlp, mo_coeff)
+    with util.SilentSCF(gw._scf):
+        # Get the overlap
+        ovlp = gw._scf.get_ovlp()
+        sc = util.einsum("...pq,...qi->...pi", ovlp, mo_coeff)
 
-    # Get the density matrix
-    dm = gw._scf.make_rdm1(mo_coeff, gw.mo_occ)
-    dm = util.einsum("...pq,...pi,...qj->...ij", dm, np.conj(sc), sc)
+        # Get the density matrix
+        dm = gw._scf.make_rdm1(mo_coeff, gw.mo_occ)
+        dm = util.einsum("...pq,...pi,...qj->...ij", dm, np.conj(sc), sc)
 
-    # Get the core Hamiltonian
-    h1e = gw._scf.get_hcore()
-    h1e = util.einsum("...pq,...pi,...qj->...ij", h1e, np.conj(mo_coeff), mo_coeff)
+        # Get the core Hamiltonian
+        h1e = gw._scf.get_hcore()
+        h1e = util.einsum("...pq,...pi,...qj->...ij", h1e, np.conj(mo_coeff), mo_coeff)
 
     diis = util.DIIS()
     diis.space = gw.diis_space

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -130,7 +130,7 @@ def kernel(
                     dm = gw._scf.make_rdm1(u, gw.mo_occ)
                     error = np.max(np.abs(dm - dm_prev))
                     conv_qp = error < gw.conv_tol_qp
-                    if qp_cycle in {1, 2, 5, 10, 50, 100, gw.max_cycle_qp} or conv_qp:
+                    if qp_cycle in {1, 5, 10, 50, 100, gw.max_cycle_qp} or conv_qp:
                         style = logging.rate(error, gw.conv_tol_qp, gw.conv_tol_qp * 1e2)
                         table.add_row(f"{qp_cycle}", f"[{style}]{error:.3g}[/]")
                     if conv_qp:

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -93,6 +93,9 @@ def kernel(
 
     conv = False
     for cycle in range(1, gw.max_cycle + 1):
+        with logging.with_comment(f"Start of iteration {cycle}"):
+            logging.write("")
+
         with logging.with_status(f"Iteration {cycle}"):
             # Build the static potential
             se_qp_prev = se_qp if cycle > 1 else None

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -182,7 +182,7 @@ class dRPA(dTDA):
         """Rescale quadrature for grid space `a`."""
         return bare_quad[0] * a, bare_quad[1] * a
 
-    def optimise_main_quad(self, d, diag_eri):
+    def optimise_main_quad(self, d, diag_eri, name="main"):
         """
         Optimise the grid spacing of Clenshaw-Curtis quadrature for the
         main integral.
@@ -193,6 +193,8 @@ class dRPA(dTDA):
             Array of orbital energy differences.
         diag_eri : numpy.ndarray
             Diagonal of the ERIs.
+        name : str, optional
+            Name of the integral. Default value is `"main"`.
 
         Returns
         -------
@@ -209,11 +211,11 @@ class dRPA(dTDA):
         exact -= np.sum(d)
 
         integrand = lambda quad: self.eval_diag_main_integral(quad, d, diag_eri)
-        quad = self.get_optimal_quad(bare_quad, integrand, exact, name="main")
+        quad = self.get_optimal_quad(bare_quad, integrand, exact, name=name)
 
         return quad
 
-    def optimise_offset_quad(self, d, diag_eri):
+    def optimise_offset_quad(self, d, diag_eri, name="offset"):
         """
         Optimise the grid spacing of Clenshaw-Curtis quadrature for the
         main integral.
@@ -224,6 +226,8 @@ class dRPA(dTDA):
             Array of orbital energy differences.
         diag_eri : numpy.ndarray
             Diagonal of the ERIs.
+        name : str, optional
+            Name of the integral. Default value is `"offset"`.
 
         Returns
         -------
@@ -238,7 +242,7 @@ class dRPA(dTDA):
         exact = 0.5 * np.dot(1.0 / d, d * diag_eri)
 
         integrand = lambda quad: self.eval_diag_offset_integral(quad, d, diag_eri)
-        quad = self.get_optimal_quad(bare_quad, integrand, exact, name="offset")
+        quad = self.get_optimal_quad(bare_quad, integrand, exact, name=name)
 
         return quad
 

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -182,8 +182,6 @@ class dRPA(dTDA):
         """Rescale quadrature for grid space `a`."""
         return bare_quad[0] * a, bare_quad[1] * a
 
-    @logging.with_timer("Quadrature optimisation")
-    @logging.with_status("Optimising quadrature")
     def optimise_main_quad(self, d, diag_eri):
         """
         Optimise the grid spacing of Clenshaw-Curtis quadrature for the
@@ -215,8 +213,6 @@ class dRPA(dTDA):
 
         return quad
 
-    @logging.with_timer("Quadrature optimisation")
-    @logging.with_status("Optimising quadrature")
     def optimise_offset_quad(self, d, diag_eri):
         """
         Optimise the grid spacing of Clenshaw-Curtis quadrature for the
@@ -276,7 +272,7 @@ class dRPA(dTDA):
             raise RuntimeError("Could not optimise `a` value.")
 
         solve = 10**res.x
-        full_name = f"{f'{name} ' if name else ''} quadrature".capitalize()
+        full_name = f"{f'{name} ' if name else ''}quadrature".capitalize()
         logging.debug(
             f"{full_name} scale:  {solve:.2e} "
             f"(error = [{'green' if res.fun < 1e-10 else 'red'}]{res.fun:.2e}[/])"
@@ -284,8 +280,6 @@ class dRPA(dTDA):
 
         return self.rescale_quad(bare_quad, solve)
 
-    @logging.with_timer("Integral evaluation")
-    @logging.with_status("Evaluating integral")
     def eval_diag_offset_integral(self, quad, d, diag_eri):
         """Evaluate the diagonal of the offset integral.
 
@@ -315,8 +309,6 @@ class dRPA(dTDA):
 
         return integral
 
-    @logging.with_timer("Integral evaluation")
-    @logging.with_status("Evaluating integral")
     def eval_diag_main_integral(self, quad, d, diag_eri):
         """Evaluate the diagonal of the main integral.
 
@@ -355,8 +347,6 @@ class dRPA(dTDA):
 
         return integral
 
-    @logging.with_timer("Integral evaluation")
-    @logging.with_status("Evaluating integral")
     def eval_offset_integral(self, quad, d, Lia=None):
         """Evaluate the offset integral.
 
@@ -396,8 +386,6 @@ class dRPA(dTDA):
 
         return integral
 
-    @logging.with_timer("Integral evaluation")
-    @logging.with_status("Evaluating integral")
     def eval_main_integral(self, quad, d, Lia=None):
         """Evaluate the main integral.
 

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -5,7 +5,7 @@ Construct RPA moments.
 import numpy as np
 import scipy.optimize
 
-from momentGW import dTDA, mpi_helper, util
+from momentGW import dTDA, logging, mpi_helper, util
 
 
 class dRPA(dTDA):
@@ -40,8 +40,7 @@ class dRPA(dTDA):
         """
 
         timer = util.Timer()
-        self.gw.log.info("Performing integration")
-        self.gw.log.debug("Memory usage: %.2f GB", self._memory_usage())
+
         p0, p1 = self.mpi_slice(self.nov)
 
         # Construct energy differences
@@ -55,23 +54,19 @@ class dRPA(dTDA):
 
         # Get the offset integral quadrature
         quad = self.optimise_offset_quad(d_full, diag_eri)
-        self.gw.log.debug(
-            "Time elapsed to optimise offset quadrature: %s", timer.format_time(timer())
-        )
+        logging.time("Quadrature", timer())
 
         # Perform the offset integral
         offset = self.eval_offset_integral(quad, d)
-        self.gw.log.debug("Time elapsed to perform offset integral: %s", timer.format_time(timer()))
+        logging.time("Integral", timer())
 
         # Get the main integral quadrature
         quad = self.optimise_main_quad(d_full, diag_eri)
-        self.gw.log.debug(
-            "Time elapsed to optimise main quadrature: %s", timer.format_time(timer())
-        )
+        logging.time("Quadrature", timer())
 
         # Perform the main integral
         integral = self.eval_main_integral(quad, d)
-        self.gw.log.debug("Time elapsed to perform main integral: %s", timer.format_time(timer()))
+        logging.time("Integral", timer())
 
         # Report quadrature error
         if self.report_quadrature_error:
@@ -80,9 +75,9 @@ class dRPA(dTDA):
             a, b = mpi_helper.allreduce(np.array([a, b]))
             a, b = a**0.5, b**0.5
             err = self.estimate_error_clencur(a, b)
-            self.gw.log.debug("One-quarter quadrature error: %s", a)
-            self.gw.log.debug("One-half quadrature error: %s", b)
-            self.gw.log.debug("Error estimate: %s", err)
+            logging.debug("One-quarter quadrature error: %s", a)
+            logging.debug("One-half quadrature error: %s", b)
+            logging.debug("Error estimate: %s", err)
 
         return integral[0] + offset
 
@@ -105,8 +100,8 @@ class dRPA(dTDA):
             integral = self.integrate()
 
         timer = util.Timer()
-        self.gw.log.info("Building density-density moments")
-        self.gw.log.debug("Memory usage: %.2f GB", self._memory_usage())
+        logging.debug("Building density-density moments")
+        logging.debug("Memory usage: %.2f GB", self._memory_usage())
 
         p0, p1 = self.mpi_slice(self.nov)
         moments = np.zeros((self.nmom_max + 1, self.naux, p1 - p0))
@@ -123,7 +118,7 @@ class dRPA(dTDA):
         u = np.dot(Liadinv, self.integrals.Lia.T) * 4.0  # aux^2 o v
         u = mpi_helper.allreduce(u)
         u = np.linalg.inv(np.eye(self.naux) + u)
-        self.gw.log.debug("Time elapsed to construct (A-B)^{-1}: %s", timer.format_time(timer()))
+        logging.debug("Time elapsed to construct (A-B)^{-1}: %s", timer.format_time(timer()))
 
         # Get the zeroth order moment
         moments[0] = integral / d[None]
@@ -131,14 +126,14 @@ class dRPA(dTDA):
         tmp = mpi_helper.allreduce(tmp)
         moments[0] -= np.dot(tmp, Liadinv) * 4.0  # aux^2 o v
         del u, tmp
-        self.gw.log.debug(
+        logging.debug(
             "Time elapsed to construct zeroth density-density moment: %s",
             timer.format_time(timer()),
         )
 
         # Get the first order moment
         moments[1] = Liad
-        self.gw.log.debug(
+        logging.debug(
             "Time elapsed to construct first density-density moment: %s", timer.format_time(timer())
         )
 
@@ -149,7 +144,7 @@ class dRPA(dTDA):
             tmp = mpi_helper.allreduce(tmp)
             moments[i] += np.dot(tmp, Liad) * 4.0  # aux^2 o v
             del tmp
-            self.gw.log.debug(
+            logging.debug(
                 "Time elapsed to construct density-density moment %d: %s",
                 i,
                 timer.format_time(timer()),
@@ -166,8 +161,8 @@ class dRPA(dTDA):
             Moments of the density-density response.
         """
 
-        self.gw.log.info("Building exact density-density moments")
-        self.gw.log.debug("Memory usage: %.2f GB", self._memory_usage())
+        logging.debug("Building exact density-density moments")
+        logging.debug("Memory usage: %.2f GB", self._memory_usage())
 
         import sys
 
@@ -291,7 +286,7 @@ class dRPA(dTDA):
             raise RuntimeError("Could not optimise `a` value.")
 
         solve = 10**res.x
-        self.gw.log.debug(
+        logging.debug(
             "Used minimisation to optimise quadrature grid: a = %.2e  penalty = %.2e",
             solve,
             res.fun,
@@ -528,18 +523,18 @@ class dRPA(dTDA):
 
         # Check how many there are
         if len(real_roots) > 1:
-            self.gw.log.warning(
+            logging.warning(
                 "Nested quadrature error estimation gives %d real roots. "
                 "Taking smallest positive root." % len(real_roots),
             )
         else:
-            self.gw.log.debug(
+            logging.debug(
                 "Nested quadrature error estimation gives %d real roots." % len(real_roots),
             )
 
         # Check if there is a root between 0 and 1
         if not np.any(np.logical_and(real_roots > 0, real_roots < 1)):
-            self.gw.log.warning(
+            logging.warning(
                 self.gw, "Nested quadrature error estimation gives no root between 0 and 1."
             )
             return np.nan

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -71,9 +71,9 @@ class dRPA(dTDA):
             a, b = mpi_helper.allreduce(np.array([a, b]))
             a, b = a**0.5, b**0.5
             err = self.estimate_error_clencur(a, b)
-            logging.debug(f"Error at half quadrature:  [{'green' if a < 1e-4 else 'red'}]{a:.3e}")
+            logging.debug(f"Error at half quadrature:  [{'green' if a < 1e-3 else 'red'}]{a:.3e}")
             logging.debug(
-                f"Error at quarter quadrature:  [{'green' if b < 1e-8 else 'red'}]{b:.3e}"
+                f"Error at quarter quadrature:  [{'green' if b < 1e-6 else 'red'}]{b:.3e}"
             )
             logging.debug(
                 f"Error estimate in quadrature:  [{'green' if err < 1e-12 else 'red'}]{err:.3e}"

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -74,9 +74,10 @@ class dRPA(dTDA):
             style_half = logging.rate(a, 1e-4, 1e-3)
             style_quar = logging.rate(b, 1e-8, 1e-6)
             style_full = logging.rate(err, 1e-12, 1e-9)
-            logging.debug(f"Error at half quadrature:  [{style_half}]{a:.3e}[/]")
-            logging.debug(f"Error at quarter quadrature:  [{style_quar}]{b:.3e}[/]")
-            logging.debug(f"Error estimate in quadrature:  [{style_full}]{err:.3e}[/]")
+            logging.debug(
+                f"Error in integral:  [{style_full}]{err:.3e}[/] "
+                f"(half = [{style_half}]{a:.3e}[/], quarter = [{style_quar}]{b:.3e}[/])",
+            )
 
         return integral[0] + offset
 

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -74,7 +74,7 @@ class dRPA(dTDA):
             style_half = logging.rate(a, 1e-4, 1e-3)
             style_quar = logging.rate(b, 1e-8, 1e-6)
             style_full = logging.rate(err, 1e-12, 1e-9)
-            logging.debug(
+            logging.write(
                 f"Error in integral:  [{style_full}]{err:.3e}[/] "
                 f"(half = [{style_half}]{a:.3e}[/], quarter = [{style_quar}]{b:.3e}[/])",
             )
@@ -274,7 +274,7 @@ class dRPA(dTDA):
         solve = 10**res.x
         full_name = f"{f'{name} ' if name else ''}quadrature".capitalize()
         style = logging.rate(res.fun, 1e-14, 1e-10)
-        logging.debug(f"{full_name} scale:  {solve:.2e} (error = [{style}]{res.fun:.2e}[/])")
+        logging.write(f"{full_name} scale:  {solve:.2e} (error = [{style}]{res.fun:.2e}[/])")
 
         return self.rescale_quad(bare_quad, solve)
 
@@ -507,19 +507,19 @@ class dRPA(dTDA):
 
         # Check how many there are
         if len(real_roots) > 1:
-            logging.warning(
+            logging.warn(
                 "Nested quadrature error estimation gives [bad]%d real roots[/]. "
                 "Taking smallest positive root." % len(real_roots),
             )
         else:
-            logging.debug(
+            logging.write(
                 f"Nested quadrature error estimation gives {len(real_roots)} "
                 f"real root{'s' if len(real_roots) != 1 else ''}.",
             )
 
         # Check if there is a root between 0 and 1
         if not np.any(np.logical_and(real_roots > 0, real_roots < 1)):
-            logging.warning(
+            logging.warn(
                 "Nested quadrature error estimation gives [bad]no root between 0 and 1[/]."
             )
             return np.nan

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -288,34 +288,6 @@ class dRPA(dTDA):
 
         return self.rescale_quad(bare_quad, solve)
 
-    def optimise_offset_quad(self, d, diag_eri):
-        """
-        Optimise the grid spacing of Gauss-Laguerre quadrature for the
-        offset integral.
-
-        Parameters
-        ----------
-        d : numpy.ndarray
-            Orbital energy differences.
-        diag_eri : numpy.ndarray
-            Diagonal of the ERIs.
-
-        Returns
-        -------
-        points : numpy.ndarray
-            The quadrature points.
-        weights : numpy.ndarray
-            The quadrature weights.
-        """
-
-        bare_quad = self.gen_gausslag_quad_semiinf()
-        exact = np.dot(1.0 / d, d * diag_eri)
-
-        integrand = lambda quad: self.eval_diag_offset_integral(quad, d, diag_eri)
-        quad = self.get_optimal_quad(bare_quad, integrand, exact)
-
-        return quad
-
     def eval_diag_offset_integral(self, quad, d, diag_eri):
         """Evaluate the diagonal of the offset integral.
 
@@ -382,37 +354,6 @@ class dRPA(dTDA):
         integral += Liad
 
         return integral
-
-    def optimise_main_quad(self, d, diag_eri):
-        """
-        Optimise the grid spacing of Clenshaw-Curtis quadrature for the
-        main integral.
-
-        Parameters
-        ----------
-        d : numpy.ndarray
-            Orbital energy differences.
-        diag_eri : numpy.ndarray
-            Diagonal of the ERIs.
-
-        Returns
-        -------
-        points : numpy.ndarray
-            The quadrature points.
-        weights : numpy.ndarray
-            The quadrature weights.
-        """
-
-        bare_quad = self.gen_clencur_quad_inf(even=True)
-
-        exact = np.sum((d * (d + diag_eri)) ** 0.5)
-        exact -= 0.5 * np.dot(1.0 / d, d * diag_eri)
-        exact -= np.sum(d)
-
-        integrand = lambda quad: self.eval_diag_main_integral(quad, d, diag_eri)
-        quad = self.get_optimal_quad(bare_quad, integrand, exact)
-
-        return quad
 
     def eval_diag_main_integral(self, quad, d, diag_eri):
         """Evaluate the diagonal of the main integral.

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -71,13 +71,12 @@ class dRPA(dTDA):
             a, b = mpi_helper.allreduce(np.array([a, b]))
             a, b = a**0.5, b**0.5
             err = self.estimate_error_clencur(a, b)
-            logging.debug(f"Error at half quadrature:  [{'green' if a < 1e-3 else 'red'}]{a:.3e}")
-            logging.debug(
-                f"Error at quarter quadrature:  [{'green' if b < 1e-6 else 'red'}]{b:.3e}"
-            )
-            logging.debug(
-                f"Error estimate in quadrature:  [{'green' if err < 1e-12 else 'red'}]{err:.3e}"
-            )
+            style_half = logging.rate(a, 1e-4, 1e-3)
+            style_quar = logging.rate(b, 1e-8, 1e-6)
+            style_full = logging.rate(err, 1e-12, 1e-9)
+            logging.debug(f"Error at half quadrature:  [{style_half}]{a:.3e}[/]")
+            logging.debug(f"Error at quarter quadrature:  [{style_quar}]{b:.3e}[/]")
+            logging.debug(f"Error estimate in quadrature:  [{style_full}]{err:.3e}[/]")
 
         return integral[0] + offset
 
@@ -273,10 +272,8 @@ class dRPA(dTDA):
 
         solve = 10**res.x
         full_name = f"{f'{name} ' if name else ''}quadrature".capitalize()
-        logging.debug(
-            f"{full_name} scale:  {solve:.2e} "
-            f"(error = [{'green' if res.fun < 1e-10 else 'red'}]{res.fun:.2e}[/])"
-        )
+        style = logging.rate(res.fun, 1e-14, 1e-10)
+        logging.debug(f"{full_name} scale:  {solve:.2e} (error = [{style}]{res.fun:.2e}[/])")
 
         return self.rescale_quad(bare_quad, solve)
 
@@ -510,7 +507,7 @@ class dRPA(dTDA):
         # Check how many there are
         if len(real_roots) > 1:
             logging.warning(
-                "Nested quadrature error estimation gives [red]%d real roots[/]. "
+                "Nested quadrature error estimation gives [bad]%d real roots[/]. "
                 "Taking smallest positive root." % len(real_roots),
             )
         else:
@@ -522,7 +519,7 @@ class dRPA(dTDA):
         # Check if there is a root between 0 and 1
         if not np.any(np.logical_and(real_roots > 0, real_roots < 1)):
             logging.warning(
-                "Nested quadrature error estimation gives [red]no root between 0 and 1[/]."
+                "Nested quadrature error estimation gives [bad]no root between 0 and 1[/]."
             )
             return np.nan
         else:

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -13,8 +13,6 @@ from momentGW.evgw import evGW
 def kernel(
     gw,
     nmom_max,
-    mo_energy,
-    mo_coeff,
     moments=None,
     integrals=None,
 ):
@@ -27,10 +25,6 @@ def kernel(
         GW object.
     nmom_max : int
         Maximum moment number to calculate.
-    mo_energy : numpy.ndarray
-        Molecular orbital energies.
-    mo_coeff : numpy.ndarray
-        Molecular orbital coefficients.
     moments : tuple of numpy.ndarray, optional
         Tuple of (hole, particle) moments, if passed then they will
         be used  as the initial guess instead of calculating them.
@@ -58,17 +52,14 @@ def kernel(
     if integrals is None:
         integrals = gw.ao2mo()
 
-    gf_ref = gf = gw.init_gf(mo_energy)
+    mo_energy = gw.mo_energy.copy()
+    gf_ref = gf = gw.init_gf(gw.mo_energy)
 
     diis = util.DIIS()
     diis.space = gw.diis_space
 
     # Get the static part of the SE
-    se_static = gw.build_se_static(
-        integrals,
-        mo_energy=mo_energy,
-        mo_coeff=mo_coeff,
-    )
+    se_static = gw.build_se_static(integrals)
 
     conv = False
     th_prev = tp_prev = None
@@ -80,8 +71,8 @@ def kernel(
             if cycle > 1:
                 # Rotate ERIs into (MO, QMO) and (QMO occ, QMO vir)
                 integrals.update_coeffs(
-                    mo_coeff_g=(None if gw.g0 else gw._gf_to_coupling(gf, mo_coeff=mo_coeff)),
-                    mo_coeff_w=(None if gw.w0 else gw._gf_to_coupling(gf, mo_coeff=mo_coeff)),
+                    mo_coeff_g=(None if gw.g0 else gw._gf_to_coupling(gf, mo_coeff=gw.mo_coeff)),
+                    mo_coeff_w=(None if gw.w0 else gw._gf_to_coupling(gf, mo_coeff=gw.mo_coeff)),
                     mo_occ_w=None if gw.w0 else gw._gf_to_occ(gf),
                 )
 

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -4,9 +4,8 @@ for molecular systems.
 """
 
 import numpy as np
-from pyscf.lib import logger
 
-from momentGW import util
+from momentGW import util, logging
 from momentGW.base import BaseGW
 from momentGW.evgw import evGW
 
@@ -74,58 +73,62 @@ def kernel(
     conv = False
     th_prev = tp_prev = None
     for cycle in range(1, gw.max_cycle + 1):
-        logger.info(gw, "%s iteration %d", gw.name, cycle)
+        with logging.with_status(f"Iteration {cycle}"):
+            with logging.with_comment(f"Start of iteration {cycle}"):
+                logging.write("")
 
-        if cycle > 1:
-            # Rotate ERIs into (MO, QMO) and (QMO occ, QMO vir)
-            integrals.update_coeffs(
-                mo_coeff_g=(None if gw.g0 else gw._gf_to_coupling(gf, mo_coeff=mo_coeff)),
-                mo_coeff_w=(None if gw.w0 else gw._gf_to_coupling(gf, mo_coeff=mo_coeff)),
-                mo_occ_w=None if gw.w0 else gw._gf_to_occ(gf),
-            )
+            if cycle > 1:
+                # Rotate ERIs into (MO, QMO) and (QMO occ, QMO vir)
+                integrals.update_coeffs(
+                    mo_coeff_g=(None if gw.g0 else gw._gf_to_coupling(gf, mo_coeff=mo_coeff)),
+                    mo_coeff_w=(None if gw.w0 else gw._gf_to_coupling(gf, mo_coeff=mo_coeff)),
+                    mo_occ_w=None if gw.w0 else gw._gf_to_occ(gf),
+                )
 
-        # Update the moments of the SE
-        if moments is not None and cycle == 1:
-            th, tp = moments
-        else:
-            th, tp = gw.build_se_moments(
-                nmom_max,
-                integrals,
-                mo_energy=dict(
-                    g=gw._gf_to_energy(gf if not gw.g0 else gf_ref),
-                    w=gw._gf_to_energy(gf if not gw.w0 else gf_ref),
-                ),
-                mo_occ=dict(
-                    g=gw._gf_to_occ(gf if not gw.g0 else gf_ref),
-                    w=gw._gf_to_occ(gf if not gw.w0 else gf_ref),
-                ),
-            )
+            # Update the moments of the SE
+            if moments is not None and cycle == 1:
+                th, tp = moments
+            else:
+                th, tp = gw.build_se_moments(
+                    nmom_max,
+                    integrals,
+                    mo_energy=dict(
+                        g=gw._gf_to_energy(gf if not gw.g0 else gf_ref),
+                        w=gw._gf_to_energy(gf if not gw.w0 else gf_ref),
+                    ),
+                    mo_occ=dict(
+                        g=gw._gf_to_occ(gf if not gw.g0 else gf_ref),
+                        w=gw._gf_to_occ(gf if not gw.w0 else gf_ref),
+                    ),
+                )
 
-        # Extrapolate the moments
-        try:
-            th, tp = diis.update_with_scaling(np.array((th, tp)), (-2, -1))
-        except Exception:
-            logger.debug(gw, "DIIS step failed at iteration %d", cycle)
+            # Extrapolate the moments
+            try:
+                th, tp = diis.update_with_scaling(np.array((th, tp)), (-2, -1))
+            except Exception:
+                logging.warn(f"DIIS step [red]failed[/] at iteration {cycle}")
 
-        # Damp the moments
-        if gw.damping != 0.0 and cycle > 1:
-            th = gw.damping * th_prev + (1.0 - gw.damping) * th
-            tp = gw.damping * tp_prev + (1.0 - gw.damping) * tp
+            # Damp the moments
+            if gw.damping != 0.0 and cycle > 1:
+                th = gw.damping * th_prev + (1.0 - gw.damping) * th
+                tp = gw.damping * tp_prev + (1.0 - gw.damping) * tp
 
-        # Solve the Dyson equation
-        gf, se = gw.solve_dyson(th, tp, se_static, integrals=integrals)
-        gf = gw.remove_unphysical_poles(gf)
+            # Solve the Dyson equation
+            gf, se = gw.solve_dyson(th, tp, se_static, integrals=integrals)
+            gf = gw.remove_unphysical_poles(gf)
 
-        # Update the MO energies
-        mo_energy_prev = mo_energy.copy()
-        mo_energy = gw._gf_to_mo_energy(gf)
+            # Update the MO energies
+            mo_energy_prev = mo_energy.copy()
+            mo_energy = gw._gf_to_mo_energy(gf)
 
-        # Check for convergence
-        conv = gw.check_convergence(mo_energy, mo_energy_prev, th, th_prev, tp, tp_prev)
-        th_prev = th.copy()
-        tp_prev = tp.copy()
-        if conv:
-            break
+            # Check for convergence
+            conv = gw.check_convergence(mo_energy, mo_energy_prev, th, th_prev, tp, tp_prev)
+            th_prev = th.copy()
+            tp_prev = tp.copy()
+            with logging.with_comment(f"End of iteration {cycle}"):
+                logging.write("")
+            if conv:
+                break
 
     return conv, gf, se, None
 

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -5,7 +5,7 @@ for molecular systems.
 
 import numpy as np
 
-from momentGW import util, logging
+from momentGW import logging, util
 from momentGW.base import BaseGW
 from momentGW.evgw import evGW
 

--- a/momentGW/thc.py
+++ b/momentGW/thc.py
@@ -4,10 +4,9 @@ Tensor hyper-contraction.
 
 import h5py
 import numpy as np
-from pyscf import lib
 from scipy.special import binom
 
-from momentGW import ints, tda, util, logging, init_logging
+from momentGW import init_logging, ints, logging, tda, util
 
 
 class Integrals(ints.Integrals):

--- a/momentGW/uhf/base.py
+++ b/momentGW/uhf/base.py
@@ -17,10 +17,10 @@ class BaseUGW(BaseGW):  # noqa: D101
         # Separate the occupied and virtual GFs
         gf_occ = (
             self.gf[0].occupied().physical(weight=1e-1),
-            self.gf[0].occupied().physical(weight=1e-1),
+            self.gf[1].occupied().physical(weight=1e-1),
         )
         gf_vir = (
-            self.gf[1].virtual().physical(weight=1e-1),
+            self.gf[0].virtual().physical(weight=1e-1),
             self.gf[1].virtual().physical(weight=1e-1),
         )
 
@@ -105,7 +105,7 @@ class BaseUGW(BaseGW):  # noqa: D101
 
             if len(check) != self.nmo[s]:
                 # TODO improve this warning
-                logging.warn("[bad]Inconsistent quasiparticle weights![/]")
+                logging.warn(f"[bad]Inconsistent quasiparticle weights for {spin}![/]")
 
         return mo_energy
 

--- a/momentGW/uhf/base.py
+++ b/momentGW/uhf/base.py
@@ -7,10 +7,38 @@ import numpy as np
 from pyscf.mp.ump2 import get_frozen_mask, get_nmo, get_nocc
 
 from momentGW import logging
-from momentGW.base import BaseGW
+from momentGW.base import Base, BaseGW
 
 
 class BaseUGW(BaseGW):  # noqa: D101
+    def _get_header(self):
+        """
+        Get the header for the solver, with the name, options, and
+        problem size.
+        """
+
+        # Get the options table
+        options = Base._get_header(self)
+
+        # Get the problem size table
+        sizes = logging.Table(title="Sizes")
+        sizes.add_column("Space", justify="right")
+        sizes.add_column("Size (α)", justify="right")
+        sizes.add_column("Size (β)", justify="right")
+        sizes.add_row("MOs", f"{self.nmo[0]}", f"{self.nmo[1]}")
+        sizes.add_row("Occupied MOs", f"{self.nocc[0]}", f"{self.nocc[1]}")
+        sizes.add_row(
+            "Virtual MOs", f"{self.nmo[0] - self.nocc[0]}", f"{self.nmo[1] - self.nocc[1]}"
+        )
+
+        # Combine the tables
+        panel = logging.Table.grid()
+        panel.add_row(options)
+        panel.add_row("")
+        panel.add_row(sizes)
+
+        return panel
+
     def _get_excitations_table(self):
         """Return the excitations as a table."""
 

--- a/momentGW/uhf/base.py
+++ b/momentGW/uhf/base.py
@@ -4,79 +4,67 @@ references.
 """
 
 import numpy as np
-from pyscf.lib import logger
 from pyscf.mp.ump2 import get_frozen_mask, get_nmo, get_nocc
 
+from momentGW import logging
 from momentGW.base import BaseGW
 
 
 class BaseUGW(BaseGW):  # noqa: D101
-    def kernel(
-        self,
-        nmom_max,
-        mo_energy=None,
-        mo_coeff=None,
-        moments=None,
-        integrals=None,
-    ):
-        """Driver for the method.
+    def _get_excitations_table(self):
+        """Return the excitations as a table."""
 
-        Parameters
-        ----------
-        nmom_max : int
-            Maximum moment number to calculate.
-        mo_energy : tuple of numpy.ndarray
-            Molecular orbital energies for each spin channel.
-        mo_coeff : tuple of numpy.ndarray
-            Molecular orbital coefficients for each spin channel.
-        moments : tuple of numpy.ndarray, optional
-            Tuple of (hole, particle) moments for each spin channel, if
-            passed then they will be used instead of calculating them.
-            Default value is `None`.
-        integrals : UIntegrals, optional
-            Integrals object. If `None`, generate from scratch. Default
-            value is `None`.
-        """
-
-        if mo_coeff is None:
-            mo_coeff = self.mo_coeff
-        if mo_energy is None:
-            mo_energy = self.mo_energy
-
-        cput0 = (logger.process_clock(), logger.perf_counter())
-        self.dump_flags()
-        logger.info(self, "nmom_max = %d", nmom_max)
-
-        self.converged, self.gf, self.se, self._qp_energy = self._kernel(
-            nmom_max,
-            mo_energy,
-            mo_coeff,
-            integrals=integrals,
+        # Separate the occupied and virtual GFs
+        gf_occ = (
+            self.gf[0].occupied().physical(weight=1e-1),
+            self.gf[0].occupied().physical(weight=1e-1),
+        )
+        gf_vir = (
+            self.gf[1].virtual().physical(weight=1e-1),
+            self.gf[1].virtual().physical(weight=1e-1),
         )
 
-        for gf, s in zip(self.gf, ["α", "β"]):
-            gf_occ = gf.occupied().physical(weight=1e-1)
-            for n in range(min(5, gf_occ.naux)):
-                en = -gf_occ.energies[-(n + 1)]
-                vn = gf_occ.couplings[:, -(n + 1)]
-                qpwt = np.linalg.norm(vn) ** 2
-                logger.note(
-                    self, "IP energy level (%s) %d E = %.16g  QP weight = %0.6g", s, n, en, qpwt
+        # Build table
+        table = logging.Table(title="Green's function poles")
+        table.add_column("Excitation", justify="right")
+        table.add_column("Energy", justify="right", style="output")
+        table.add_column("QP weight", justify="right")
+        table.add_column("Dominant MOs", justify="right")
+
+        # Add IPs
+        for s, spin in enumerate(["α", "β"]):
+            for n in range(min(3, gf_occ[s].naux)):
+                en = -gf_occ[s].energies[-(n + 1)]
+                weights = gf_occ[s].couplings[:, -(n + 1)] ** 2
+                weight = np.sum(weights)
+                dominant = np.argsort(weights)[::-1]
+                dominant = dominant[weights[dominant] > 0.1][:3]
+                mo_string = ", ".join(
+                    [f"{i} ({100 * weights[i] / weight:5.1f}%)" for i in dominant]
                 )
+                table.add_row(f"IP ({spin}) {n:>2}", f"{en:.10f}", f"{weight:.5f}", mo_string)
 
-        for gf, s in zip(self.gf, ["α", "β"]):
-            gf_vir = gf.virtual().physical(weight=1e-1)
-            for n in range(min(5, gf_vir.naux)):
-                en = gf_vir.energies[n]
-                vn = gf_vir.couplings[:, n]
-                qpwt = np.linalg.norm(vn) ** 2
-                logger.note(
-                    self, "EA energy level (%s) %d E = %.16g  QP weight = %0.6g", s, n, en, qpwt
+            # Add a break
+            table.add_section()
+
+        for s, spin in enumerate(["α", "β"]):
+            # Add EAs
+            for n in range(min(3, gf_vir[s].naux)):
+                en = gf_vir[s].energies[n]
+                weights = gf_vir[s].couplings[:, n] ** 2
+                weight = np.sum(weights)
+                dominant = np.argsort(weights)[::-1]
+                dominant = dominant[weights[dominant] > 0.1][:3]
+                mo_string = ", ".join(
+                    [f"{i} ({100 * weights[i] / weight:5.1f}%)" for i in dominant]
                 )
+                table.add_row(f"EA ({spin}) {n:>2}", f"{en:.10f}", f"{weight:.5f}", mo_string)
 
-        logger.timer(self, self.name, *cput0)
+            # Add a break
+            if s != 1:
+                table.add_section()
 
-        return self.converged, self.gf, self.se, self.qp_energy
+        return table
 
     @staticmethod
     def _gf_to_occ(gf):
@@ -116,7 +104,8 @@ class BaseUGW(BaseGW):  # noqa: D101
                 check.add(arg)
 
             if len(check) != self.nmo[s]:
-                logger.warn(self, f"Inconsistent quasiparticle weights for {spin}!")
+                # TODO improve this warning
+                logging.warn("[bad]Inconsistent quasiparticle weights![/]")
 
         return mo_energy
 

--- a/momentGW/uhf/fock.py
+++ b/momentGW/uhf/fock.py
@@ -4,9 +4,8 @@ Fock matrix self-consistent loop for unrestricted references.
 
 import numpy as np
 from dyson import Lehmann
-from pyscf.lib import logger
 
-from momentGW import mpi_helper, util
+from momentGW import logging, mpi_helper, util
 from momentGW.fock import minimize_chempot, search_chempot
 
 
@@ -79,66 +78,67 @@ def fock_loop(
     opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner, occupancy=1)
     rdm1_prev = rdm1
 
-    for niter1 in range(1, max_cycle_outer + 1):
-        se_α, opt = minimize_chempot(se[0], fock[0], nelec[0], x0=se[0].chempot, **opts)
-        se_β, opt = minimize_chempot(se[1], fock[1], nelec[1], x0=se[1].chempot, **opts)
-        se = [se_α, se_β]
+    with logging.with_table(title="Fock loop") as table:
+        table.add_column("Iter", justify="right")
+        table.add_column("Cycle", justify="right")
+        table.add_column("Error (nα)", justify="right")
+        table.add_column("Error (nβ)", justify="right")
+        table.add_column("Δ (density)", justify="right")
 
-        for niter2 in range(1, max_cycle_inner + 1):
-            w, v = se[0].diagonalise_matrix(fock[0], chempot=0.0, out=buf)
-            w = mpi_helper.bcast(w, root=0)
-            v = mpi_helper.bcast(v, root=0)
-            se[0].chempot, nerr_α = search_chempot(w, v, nmo[0], nelec[0], occupancy=1)
+        for niter1 in range(1, max_cycle_outer + 1):
+            se_α, opt = minimize_chempot(se[0], fock[0], nelec[0], x0=se[0].chempot, **opts)
+            se_β, opt = minimize_chempot(se[1], fock[1], nelec[1], x0=se[1].chempot, **opts)
+            se = [se_α, se_β]
 
-            w, v = se[1].diagonalise_matrix(fock[1], chempot=0.0, out=buf)
-            w = mpi_helper.bcast(w, root=0)
-            v = mpi_helper.bcast(v, root=0)
-            se[1].chempot, nerr_β = search_chempot(w, v, nmo[1], nelec[1], occupancy=1)
+            for niter2 in range(1, max_cycle_inner + 1):
+                with logging.with_status(f"Iteration [{niter1}, {niter2}]"):
+                    w, v = se[0].diagonalise_matrix(fock[0], chempot=0.0, out=buf)
+                    w = mpi_helper.bcast(w, root=0)
+                    v = mpi_helper.bcast(v, root=0)
+                    se[0].chempot, nerr_α = search_chempot(w, v, nmo[0], nelec[0], occupancy=1)
+                    nerr_α = abs(nerr_α)
 
-            w, v = se[0].diagonalise_matrix(fock[0], out=buf)
-            w = mpi_helper.bcast(w, root=0)
-            v = mpi_helper.bcast(v, root=0)
-            gf[0] = Lehmann(w, v[: nmo[0]], chempot=se[0].chempot)
+                    w, v = se[1].diagonalise_matrix(fock[1], chempot=0.0, out=buf)
+                    w = mpi_helper.bcast(w, root=0)
+                    v = mpi_helper.bcast(v, root=0)
+                    se[1].chempot, nerr_β = search_chempot(w, v, nmo[1], nelec[1], occupancy=1)
+                    nerr_β = abs(nerr_β)
 
-            w, v = se[1].diagonalise_matrix(fock[1], out=buf)
-            w = mpi_helper.bcast(w, root=0)
-            v = mpi_helper.bcast(v, root=0)
-            gf[1] = Lehmann(w, v[: nmo[1]], chempot=se[1].chempot)
+                    w, v = se[0].diagonalise_matrix(fock[0], out=buf)
+                    w = mpi_helper.bcast(w, root=0)
+                    v = mpi_helper.bcast(v, root=0)
+                    gf[0] = Lehmann(w, v[: nmo[0]], chempot=se[0].chempot)
 
-            rdm1 = gf_to_dm(gf)
-            fock = integrals.get_fock(rdm1, h1e)
-            fock = diis.update(fock, xerr=None)
+                    w, v = se[1].diagonalise_matrix(fock[1], out=buf)
+                    w = mpi_helper.bcast(w, root=0)
+                    v = mpi_helper.bcast(v, root=0)
+                    gf[1] = Lehmann(w, v[: nmo[1]], chempot=se[1].chempot)
 
-            derr = np.max(np.absolute(rdm1 - rdm1_prev))
-            if derr < conv_tol_rdm1:
+                    rdm1 = gf_to_dm(gf)
+                    fock = integrals.get_fock(rdm1, h1e)
+                    fock = diis.update(fock, xerr=None)
+
+                    derr = np.max(np.absolute(rdm1 - rdm1_prev))
+                    if niter2 in {1, 5, 10, 50, 100, max_cycle_inner} or derr < conv_tol_rdm1:
+                        nerr_α_style = logging.rate(nerr_α, conv_tol_nelec, conv_tol_nelec * 1e2)
+                        nerr_β_style = logging.rate(nerr_β, conv_tol_nelec, conv_tol_nelec * 1e2)
+                        derr_style = logging.rate(derr, conv_tol_rdm1, conv_tol_rdm1 * 1e2)
+                        table.add_row(
+                            f"{niter1}",
+                            f"{niter2}",
+                            f"[{nerr_α_style}]{nerr_α:.3g}[/]",
+                            f"[{nerr_β_style}]{nerr_β:.3g}[/]",
+                            f"[{derr_style}]{derr:.3g}[/]",
+                        )
+                    if derr < conv_tol_rdm1:
+                        break
+
+                    rdm1_prev = rdm1.copy()
+
+            if derr < conv_tol_rdm1 and (nerr_α + nerr_β) < conv_tol_nelec:
+                converged = True
                 break
 
-            rdm1_prev = rdm1.copy()
-
-        logger.debug1(
-            gw,
-            "fock loop %d  cycles = %d  dNα = %.3g  dNβ = %.3g  |ddm| = %.3g",
-            niter1,
-            niter2,
-            nerr_α,
-            nerr_β,
-            derr,
-        )
-
-        if derr < conv_tol_rdm1 and (abs(nerr_α) + abs(nerr_β)) < conv_tol_nelec:
-            converged = True
-            break
-
-    logger.info(
-        gw,
-        "fock converged = %s  chempot (α) = %.9g  chempot (β) = %.9g  dNα = %.3g  dNβ = %.3g  "
-        + "|ddm| = %.3g",
-        converged,
-        se[0].chempot,
-        se[1].chempot,
-        nerr_α,
-        nerr_β,
-        derr,
-    )
+        logging.write(table)
 
     return tuple(gf), tuple(se), converged

--- a/momentGW/uhf/fock.py
+++ b/momentGW/uhf/fock.py
@@ -57,7 +57,8 @@ def fock_loop(
     if integrals is None:
         integrals = gw.ao2mo()
 
-    h1e = util.einsum("pq,spi,sqj->sij", gw._scf.get_hcore(), gw.mo_coeff, gw.mo_coeff)
+    with util.SilentSCF(gw._scf):
+        h1e = util.einsum("pq,spi,sqj->sij", gw._scf.get_hcore(), gw.mo_coeff, gw.mo_coeff)
     nmo = gw.nmo
     nocc = gw.nocc
     naux = (se[0].naux, se[1].naux)

--- a/momentGW/uhf/fock.py
+++ b/momentGW/uhf/fock.py
@@ -9,6 +9,8 @@ from momentGW import logging, mpi_helper, util
 from momentGW.fock import minimize_chempot, search_chempot
 
 
+@logging.with_timer("Fock loop")
+@logging.with_status("Running Fock loop")
 def fock_loop(
     gw,
     gf,

--- a/momentGW/uhf/fock.py
+++ b/momentGW/uhf/fock.py
@@ -77,7 +77,7 @@ def fock_loop(
     buf = np.zeros((max(nqmo), max(nqmo)))
     converged = False
     opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner, occupancy=1)
-    rdm1_prev = 0
+    rdm1_prev = rdm1
 
     for niter1 in range(1, max_cycle_outer + 1):
         se_α, opt = minimize_chempot(se[0], fock[0], nelec[0], x0=se[0].chempot, **opts)
@@ -109,10 +109,9 @@ def fock_loop(
             fock = integrals.get_fock(rdm1, h1e)
             fock = diis.update(fock, xerr=None)
 
-            if niter2 > 1:
-                derr = np.max(np.absolute(rdm1 - rdm1_prev))
-                if derr < conv_tol_rdm1:
-                    break
+            derr = np.max(np.absolute(rdm1 - rdm1_prev))
+            if derr < conv_tol_rdm1:
+                break
 
             rdm1_prev = rdm1.copy()
 

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -198,6 +198,10 @@ class UGW(BaseUGW, GW):  # noqa: D101
         )
         cpt = (cpt_α, cpt_β)
         error = (error_α, error_β)
+        se[0].chempot = cpt[0]
+        se[1].chempot = cpt[1]
+        gf[0].chempot = cpt[0]
+        gf[1].chempot = cpt[1]
 
         logging.write("")
         for s, spin in enumerate(["α", "β"]):
@@ -208,14 +212,9 @@ class UGW(BaseUGW, GW):  # noqa: D101
             )
             logging.write(f"Error in number of electrons ({spin}):  [{color}]{error[s]:.3e}[/]")
         for s, spin in enumerate(["α", "β"]):
-            logging.write(f"Chemical potential ({spin}):  {cpt[0]:.6f}")
+            logging.write(f"Chemical potential ({spin}):  {cpt[s]:.6f}")
 
-        se[0].chempot = cpt[0]
-        se[1].chempot = cpt[1]
-        gf[0].chempot = cpt[0]
-        gf[1].chempot = cpt[1]
-
-        return gf, se
+        return tuple(gf), tuple(se)
 
     def make_rdm1(self, gf=None):
         """Get the first-order reduced density matrix.

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -261,9 +261,11 @@ class UGW(BaseUGW, GW):  # noqa: D101
         if integrals is None:
             integrals = self.ao2mo()
 
-        h1e = tuple(
-            util.einsum("pq,pi,qj->ij", self._scf.get_hcore(), c.conj(), c) for c in self.mo_coeff
-        )
+        with util.SilentSCF(self._scf):
+            h1e = tuple(
+                util.einsum("pq,pi,qj->ij", self._scf.get_hcore(), c.conj(), c)
+                for c in self.mo_coeff
+            )
         rdm1 = self.make_rdm1(gf=gf)
         fock = integrals.get_fock(rdm1, h1e)
 

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -138,7 +138,6 @@ class UIntegrals(Integrals):
                         Lxy = np.zeros((self.naux_full, p1 - p0))
                         b1 = 0
                         for block in self.with_df.loop():
-                            block = lib.unpack_tril(block)
                             b0, b1 = b1, b1 + block.shape[0]
                             progress = (p0 * self.naux_full + b0) / (ni * nj * self.naux_full)
                             with logging.with_status(

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -3,7 +3,6 @@ Integral helpers with unrestricted reference.
 """
 
 import numpy as np
-from pyscf import lib
 from pyscf.ao2mo import _ao2mo
 
 from momentGW import logging, mpi_helper

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -6,7 +6,7 @@ import numpy as np
 from pyscf import lib
 from pyscf.ao2mo import _ao2mo
 
-from momentGW import init_logging, logging, mpi_helper
+from momentGW import logging, mpi_helper
 from momentGW.ints import Integrals
 
 
@@ -77,9 +77,6 @@ class UIntegrals(Integrals):
         self.compression = compression
         self.compression_tol = compression_tol
         self.store_full = store_full
-
-        # Logging
-        init_logging()
 
         # Attributes
         self._spins = {

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -8,6 +8,8 @@ import scipy.linalg
 from pyscf import __config__ as _pyscf_config
 from pyscf import lib
 
+from momentGW import logging
+
 # Define the size of problem to fall back on NumPy
 NUMPY_EINSUM_SIZE = 2000
 
@@ -178,16 +180,13 @@ class DIIS(lib.diis.DIIS):
 
         w, v = scipy.linalg.eigh(h)
         if np.any(abs(w) < 1e-14):
-            lib.logger.debug(self, "Linear dependence found in DIIS error vectors.")
             idx = abs(w) > 1e-14
             c = np.dot(v[:, idx] * (1.0 / w[idx]), np.dot(v[:, idx].T.conj(), g))
         else:
             try:
                 c = np.linalg.solve(h, g)
             except np.linalg.linalg.LinAlgError as e:
-                lib.logger.warn(self, " diis singular, eigh(h) %s", w)
-                raise e
-        lib.logger.debug1(self, "diis-c %s", c)
+                raise np.linalg.linalg.LinAlgError("DIIS matrix is singular.") from e
 
         if np.all(abs(c) < 1e-14):
             raise np.linalg.linalg.LinAlgError("DIIS vectors are fully linearly dependent.")

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -5,7 +5,7 @@ import time
 
 import numpy as np
 import scipy.linalg
-from pyscf import config, lib
+from pyscf import lib, __config__ as _pyscf_config
 
 # Define the size of problem to fall back on NumPy
 NUMPY_EINSUM_SIZE = 2000
@@ -217,8 +217,8 @@ class SilentSCF:
         Return the SCF object with verbosity set to zero.
         """
 
-        self._cache["config"] = config.VERBOSE
-        config.VERBOSE = 0
+        self._cache["config"] = _pyscf_config.VERBOSE
+        _pyscf_config.VERBOSE = 0
 
         self._cache["mol"] = self.mf.mol.verbose
         self.mf.mol.verbose = 0
@@ -236,7 +236,7 @@ class SilentSCF:
         """
         Reset the verbosity of the SCF object.
         """
-        config.VERBOSE = self._cache["config"]
+        _pyscf_config.VERBOSE = self._cache["config"]
         self.mf.mol.verbose = self._cache["mol"]
         self.mf.verbose = self._cache["mf"]
         if getattr(self.mf, "with_df", None):

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -41,13 +41,13 @@ class Timer:
 
         out = []
         if hours:
-            out.append("%d h" % hours)
+            out.append("%3d h" % hours)
         if minutes:
-            out.append("%d m" % minutes)
+            out.append("%2d m" % minutes)
         if seconds:
-            out.append("%d s" % seconds)
+            out.append("%2d s" % seconds)
         if milliseconds:
-            out.append("%d ms" % milliseconds)
+            out.append("%3d ms" % milliseconds)
 
         return " ".join(out[-max(precision, len(out)) :])
 

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -1,12 +1,55 @@
 """Utility functions.
 """
 
+import time
+
 import numpy as np
 import scipy.linalg
 from pyscf import lib
 
 # Define the size of problem to fall back on NumPy
 NUMPY_EINSUM_SIZE = 2000
+
+
+class Timer:
+    """Timer class."""
+
+    def __init__(self):
+        self.t_init = time.perf_counter()
+        self.t_prev = time.perf_counter()
+        self.t_curr = time.perf_counter()
+
+    def lap(self):
+        """Return the time since the last call to `lap`."""
+        self.t_prev, self.t_curr = self.t_curr, time.perf_counter()
+        return self.t_curr - self.t_prev
+
+    __call__ = lap
+
+    def total(self):
+        """Return the total time since initialization."""
+        return time.perf_counter() - self.t_init
+
+    @staticmethod
+    def format_time(seconds, precision=2):
+        """Return a formatted time."""
+
+        seconds, milliseconds = divmod(seconds, 1)
+        milliseconds *= 1000
+        minutes, seconds = divmod(seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+
+        out = []
+        if hours:
+            out.append("%d h" % hours)
+        if minutes:
+            out.append("%d m" % minutes)
+        if seconds:
+            out.append("%d s" % seconds)
+        if milliseconds:
+            out.append("%d ms" % milliseconds)
+
+        return " ".join(out[-max(precision, len(out)) :])
 
 
 class DIIS(lib.diis.DIIS):

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -5,7 +5,8 @@ import time
 
 import numpy as np
 import scipy.linalg
-from pyscf import lib, __config__ as _pyscf_config
+from pyscf import __config__ as _pyscf_config
+from pyscf import lib
 
 # Define the size of problem to fall back on NumPy
 NUMPY_EINSUM_SIZE = 2000

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -8,8 +8,6 @@ import scipy.linalg
 from pyscf import __config__ as _pyscf_config
 from pyscf import lib
 
-from momentGW import logging
-
 # Define the size of problem to fall back on NumPy
 NUMPY_EINSUM_SIZE = 2000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "coverage[toml]>=5.5.0",
     "pytest>=6.2.4",
     "pytest-cov>=4.0.0",
+    "pytest-env>=1.1.0",
 ]
 
 [tool.black]
@@ -133,3 +134,6 @@ directory = "cov_html"
 testpaths = [
     "tests",
 ]
+
+[tool.pytest_env]
+MOMENTGW_SILENT = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "numpy>=1.19.0",
     "scipy<=1.10.0",
     "pyscf>=2.0.0",
+    "rich>=13.0.0",
     "dyson @ git+https://github.com/BoothGroup/dyson@master",
 ]
 dynamic = [

--- a/tests/test_fskgw.py
+++ b/tests/test_fskgw.py
@@ -78,7 +78,7 @@ class Test_fsKGW(unittest.TestCase):
         np.testing.assert_allclose(e1, e2, atol=1e-8)
 
     def test_dtda_vs_supercell(self):
-        nmom_max = 3
+        nmom_max = 1
 
         kgw = fsKGW(self.mf)
         kgw.polarizability = "dtda"


### PR DESCRIPTION
This PR overhauls the logging system:

- `Base` no longer inherits from `pyscf.lib.StreamObject`, so we don't need to use their standards for the logging internals
- Added `rich` dependency
- Changed logging internals to use a `rich.Console` instance with colour coded outputs, live status and table updates, and much better formatted outputs
- Added `MOMENTGW_SILENT` environment variable (or `momentGW.logging.silent`) to suppress outputs
- Removed timings from outputs -- a table of useful timings can be printed using `momentGW.logging.dump_times()` at the end of a script
- Removed `mo_energy` and `mo_coeff` from kernel arguments -- this is legacy stuff from PySCF styles, I don't think it's necessary and doesn't even work properly

To-do:

- [x] `momentGW`
- [x] `momentGW.uhf`
- [x] `momentGW.pbc`
- [x] `momentGW.pbc.uhf`
- [x] Clean up