### PR TITLE
Self-energy construction fixes

### DIFF
--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -114,8 +114,9 @@ class GW(BaseGW):  # noqa: D101
             with util.SilentSCF(self._scf):
                 dm = self._scf.make_rdm1(mo_coeff=self.mo_coeff)
                 veff = self._scf.get_veff(dm=dm)
+                vj = self._scf.get_j(dm=dm)
 
-            vhf = integrals.get_veff(dm, basis="ao")
+            vhf = integrals.get_veff(dm, j=vj, basis="ao")
             se_static = vhf - veff
             se_static = util.einsum(
                 "...pq,...pi,...qj->...ij", se_static, np.conj(self.mo_coeff), self.mo_coeff

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -112,8 +112,8 @@ class GW(BaseGW):  # noqa: D101
             se_static = np.zeros_like(self._scf.make_rdm1(mo_coeff=self.mo_coeff))
         else:
             with util.SilentSCF(self._scf):
-                veff = self._scf.get_veff()
                 dm = self._scf.make_rdm1(mo_coeff=self.mo_coeff)
+                veff = self._scf.get_veff(dm=dm)
 
             vhf = integrals.get_veff(dm, basis="ao")
             se_static = vhf - veff

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -113,7 +113,7 @@ class GW(BaseGW):  # noqa: D101
         else:
             with util.SilentSCF(self._scf):
                 veff = self._scf.get_veff()
-                dm = self._scf.make_rdm1(mo_coeff=mo_coeff)
+                dm = self._scf.make_rdm1(mo_coeff=self.mo_coeff)
 
             vhf = integrals.get_veff(dm, basis="ao")
             se_static = vhf - veff

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -132,11 +132,11 @@ class GW(BaseGW):  # noqa: D101
             se_static = np.zeros_like(self._scf.make_rdm1(mo_coeff=mo_coeff))
         else:
             with util.SilentSCF(self._scf):
-                vmf = self._scf.get_j() - self._scf.get_veff()
+                veff = self._scf.get_veff()
                 dm = self._scf.make_rdm1(mo_coeff=mo_coeff)
-                vk = integrals.get_k(dm, basis="ao")
 
-            se_static = vmf - vk * 0.5
+            vhf = integrals.get_veff(dm, basis="ao")
+            se_static = vhf - veff
             se_static = util.einsum(
                 "...pq,...pi,...qj->...ij", se_static, np.conj(mo_coeff), mo_coeff
             )

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -113,8 +113,8 @@ class GW(BaseGW):  # noqa: D101
         else:
             with util.SilentSCF(self._scf):
                 dm = self._scf.make_rdm1(mo_coeff=self.mo_coeff)
-                veff = self._scf.get_veff(dm=dm)
-                vj = self._scf.get_j(dm=dm)
+                veff = self._scf.get_veff(None, dm)
+                vj = self._scf.get_j(None, dm)
 
             vhf = integrals.get_veff(dm, j=vj, basis="ao")
             se_static = vhf - veff

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -472,19 +472,28 @@ class Integrals:
         """
         return self.get_j(dm, **kwargs), self.get_k(dm, **kwargs)
 
-    def get_veff(self, dm, **kwargs):
+    def get_veff(self, dm, j=None, k=None, **kwargs):
         """Build the effective potential.
 
         Returns
         -------
         veff : numpy.ndarray
             Effective potential.
+        j : numpy.ndarray, optional
+            J matrix. If `None`, compute it. Default value is `None`.
+        k : numpy.ndarray, optional
+            K matrix. If `None`, compute it. Default value is `None`.
 
         Notes
         -----
         See `get_jk` for more information.
         """
-        vj, vk = self.get_jk(dm, **kwargs)
+        if j is None and k is None:
+            vj, vk = self.get_jk(dm, **kwargs)
+        elif j is None:
+            vj, vk = self.get_j(dm, **kwargs), k
+        elif k is None:
+            vj, vk = j, self.get_k(dm, **kwargs)
         return vj - vk * 0.5
 
     def get_fock(self, dm, h1e, **kwargs):

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -454,6 +454,21 @@ class Integrals:
         """
         return self.get_j(dm, **kwargs), self.get_k(dm, **kwargs)
 
+    def get_veff(self, dm, **kwargs):
+        """Build the effective potential.
+
+        Returns
+        -------
+        veff : numpy.ndarray
+            Effective potential.
+
+        Notes
+        -----
+        See `get_jk` for more information.
+        """
+        vj, vk = self.get_jk(dm, **kwargs)
+        return vj - vk * 0.5
+
     def get_fock(self, dm, h1e, **kwargs):
         """Build the Fock matrix.
 
@@ -476,8 +491,8 @@ class Integrals:
         See `get_jk` for more information. The basis of `h1e` must be
         the same as `dm`.
         """
-        vj, vk = self.get_jk(dm, **kwargs)
-        return h1e + vj - vk * 0.5
+        veff = self.get_veff(dm, **kwargs)
+        return h1e + veff
 
     @property
     def Lpq(self):

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -303,30 +303,27 @@ class UIntegrals(Integrals):
 
         return vk
 
-    def get_fock(self, dm, h1e, **kwargs):
-        """Build the Fock matrix.
+    def get_veff(self, dm, **kwargs):
+        """Build the effective potential.
 
         Parameters
         ----------
         dm : numpy.ndarray
             Density matrix for each spin channel.
-        h1e : numpy.ndarray
-            Core Hamiltonian matrix for each spin channel.
         **kwargs : dict, optional
             Additional keyword arguments for `get_jk`.
 
         Returns
         -------
-        fock : numpy.ndarray
-            Fock matrix for each spin channel.
+        veff : numpy.ndarray
+            Effective potential.
 
         Notes
         -----
-        See `get_jk` for more information. The basis of `h1e` must be
-        the same as `dm`.
+        See `get_jk` for more information.
         """
         vj, vk = self.get_jk(dm, **kwargs)
-        return h1e + vj - vk
+        return vj - vk
 
     def __getitem__(self, key):
         """Get the integrals for one spin."""

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -313,13 +313,19 @@ class UIntegrals(Integrals):
 
         return vk
 
-    def get_veff(self, dm, **kwargs):
+    def get_veff(self, dm, j=None, k=None, **kwargs):
         """Build the effective potential.
 
         Parameters
         ----------
         dm : numpy.ndarray
             Density matrix for each spin channel.
+        j : numpy.ndarray, optional
+            J matrix for each spin channel. If `None`, compute it.
+            Default value is `None`.
+        k : numpy.ndarray, optional
+            K matrix for each spin channel. If `None`, compute it.
+            Default value is `None`.
         **kwargs : dict, optional
             Additional keyword arguments for `get_jk`.
 
@@ -332,7 +338,12 @@ class UIntegrals(Integrals):
         -----
         See `get_jk` for more information.
         """
-        vj, vk = self.get_jk(dm, **kwargs)
+        if j is None and k is None:
+            vj, vk = self.get_jk(dm, **kwargs)
+        elif j is None:
+            vj, vk = self.get_j(dm, **kwargs), k
+        elif k is None:
+            vj, vk = j, self.get_k(dm, **kwargs)
         return vj - vk
 
     def __getitem__(self, key):

--- a/tests/test_fsgw.py
+++ b/tests/test_fsgw.py
@@ -50,11 +50,11 @@ class Test_fsGW(unittest.TestCase):
 
     def test_regression_pbe(self):
         # Quasiparticle energies:
-        ip = -0.298634443617
-        ea = 0.009231958865
+        ip = -0.298631888610
+        ea = 0.009232004612
         # GF poles:
-        ip_full = -0.279442462661
-        ea_full = 0.006197011695
+        ip_full = -0.279446170582
+        ea_full = 0.006189745568
         self._test_regression("pbe", dict(), 3, ip, ea, ip_full, ea_full, "pbe srg")
 
 

--- a/tests/test_qsgw.py
+++ b/tests/test_qsgw.py
@@ -40,20 +40,20 @@ class Test_qsGW(unittest.TestCase):
 
     def test_regression_simple(self):
         # Quasiparticle energies:
-        ip = -0.274195090782
-        ea = 0.076494888472
+        ip = -0.274195084690
+        ea = 0.076494883697
         # GF poles:
-        ip_full = -0.264403356683
-        ea_full = 0.074970722944
+        ip_full = -0.264403349572
+        ea_full = 0.074970718795
         self._test_regression("hf", dict(), 1, ip, ea, ip_full, ea_full, "simple")
 
     def test_regression_pbe_srg(self):
         # Quasiparticle energies:
-        ip = -0.271017107281
-        ea = 0.075779752028
+        ip = -0.271017148443
+        ea = 0.075779760938
         # GF poles:
-        ip_full = -0.393373116391
-        ea_full = 0.171968122921
+        ip_full = -0.393500679528
+        ea_full = 0.170103953696
         self._test_regression("pbe", dict(srg=1000), 3, ip, ea, ip_full, ea_full, "pbe srg")
 
 


### PR DESCRIPTION
Implements a more rigorous construction of the static self-energy.

- [x] Implements `Integrals.get_veff` methods (`vj - vk * 0.5` for RHF, `vj - vk` for UHF)
- [x] Fixes static self-energy for non-HF UKS input (side effect of above)