### PR TITLE
Fock loop solvers

### DIFF
--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -45,6 +45,13 @@ except ImportError:
     raise ImportError("Missing dependency: https://github.com/BoothGroup/dyson")
 
 
+# --- Patch `dyson` to suppress logging
+
+import dyson
+
+dyson.default_log.setLevel(logging.CRITICAL)
+
+
 # --- Imports
 
 from momentGW import logging

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -4,7 +4,7 @@ constraints for molecular systems.
 """
 
 import numpy as np
-from dyson import CPGF, MBLGF, NullLogger
+from dyson import CPGF, MBLGF
 from pyscf import lib
 
 from momentGW import logging, mpi_helper, util
@@ -315,9 +315,7 @@ class BSE(Base):
             Moments of the dynamic polarizability.
         """
 
-        nlog = NullLogger()
-
-        solver = MBLGF(np.array(moments), log=nlog)
+        solver = MBLGF(np.array(moments))
         solver.kernel()
 
         gf = solver.get_greens_function()
@@ -533,8 +531,6 @@ class cpBSE(BSE):
             Chebyshev moments of the dynamic polarizability.
         """
 
-        nlog = NullLogger()
-
         solver = CPGF(
             np.array(moments),
             self.grid,
@@ -543,7 +539,6 @@ class cpBSE(BSE):
             # Maybe these are unnecessary?
             trace=False,
             include_real=True,
-            log=nlog,
         )
         gf = solver.kernel()
 

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -7,7 +7,7 @@ import scipy
 from dyson import Lehmann
 from pyscf import lib
 
-from momentGW import logging, mpi_helper, util
+from momentGW import init_logging, logging, mpi_helper, util
 
 
 class ChemicalPotentialError(ValueError):
@@ -86,7 +86,7 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
     buf = np.zeros(((nphys + naux) ** 2,), dtype=dtype)
     fargs = (se, fock, nelec, occupancy, buf)
 
-    options = dict(maxiter=maxiter, ftol=tol, xtol=tol, gtol=tol)
+    options = dict(maxfun=maxiter, ftol=tol, xtol=tol, gtol=tol)
     kwargs = dict(x0=x0, method="TNC", jac=True, options=options)
     fun = _gradient
 
@@ -99,35 +99,292 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
     return se, opt
 
 
-@logging.with_timer("Fock loop")
-@logging.with_status("Running Fock loop")
-def fock_loop(
-    gw,
-    gf,
-    se,
-    integrals=None,
-    fock_diis_space=10,
-    fock_diis_min_space=1,
-    conv_tol_nelec=1e-6,
-    conv_tol_rdm1=1e-8,
-    max_cycle_inner=100,
-    max_cycle_outer=20,
-):
+class BaseFockLoop:
+    """Base class for Fock loops."""
+
+    _opts = []
+
+    # --- Default Fock loop options
+
+    fock_diis_space = 10
+    fock_diis_min_space = 1
+    conv_tol_nelec = 1e-6
+    conv_tol_rdm1 = 1e-8
+    max_cycle_inner = 100
+    max_cycle_outer = 20
+
+    def __init__(self, gw, gf=None, se=None, **kwargs):
+        # Parameters
+        self.gw = gw
+
+        # Options
+        for key, val in kwargs.items():
+            if not hasattr(self, key):
+                raise AttributeError(f"{key} is not a valid option for {self.name}")
+            setattr(self, key, val)
+
+        # Attributes
+        self._h1e = None
+        self.converged = None
+        self.gf = gf if gf is not None else gw.init_gf()
+        self.se = se
+
+        # Logging
+        init_logging()
+
+    def auxiliary_shift(self, fock=None, se=None):
+        """
+        Optimise a shift in the auxiliary energies to best satisfy the
+        electron number.
+        """
+        raise NotImplementedError
+
+    def solve_dyson(self, fock=None, se=None, chempot=0.0):
+        """Solve the Dyson equation for a given Fock matrix."""
+        raise NotImplementedError
+
+    def search_chempot(self, gf=None):
+        """Search for a chemical potential."""
+        raise NotImplementedError
+
+    @logging.with_timer("Fock loop")
+    @logging.with_status("Running Fock loop")
+    def kernel(self, integrals=None):
+        """Driver for the Fock loop.
+
+        Parameters
+        ----------
+        integrals : Integrals, optional
+            Integrals object. If `None`, generate from scratch. Default
+            value is `None`.
+
+        Returns
+        -------
+        converged : bool
+            Whether the loop has converged.
+        gf : dyson.Lehmann
+            Green's function.
+        se : dyson.Lehmann
+            Self-energy.
+        """
+
+        if self.se is None:
+            kernel = self._kernel_static
+        else:
+            kernel = self._kernel_dynamic
+
+        self.converged, self.gf, self.se = kernel(integrals=integrals)
+
+        return self.converged, self.gf, self.se
+
+    def _kernel_dynamic(self, integrals=None):
+        """Driver for the Fock loop with a self-energy."""
+
+        if integrals is None:
+            integrals = self.gw.ao2mo()
+
+        diis = util.DIIS()
+        diis.space = self.fock_diis_space
+        diis.min_space = self.fock_diis_min_space
+
+        gf = self.gf
+        se = self.se
+
+        rdm1 = rdm1_prev = self.make_rdm1(gf=gf)
+        fock = self.get_fock(integrals, rdm1)
+
+        with logging.with_table(title="Fock loop") as table:
+            table.add_column("Iter", justify="right")
+            table.add_column("Cycle", justify="right")
+            table.add_column("Error (nelec)", justify="right")
+            table.add_column("Δ (density)", justify="right")
+
+            converged = False
+            for cycle1 in range(1, self.max_cycle_outer + 1):
+                se = self.auxiliary_shift(fock, se=se)
+
+                for cycle2 in range(1, self.max_cycle_inner + 1):
+                    with logging.with_status(f"Iteration [{cycle1}, {cycle2}]"):
+                        gf, nerr = self.solve_dyson(fock, se=se)
+                        rdm1 = self.make_rdm1(gf=gf)
+                        fock = self.get_fock(integrals, rdm1)
+                        fock = diis.update(fock, xerr=None)
+
+                        derr = self._density_error(rdm1, rdm1_prev)
+                        if (
+                            cycle2 in {1, 5, 10, 50, 100, self.max_cycle_inner}
+                            or derr < self.conv_tol_rdm1
+                        ):
+                            nerr_style = logging.rate(
+                                nerr, self.conv_tol_nelec, self.conv_tol_nelec * 1e2
+                            )
+                            derr_style = logging.rate(
+                                derr, self.conv_tol_rdm1, self.conv_tol_rdm1 * 1e2
+                            )
+                            table.add_row(
+                                f"{cycle1}",
+                                f"{cycle2}",
+                                f"[{nerr_style}]{nerr:.3g}[/]",
+                                f"[{derr_style}]{derr:.3g}[/]",
+                            )
+                        if derr < self.conv_tol_rdm1:
+                            break
+
+                        rdm1_prev = rdm1
+
+                if derr < self.conv_tol_rdm1 and nerr < self.conv_tol_nelec:
+                    converged = True
+                    break
+
+            else:
+                converged = False
+
+            logging.write(table)
+
+        return converged, gf, se
+
+    def _kernel_static(self, integrals=None):
+        """Driver for the Fock loop without a self-energy."""
+
+        if integrals is None:
+            integrals = self.gw.ao2mo()
+
+        diis = util.DIIS()
+        diis.space = self.fock_diis_space
+        diis.min_space = self.fock_diis_min_space
+
+        gf = self.gf
+
+        rdm1 = rdm1_prev = self.make_rdm1(gf=gf)
+        fock = self.get_fock(integrals, rdm1)
+
+        with logging.with_table(title="Fock loop") as table:
+            table.add_column("Iter", justify="right")
+            table.add_column("Δ (density)", justify="right")
+
+            for cycle in range(1, self.max_cycle_inner + 1):
+                with logging.with_status(f"Iteration {cycle}"):
+                    gf = self.solve_dyson(fock)
+                    chempot, _ = self.search_chempot(gf=gf)
+                    gf.chempot = chempot
+
+                    rdm1 = self.make_rdm1(gf=gf)
+                    fock = self.get_fock(integrals, rdm1)
+                    fock = diis.update(fock, xerr=None)
+
+                    derr = np.max(np.absolute(rdm1 - rdm1_prev))
+                    if (
+                        cycle in {1, 5, 10, 50, 100, self.max_cycle_inner}
+                        or derr < self.conv_tol_rdm1
+                    ):
+                        style = logging.rate(derr, self.conv_tol_rdm1, self.conv_tol_rdm1 * 1e2)
+                        table.add_row(f"{cycle}", f"[{style}]{derr:.3g}[/]")
+                    if derr < self.conv_tol_rdm1:
+                        converged = True
+                        break
+
+                    rdm1_prev = rdm1.copy()
+
+            else:
+                converged = False
+
+            logging.write(table)
+
+        return converged, gf, None
+
+    @property
+    def h1e(self):
+        """Get the core Hamiltonian."""
+        if self._h1e is None:
+            with util.SilentSCF(self.gw._scf):
+                self._h1e = util.einsum(
+                    "...pq,...pi,...qj->...ij",
+                    self.gw._scf.get_hcore(),
+                    np.conj(self.mo_coeff),
+                    self.mo_coeff,
+                )
+        return self._h1e
+
+    def make_rdm1(self, gf=None):
+        """Get the first-order reduced density matrix.
+
+        Parameters
+        ----------
+        gf : dyson.Lehmann, optional
+            Green's function. If `None`, use either `self.gf`, or the
+            mean-field Green's function. Default value is `None`.
+
+        Returns
+        -------
+        rdm1 : numpy.ndarray
+            First-order reduced density matrix.
+        """
+
+        if gf is None:
+            gf = self.gf
+
+        return self.gw.make_rdm1(gf=gf)
+
+    def get_fock(self, integrals, rdm1, h1e=None):
+        """Get the Fock matrix.
+
+        Parameters
+        ----------
+        integrals : Integrals
+            Integrals object.
+        rdm1 : numpy.ndarray
+            First-order reduced density matrix.
+        h1e : numpy.ndarray, optional
+            Core Hamiltonian. If `None`, use `self.h1e`. Default value
+            is `None`.
+
+        Returns
+        -------
+        fock : numpy.ndarray
+            Fock matrix.
+        """
+
+        if h1e is None:
+            h1e = self.h1e
+
+        return integrals.get_fock(rdm1, h1e)
+
+    def _density_error(self, rdm1, rdm1_prev):
+        """Calculate the density error."""
+        return np.max(np.abs(rdm1 - rdm1_prev)).real
+
+    @property
+    def mo_coeff(self):
+        """Get the MO coefficients."""
+        return self.gw.mo_coeff
+
+    @property
+    def nmo(self):
+        """Get the number of MOs."""
+        return self.gw.nmo
+
+    @property
+    def nocc(self):
+        """Get the number of occupied MOs."""
+        return self.gw.nocc
+
+
+class FockLoop(BaseFockLoop):
     """
     Self-consistent loop for the density matrix via the Hartree--Fock
-    self-consistent field.
+    self-consistent field for spin-restricted molecular systems.
 
     Parameters
     ----------
     gw : BaseGW
         GW object.
-    gf : dyson.Lehmann
-        Green's function object.
-    se : dyson.Lehmann
-        Self-energy object.
-    integrals : Integrals, optional
-        Integrals object. If `None`, generate from scratch. Default
-        value is `None`.
+    gf : dyson.Lehmann, optional
+        Initial Green's function object. If `None`, use `gw.init_gf()`.
+        Default value is `None`.
+    se : dyson.Lehmann, optional
+        Initial self-energy object. If passed, use as dynamic part of
+        the self-energy. If `None`, self-energy is assumed to be static
+        and fully defined by the Fock matrix. Default value is `None`.
     fock_diis_space : int, optional
         DIIS space size for the Fock matrix. Default value is `10`.
     fock_diis_min_space : int, optional
@@ -145,74 +402,101 @@ def fock_loop(
         Maximum number of outer iterations. Default value is `20`.
     """
 
-    if integrals is None:
-        integrals = gw.ao2mo()
+    def auxiliary_shift(self, fock, se=None):
+        """
+        Optimise a shift in the auxiliary energies to best satisfy the
+        electron number.
 
-    with util.SilentSCF(gw._scf):
-        h1e = np.linalg.multi_dot((gw.mo_coeff.T, gw._scf.get_hcore(), gw.mo_coeff))
-    nmo = gw.nmo
-    nocc = gw.nocc
-    naux = se.naux
-    nqmo = nmo + naux
-    nelec = nocc * 2
+        Parameters
+        ----------
+        fock : numpy.ndarray
+            Fock matrix.
+        se : dyson.Lehmann, optional
+            Self-energy. If `None`, use `self.se`. Default value is
+            `None`.
 
-    diis = util.DIIS()
-    diis.space = fock_diis_space
-    diis.min_space = fock_diis_min_space
-    gf_to_dm = lambda gf: gf.occupied().moment(0) * 2.0
-    rdm1 = gf_to_dm(gf)
-    fock = integrals.get_fock(rdm1, h1e)
+        Returns
+        -------
+        se : dyson.Lehmann
+            Self-energy.
 
-    buf = np.zeros((nqmo, nqmo))
-    converged = False
-    opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner)
-    rdm1_prev = rdm1
+        Notes
+        -----
+        If there is no dynamic part of the self-energy (`self.se` is
+        `None`), this method returns `None`.
+        """
 
-    with logging.with_table(title="Fock loop") as table:
-        table.add_column("Iter", justify="right")
-        table.add_column("Cycle", justify="right")
-        table.add_column("Error (nelec)", justify="right")
-        table.add_column("Δ (density)", justify="right")
+        if se is None:
+            se = self.se
+        if se is None:
+            return None
 
-        for niter1 in range(1, max_cycle_outer + 1):
-            se, opt = minimize_chempot(se, fock, nelec, x0=se.chempot, **opts)
+        se, opt = minimize_chempot(
+            se,
+            fock,
+            self.nelec,
+            x0=se.chempot,
+            tol=self.conv_tol_nelec,
+            maxiter=self.max_cycle_inner,
+        )
 
-            for niter2 in range(1, max_cycle_inner + 1):
-                with logging.with_status(f"Iteration [{niter1}, {niter2}]"):
-                    w, v = se.diagonalise_matrix(fock, chempot=0.0, out=buf)
-                    w = mpi_helper.bcast(w, root=0)
-                    v = mpi_helper.bcast(v, root=0)
-                    se.chempot, nerr = search_chempot(w, v, nmo, nelec)
-                    nerr = abs(nerr)
+        return se
 
-                    w, v = se.diagonalise_matrix(fock, out=buf)
-                    w = mpi_helper.bcast(w, root=0)
-                    v = mpi_helper.bcast(v, root=0)
-                    gf = Lehmann(w, v[:nmo], chempot=se.chempot)
+    def solve_dyson(self, fock, se=None):
+        """Solve the Dyson equation for a given Fock matrix.
 
-                    rdm1 = gf_to_dm(gf)
-                    fock = integrals.get_fock(rdm1, h1e)
-                    fock = diis.update(fock, xerr=None)
+        Parameters
+        ----------
+        fock : numpy.ndarray
+            Fock matrix.
+        se : dyson.Lehmann, optional
+            Self-energy. If `None`, use `self.se`. Default value is
+            `None`.
 
-                    derr = np.max(np.absolute(rdm1 - rdm1_prev))
-                    if niter2 in {1, 5, 10, 50, 100, max_cycle_inner} or derr < conv_tol_rdm1:
-                        nerr_style = logging.rate(nerr, conv_tol_nelec, conv_tol_nelec * 1e2)
-                        derr_style = logging.rate(derr, conv_tol_rdm1, conv_tol_rdm1 * 1e2)
-                        table.add_row(
-                            f"{niter1}",
-                            f"{niter2}",
-                            f"[{nerr_style}]{nerr:.3g}[/]",
-                            f"[{derr_style}]{derr:.3g}[/]",
-                        )
-                    if derr < conv_tol_rdm1:
-                        break
+        Returns
+        -------
+        gf : dyson.Lehmann
+            Green's function.
+        nerr : float
+            Error in the number of electrons.
 
-                    rdm1_prev = rdm1.copy()
+        Notes
+        -----
+        If there is no dynamic part of the self-energy (`self.se` is
+        `None`), this method simply diagonalises the Fock matrix and
+        returns the Lehmann representation of the resulting zeroth-order
+        Green's function.
+        """
 
-            if derr < conv_tol_rdm1 and nerr < conv_tol_nelec:
-                converged = True
-                break
+        if se is None:
+            se = self.se
 
-        logging.write(table)
+        if se is None:
+            e, c = np.linalg.eigh(fock)
+        else:
+            e, c = se.diagonalise_matrix(fock, chempot=0.0)
 
-    return gf, se, converged
+        e = mpi_helper.bcast(e, root=0)
+        c = mpi_helper.bcast(c, root=0)
+
+        gf = Lehmann(e, c[: self.nmo], chempot=se.chempot if se is not None else 0.0)
+
+        gf.chempot, nerr = search_chempot(gf.energies, gf.couplings, self.nmo, self.nelec)
+        nerr = abs(nerr)
+
+        return gf, nerr
+
+    @property
+    def naux(self):
+        """Get the number of auxiliary states."""
+        return self.se.naux
+
+    @property
+    def nqmo(self):
+        """Get the number of quasiparticle MOs."""
+        return self.nmo + self.naux
+
+    @property
+    def nelec(self):
+        """Get the number of electrons."""
+        return self.nocc * 2

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -458,7 +458,14 @@ class FockLoop(BaseFockLoop):
         nerr : float
             Error in the number of electrons.
         """
-        return search_chempot(gf.energies, gf.couplings, self.nmo, self.nelec)
+
+        if gf is None:
+            gf = self.gf
+
+        chempot, nerr = search_chempot(gf.energies, gf.couplings, self.nmo, self.nelec)
+        nerr = abs(nerr)
+
+        return chempot, nerr
 
     def solve_dyson(self, fock, se=None):
         """Solve the Dyson equation for a given Fock matrix.
@@ -500,7 +507,6 @@ class FockLoop(BaseFockLoop):
         gf = Lehmann(e, c[: self.nmo], chempot=se.chempot if se is not None else 0.0)
 
         gf.chempot, nerr = self.search_chempot(gf)
-        nerr = abs(nerr)
 
         return gf, nerr
 

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -442,6 +442,24 @@ class FockLoop(BaseFockLoop):
 
         return se
 
+    def search_chempot(self, gf=None):
+        """Search for a chemical potential for a given Green's function.
+
+        Parameters
+        ----------
+        gf : dyson.Lehmann, optional
+            Green's function. If `None`, use `self.gf`. Default value is
+            `None`.
+
+        Returns
+        -------
+        chempot : float
+            Chemical potential.
+        nerr : float
+            Error in the number of electrons.
+        """
+        return search_chempot(gf.energies, gf.couplings, self.nmo, self.nelec)
+
     def solve_dyson(self, fock, se=None):
         """Solve the Dyson equation for a given Fock matrix.
 
@@ -481,7 +499,7 @@ class FockLoop(BaseFockLoop):
 
         gf = Lehmann(e, c[: self.nmo], chempot=se.chempot if se is not None else 0.0)
 
-        gf.chempot, nerr = search_chempot(gf.energies, gf.couplings, self.nmo, self.nelec)
+        gf.chempot, nerr = self.search_chempot(gf)
         nerr = abs(nerr)
 
         return gf, nerr

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -8,7 +8,7 @@ from dyson import MBLSE, Lehmann, MixedMBLSE
 
 from momentGW import energy, logging, mpi_helper, thc, util
 from momentGW.base import BaseGW
-from momentGW.fock import fock_loop, minimize_chempot, search_chempot
+from momentGW.fock import FockLoop, minimize_chempot, search_chempot
 from momentGW.ints import Integrals
 from momentGW.rpa import dRPA
 from momentGW.tda import dTDA
@@ -276,7 +276,8 @@ class GW(BaseGW):  # noqa: D101
         if self.fock_loop:
             logging.write("")
             with logging.with_status("Running Fock loop"):
-                gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
+                solver = FockLoop(self, gf=gf, se=se, **self.fock_opts)
+                conv, gf, se = solver.kernel(integrals=integrals)
 
         cpt, error = search_chempot(
             gf.energies,

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -4,7 +4,7 @@ molecular systems.
 """
 
 import numpy as np
-from dyson import MBLSE, Lehmann, MixedMBLSE, NullLogger
+from dyson import MBLSE, Lehmann, MixedMBLSE
 
 from momentGW import energy, logging, mpi_helper, thc, util
 from momentGW.base import BaseGW
@@ -248,10 +248,10 @@ class GW(BaseGW):  # noqa: D101
         """
 
         with logging.with_modifiers(status="Solving Dyson equation", timer="Dyson equation"):
-            solver_occ = MBLSE(se_static, np.array(se_moments_hole), log=NullLogger())
+            solver_occ = MBLSE(se_static, np.array(se_moments_hole))
             solver_occ.kernel()
 
-            solver_vir = MBLSE(se_static, np.array(se_moments_part), log=NullLogger())
+            solver_vir = MBLSE(se_static, np.array(se_moments_part))
             solver_vir.kernel()
 
             solver = MixedMBLSE(solver_occ, solver_vir)

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -6,9 +6,9 @@ molecular systems.
 import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE
 
-from momentGW import energy, logging, mpi_helper, thc, util
+from momentGW import energy, logging, thc, util
 from momentGW.base import BaseGW
-from momentGW.fock import FockLoop, minimize_chempot, search_chempot
+from momentGW.fock import FockLoop, search_chempot
 from momentGW.ints import Integrals
 from momentGW.rpa import dRPA
 from momentGW.tda import dTDA
@@ -257,9 +257,10 @@ class GW(BaseGW):  # noqa: D101
             solver = MixedMBLSE(solver_occ, solver_vir)
             se = solver.get_self_energy()
 
+        solver = FockLoop(self, se=se, **self.fock_opts)
+
         if self.optimise_chempot:
-            with logging.with_status("Optimising chemical potential"):
-                se, opt = minimize_chempot(se, se_static, self.nocc * 2)
+            se = solver.auxiliary_shift(se_static)
 
         error = self.moment_error(se_moments_hole, se_moments_part, se)
         logging.write(
@@ -268,25 +269,15 @@ class GW(BaseGW):  # noqa: D101
             f"particle = [{logging.rate(error[1], 1e-12, 1e-8)}]{error[1]:.3e}[/])"
         )
 
-        gf = Lehmann(*se.diagonalise_matrix_with_projection(se_static))
-        gf.energies = mpi_helper.bcast(gf.energies, root=0)
-        gf.couplings = mpi_helper.bcast(gf.couplings, root=0)
-        gf.chempot = se.chempot
+        gf, error = solver.solve_dyson(se_static)
+        se.chempot = gf.chempot
 
         if self.fock_loop:
             logging.write("")
-            with logging.with_status("Running Fock loop"):
-                solver = FockLoop(self, gf=gf, se=se, **self.fock_opts)
-                conv, gf, se = solver.kernel(integrals=integrals)
-
-        cpt, error = search_chempot(
-            gf.energies,
-            gf.couplings,
-            gf.nphys,
-            self.nocc * 2,
-        )
-        se.chempot = cpt
-        gf.chempot = cpt
+            solver.gf = gf
+            solver.se = se
+            conv, gf, se = solver.kernel(integrals=integrals)
+            _, error = solver.search_chempot(gf)
 
         logging.write("")
         style = logging.rate(
@@ -295,7 +286,7 @@ class GW(BaseGW):  # noqa: D101
             1e-6 if self.fock_loop or self.optimise_chempot else 1e-1,
         )
         logging.write(f"Error in number of electrons:  [{style}]{error:.3e}[/]")
-        logging.write(f"Chemical potential:  {cpt:.6f}")
+        logging.write(f"Chemical potential:  {gf.chempot:.6f}")
 
         return gf, se
 

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -9,7 +9,7 @@ from dyson import Lehmann
 from pyscf import lib
 
 from momentGW import logging, mpi_helper, util
-from momentGW.fock import FockLoop, ChemicalPotentialError
+from momentGW.fock import ChemicalPotentialError, FockLoop
 
 
 # TODO inherit
@@ -287,7 +287,7 @@ class FockLoop(FockLoop):
         e = [mpi_helper.bcast(ek, root=0) for ek in e]
         c = [mpi_helper.bcast(ck, root=0) for ck in c]
 
-        gf = [Lehmann(ek, ck[:self.nmo], chempot=0.0) for ek, ck in zip(e, c)]
+        gf = [Lehmann(ek, ck[: self.nmo], chempot=0.0) for ek, ck in zip(e, c)]
 
         chempot, nerr = search_chempot(
             [g.energies for g in gf],
@@ -318,4 +318,5 @@ class FockLoop(FockLoop):
 
     @property
     def kpts(self):
+        """Get the k-points object."""
         return self.gw.kpts

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -9,7 +9,7 @@ from dyson import Lehmann
 from pyscf import lib
 
 from momentGW import logging, mpi_helper, util
-from momentGW.fock import ChemicalPotentialError
+from momentGW.fock import FockLoop, ChemicalPotentialError
 
 
 # TODO inherit
@@ -176,35 +176,23 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
     return se, opt
 
 
-@logging.with_timer("Fock loop")
-@logging.with_status("Running Fock loop")
-def fock_loop(
-    gw,
-    gf,
-    se,
-    integrals=None,
-    fock_diis_space=10,
-    fock_diis_min_space=1,
-    conv_tol_nelec=1e-6,
-    conv_tol_rdm1=1e-8,
-    max_cycle_inner=100,
-    max_cycle_outer=20,
-):
+class FockLoop(FockLoop):
     """
     Self-consistent loop for the density matrix via the Hartree--Fock
-    self-consistent field.
+    self-consistent field for spin-restricted periodic systems.
 
     Parameters
     ----------
     gw : BaseKGW
         GW object.
-    gf : tuple of dyson.Lehmann
-        Green's function object at each k-point.
-    se : tuple of dyson.Lehmann
-        Self-energy object at each k-point.
-    integrals : KIntegrals, optional
-        Integrals object. If `None`, generate from scratch. Default
-        value is `None`.
+    gf : tuple of dyson.Lehmann, optional
+        Initial Green's function object at each k-point. If `None`, use
+        `gw.init_gf()`. Default value is `None`.
+    se : tuple of dyson.Lehmann, optional
+        Initial self-energy object at each k-point. If passed, use as
+        dynamic part of the self-energy. If `None`, self-energy is
+        assumed to be static and fully defined by the Fock matrix.
+        Default value is `None`.
     fock_diis_space : int, optional
         DIIS space size for the Fock matrix. Default value is `10`.
     fock_diis_min_space : int, optional
@@ -222,82 +210,112 @@ def fock_loop(
         Maximum number of outer iterations. Default value is `20`.
     """
 
-    if integrals is None:
-        integrals = gw.ao2mo()
+    def auxiliary_shift(self, fock, se=None):
+        """
+        Optimise a shift in the auxiliary energies to best satisfy the
+        electron number.
 
-    with util.SilentSCF(gw._scf):
-        h1e = util.einsum(
-            "kpq,kpi,kqj->kij",
-            gw._scf.get_hcore(),
-            np.conj(gw.mo_coeff),
-            gw.mo_coeff,
+        Parameters
+        ----------
+        fock : numpy.ndarray
+            Fock matrix.
+        se : tuple of dyson.Lehmann, optional
+            Self-energy at each k-point. If `None`, use `self.se`.
+            Default value is `None`.
+
+        Returns
+        -------
+        se : tuple of dyson.Lehmann
+            Self-energy at each k-point.
+
+        Notes
+        -----
+        If there is no dynamic part of the self-energy (`self.se` is
+        `None`), this method returns `None`.
+        """
+
+        if se is None:
+            se = self.se
+        if se is None:
+            return None
+
+        se, opt = minimize_chempot(
+            se,
+            fock,
+            sum(self.nelec),
+            x0=se[0].chempot,
+            tol=self.conv_tol_nelec,
+            maxiter=self.max_cycle_inner,
         )
-    nmo = gw.nmo
-    nocc = gw.nocc
-    naux = [s.naux for s in se]
-    nqmo = [nmo + n for n in naux]
-    nelec = [n * 2 for n in nocc]
-    kpts = gw.kpts
 
-    diis = util.DIIS()
-    diis.space = fock_diis_space
-    diis.min_space = fock_diis_min_space
-    gf_to_dm = lambda gf: np.array([g.occupied().moment(0) for g in gf]) * 2.0
-    rdm1 = gf_to_dm(gf)
-    fock = integrals.get_fock(rdm1, h1e)
+        return se
 
-    buf = np.zeros((max(nqmo), max(nqmo)), dtype=complex)
-    converged = False
-    opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner)
-    rdm1_prev = rdm1
+    def solve_dyson(self, fock, se=None):
+        """Solve the Dyson equation for a given Fock matrix.
 
-    with logging.with_table(title="Fock loop") as table:
-        table.add_column("Iter", justify="right")
-        table.add_column("Cycle", justify="right")
-        table.add_column("Error (nelec)", justify="right")
-        table.add_column("Δ (density)", justify="right")
+        Parameters
+        ----------
+        fock : numpy.ndarray
+            Fock matrix at each k-point.
+        se : tuple of dyson.Lehmann, optional
+            Self-energy at each k-point. If `None`, use `self.se`.
+            Default value is `None`.
 
-        for niter1 in range(1, max_cycle_outer + 1):
-            se, opt = minimize_chempot(se, fock, sum(nelec), x0=se[0].chempot, **opts)
+        Returns
+        -------
+        gf : tuple of dyson.Lehmann
+            Green's function at each k-point.
+        nerr : float
+            Error in the number of electrons.
 
-            for niter2 in range(1, max_cycle_inner + 1):
-                with logging.with_status(f"Iteration [{niter1}, {niter2}]"):
-                    w, v = zip(
-                        *[s.diagonalise_matrix(f, chempot=0.0, out=buf) for s, f in zip(se, fock)]
-                    )
-                    w = [mpi_helper.bcast(wk, root=0) for wk in w]
-                    v = [mpi_helper.bcast(vk, root=0) for vk in v]
-                    chempot, nerr = search_chempot(w, v, nmo, sum(nelec))
-                    nerr = abs(nerr)
+        Notes
+        -----
+        If there is no dynamic part of the self-energy (`self.se` is
+        `None`), this method simply diagonalises the Fock matrix and
+        returns the Lehmann representation of the resulting zeroth-order
+        Green's function.
+        """
 
-                    for k in kpts.loop(1):
-                        se[k].chempot = chempot
-                        w, v = se[k].diagonalise_matrix(fock[k], out=buf)
-                        gf[k] = Lehmann(w, v[:nmo], chempot=se[k].chempot)
+        if se is None:
+            se = self.se
 
-                    rdm1 = gf_to_dm(gf)
-                    fock = integrals.get_fock(rdm1, h1e)
-                    fock = diis.update(fock, xerr=None)
+        if se is None:
+            e, c = np.linalg.eigh(fock)
+        else:
+            e, c = zip(*[s.diagonalise_matrix(f, chempot=0.0) for s, f in zip(se, fock)])
 
-                    derr = np.max(np.absolute(rdm1 - rdm1_prev))
-                    if niter2 in {1, 5, 10, 50, 100, max_cycle_inner} or derr < conv_tol_rdm1:
-                        nerr_style = logging.rate(nerr, conv_tol_nelec, conv_tol_nelec * 1e2)
-                        derr_style = logging.rate(derr, conv_tol_rdm1, conv_tol_rdm1 * 1e2)
-                        table.add_row(
-                            f"{niter1}",
-                            f"{niter2}",
-                            f"[{nerr_style}]{nerr:.3g}[/]",
-                            f"[{derr_style}]{derr:.3g}[/]",
-                        )
-                    if derr < conv_tol_rdm1:
-                        break
+        e = [mpi_helper.bcast(ek, root=0) for ek in e]
+        c = [mpi_helper.bcast(ck, root=0) for ck in c]
 
-                    rdm1_prev = rdm1.copy()
+        gf = [Lehmann(ek, ck[:self.nmo], chempot=0.0) for ek, ck in zip(e, c)]
 
-            if derr < conv_tol_rdm1 and nerr < conv_tol_nelec:
-                converged = True
-                break
+        chempot, nerr = search_chempot(
+            [g.energies for g in gf],
+            [g.couplings for g in gf],
+            self.nmo,
+            sum(self.nelec),
+        )
+        nerr = abs(nerr)
 
-        logging.write(table)
+        for k in self.kpts.loop(1):
+            gf[k].chempot = chempot
 
-    return gf, se, converged
+        return tuple(gf), nerr
+
+    def _density_error(self, rdm1, rdm1_prev):
+        """Calculate the density error."""
+        return np.max(np.absolute(rdm1 - rdm1_prev)).real
+
+    @property
+    def naux(self):
+        """Get the number of auxiliary states."""
+        return tuple(s.naux for s in self.se)
+
+    @property
+    def nqmo(self):
+        """Get the number of quasiparticle MOs."""
+        return tuple(s.nphys + s.naux for s in self.se)
+
+    @property
+    def kpts(self):
+        return self.gw.kpts

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -4,7 +4,7 @@ periodic systems.
 """
 
 import numpy as np
-from dyson import MBLSE, Lehmann, MixedMBLSE, NullLogger
+from dyson import MBLSE, Lehmann, MixedMBLSE
 
 from momentGW import energy, logging, mpi_helper, util
 from momentGW.gw import GW
@@ -147,10 +147,10 @@ class KGW(BaseKGW, GW):  # noqa: D101
         with logging.with_modifiers(status="Solving Dyson equation", timer="Dyson equation"):
             se = []
             for k in self.kpts.loop(1):
-                solver_occ = MBLSE(se_static[k], np.array(se_moments_hole[k]), log=NullLogger())
+                solver_occ = MBLSE(se_static[k], np.array(se_moments_hole[k]))
                 solver_occ.kernel()
 
-                solver_vir = MBLSE(se_static[k], np.array(se_moments_part[k]), log=NullLogger())
+                solver_vir = MBLSE(se_static[k], np.array(se_moments_part[k]))
                 solver_vir.kernel()
 
                 solver = MixedMBLSE(solver_occ, solver_vir)

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -6,16 +6,11 @@ periodic systems.
 import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE
 
-from momentGW import energy, logging, mpi_helper, util
+from momentGW import energy, logging, util
 from momentGW.gw import GW
 from momentGW.pbc import thc
 from momentGW.pbc.base import BaseKGW
-from momentGW.pbc.fock import (
-    FockLoop,
-    minimize_chempot,
-    search_chempot,
-    search_chempot_unconstrained,
-)
+from momentGW.pbc.fock import FockLoop, search_chempot_unconstrained
 from momentGW.pbc.ints import KIntegrals
 from momentGW.pbc.tda import dTDA
 
@@ -156,9 +151,10 @@ class KGW(BaseKGW, GW):  # noqa: D101
                 solver = MixedMBLSE(solver_occ, solver_vir)
                 se.append(solver.get_self_energy())
 
+        solver = FockLoop(self, se=se, **self.fock_opts)
+
         if self.optimise_chempot:
-            with logging.with_status("Optimising chemical potential"):
-                se, opt = minimize_chempot(se, se_static, sum(self.nocc) * 2)
+            se = solver.auxiliary_shift(se_static)
 
         error_h, error_p = zip(
             *(
@@ -173,26 +169,16 @@ class KGW(BaseKGW, GW):  # noqa: D101
             f"particle = [{logging.rate(error[1], 1e-12, 1e-8)}]{error[1]:.3e}[/])"
         )
 
-        gf = []
-        for k in self.kpts.loop(1):
-            g = Lehmann(*se[k].diagonalise_matrix_with_projection(se_static[k]))
-            g.energies = mpi_helper.bcast(g.energies, root=0)
-            g.couplings = mpi_helper.bcast(g.couplings, root=0)
-            g.chempot = se[k].chempot
-            gf.append(g)
+        gf, error = solver.solve_dyson(se_static)
+        for g, s in zip(gf, se):
+            s.chempot = g.chempot
 
         if self.fock_loop:
             logging.write("")
-            with logging.with_status("Running Fock loop"):
-                solver = FockLoop(self, gf=gf, se=se, **self.fock_opts)
-                conv, gf, se = solver.kernel(integrals=integrals)
-
-        w = [g.energies for g in gf]
-        v = [g.couplings for g in gf]
-        cpt, error = search_chempot(w, v, self.nmo, sum(self.nocc) * 2)
-        for g, s in zip(gf, se):
-            g.chempot = cpt
-            s.chempot = cpt
+            solver.gf = gf
+            solver.se = se
+            conv, gf, se = solver.kernel(integrals=integrals)
+            _, error = solver.search_chempot(gf)
 
         logging.write("")
         style = logging.rate(
@@ -201,7 +187,7 @@ class KGW(BaseKGW, GW):  # noqa: D101
             1e-6 if self.fock_loop or self.optimise_chempot else 1e-1,
         )
         logging.write(f"Error in number of electrons:  [{style}]{error:.3e}[/]")
-        logging.write(f"Chemical potential (Γ):  {cpt:.6f}")
+        logging.write(f"Chemical potential (Γ):  {gf[0].chempot:.6f}")
 
         return tuple(gf), tuple(se)
 

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -11,7 +11,7 @@ from momentGW.gw import GW
 from momentGW.pbc import thc
 from momentGW.pbc.base import BaseKGW
 from momentGW.pbc.fock import (
-    fock_loop,
+    FockLoop,
     minimize_chempot,
     search_chempot,
     search_chempot_unconstrained,
@@ -184,7 +184,8 @@ class KGW(BaseKGW, GW):  # noqa: D101
         if self.fock_loop:
             logging.write("")
             with logging.with_status("Running Fock loop"):
-                gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
+                solver = FockLoop(self, gf=gf, se=se, **self.fock_opts)
+                conv, gf, se = solver.kernel(integrals=integrals)
 
         w = [g.energies for g in gf]
         v = [g.couplings for g in gf]

--- a/momentGW/pbc/uhf/fock.py
+++ b/momentGW/pbc/uhf/fock.py
@@ -7,38 +7,26 @@ import numpy as np
 from dyson import Lehmann
 
 from momentGW import logging, mpi_helper, util
-from momentGW.pbc.fock import minimize_chempot, search_chempot
+from momentGW.pbc.fock import minimize_chempot, search_chempot, FockLoop
 
 
-@logging.with_timer("Fock loop")
-@logging.with_status("Running Fock loop")
-def fock_loop(
-    gw,
-    gf,
-    se,
-    integrals=None,
-    fock_diis_space=10,
-    fock_diis_min_space=1,
-    conv_tol_nelec=1e-6,
-    conv_tol_rdm1=1e-8,
-    max_cycle_inner=100,
-    max_cycle_outer=20,
-):
+class FockLoop(FockLoop):
     """
     Self-consistent loop for the density matrix via the Hartree--Fock
-    self-consistent field.
+    self-consistent field for spin-unrestricted periodic systems.
 
     Parameters
     ----------
     gw : BaseKUGW
         GW object.
-    gf : tuple of tuple of dyson.Lehmann
-        Green's function object at each k-point for each spin channel.
-    se : tuple of tuple of dyson.Lehmann
-        Self-energy object at each k-point for each spin channel.
-    integrals : KUIntegrals, optional
-        Integrals object. If `None`, generate from scratch. Default
-        value is `None`.
+    gf : tuple of tuple of dyson.Lehmann, optional
+        Initial Green's function object at each k-point for each spin
+        channel. If `None`, use `gw.init_gf()`. Default value is `None`.
+    se : tuple of tuple of dyson.Lehmann, optional
+        Initial self-energy object at each k-point for each spin
+        channel. If passed, use as dynamic part of the self-energy. If
+        `None`, self-energy is assumed to be static and fully defined by
+        the Fock matrix. Default value is `None`.
     fock_diis_space : int, optional
         DIIS space size for the Fock matrix. Default value is `10`.
     fock_diis_min_space : int, optional
@@ -56,111 +44,154 @@ def fock_loop(
         Maximum number of outer iterations. Default value is `20`.
     """
 
-    if integrals is None:
-        integrals = gw.ao2mo()
+    def auxiliary_shift(self, fock, se=None):
+        """
+        Optimise a shift in the auxiliary energies to best satisfy the
+        electron number.
 
-    with util.SilentSCF(gw._scf):
-        h1e = util.einsum(
-            "kpq,skpi,skqj->skij",
-            gw._scf.get_hcore(),
-            np.conj(gw.mo_coeff),
-            gw.mo_coeff,
+        Parameters
+        ----------
+        fock : numpy.ndarray
+            Fock matrix at each k-point for each spin channel.
+        se : tuple of tuple of dyson.Lehmann, optional
+            Self-energy at each k-point for each spin channel. If
+            `None`, use `self.se`. Default value is `None`.
+
+        Returns
+        -------
+        se : tuple of tuple of dyson.Lehmann
+            Self-energy at each k-point for each spin channel.
+
+        Notes
+        -----
+        If there is no dynamic part of the self-energy (`self.se` is
+        `None`), this method returns `None`.
+        """
+
+        if se is None:
+            se = self.se
+        if se is None:
+            return None
+
+        se_α, opt_α = minimize_chempot(
+            se[0],
+            fock[0],
+            sum(self.nelec[0]),
+            x0=se[0][0].chempot,
+            tol=self.conv_tol_nelec,
+            maxiter=self.max_cycle_inner,
+            occupancy=1,
         )
-    nmo = gw.nmo
-    nocc = gw.nocc
-    naux = (
-        [s.naux for s in se[0]],
-        [s.naux for s in se[1]],
-    )
-    nqmo = (
-        [nmo[0] + n for n in naux[0]],
-        [nmo[1] + n for n in naux[1]],
-    )
-    nelec = nocc
-    kpts = gw.kpts
 
-    diis = util.DIIS()
-    diis.space = fock_diis_space
-    diis.min_space = fock_diis_min_space
-    gf_to_dm = lambda gf: np.array([[g.occupied().moment(0) for g in gs] for gs in gf])
-    rdm1 = gf_to_dm(gf)
-    fock = integrals.get_fock(rdm1, h1e)
+        se_β, opt_β = minimize_chempot(
+            se[1],
+            fock[1],
+            sum(self.nelec[1]),
+            x0=se[1][0].chempot,
+            tol=self.conv_tol_nelec,
+            maxiter=self.max_cycle_inner,
+            occupancy=1,
+        )
 
-    buf = np.zeros((np.max(nqmo), np.max(nqmo)), dtype=complex)
-    converged = False
-    opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner, occupancy=1)
-    rdm1_prev = rdm1
+        se = (se_α, se_β)
 
-    with logging.with_table(title="Fock loop") as table:
-        table.add_column("Iter", justify="right")
-        table.add_column("Cycle", justify="right")
-        table.add_column("Error (nα)", justify="right")
-        table.add_column("Error (nβ)", justify="right")
-        table.add_column("Δ (density)", justify="right")
+        return se
 
-        for niter1 in range(1, max_cycle_outer + 1):
-            se_α, opt = minimize_chempot(se[0], fock[0], sum(nelec[0]), x0=se[0][0].chempot, **opts)
-            se_β, opt = minimize_chempot(se[1], fock[1], sum(nelec[1]), x0=se[1][0].chempot, **opts)
-            se = [se_α, se_β]
+    def solve_dyson(self, fock, se=None):
+        """Solve the Dyson equation for a given Fock matrix.
 
-            for niter2 in range(1, max_cycle_inner + 1):
-                with logging.with_status(f"Iteration [{niter1}, {niter2}]"):
-                    w, v = zip(
-                        *[
-                            s.diagonalise_matrix(f, chempot=0.0, out=buf)
-                            for s, f in zip(se[0], fock[0])
-                        ]
-                    )
-                    w = [mpi_helper.bcast(wk, root=0) for wk in w]
-                    v = [mpi_helper.bcast(vk, root=0) for vk in v]
-                    chempot_α, nerr_α = search_chempot(w, v, nmo[0], sum(nelec[0]), occupancy=1)
-                    nerr_α = abs(nerr_α)
+        Parameters
+        ----------
+        fock : numpy.ndarray
+            Fock matrix at each k-point for each spin channel.
+        se : tuple of dyson.Lehmann, optional
+            Self-energy at each k-point. If `None`, use `self.se`.
+            Default value is `None`.
 
-                    w, v = zip(
-                        *[
-                            s.diagonalise_matrix(f, chempot=0.0, out=buf)
-                            for s, f in zip(se[1], fock[1])
-                        ]
-                    )
-                    w = [mpi_helper.bcast(wk, root=0) for wk in w]
-                    v = [mpi_helper.bcast(vk, root=0) for vk in v]
-                    chempot_β, nerr_β = search_chempot(w, v, nmo[1], sum(nelec[1]), occupancy=1)
-                    nerr_β = abs(nerr_β)
+        Returns
+        -------
+        gf : tuple of dyson.Lehmann
+            Green's function at each k-point.
+        nerr : float
+            Error in the number of electrons.
 
-                    for k in kpts.loop(1):
-                        se[0][k].chempot = chempot_α
-                        w, v = se[0][k].diagonalise_matrix(fock[0][k], out=buf)
-                        gf[0][k] = Lehmann(w, v[: nmo[0]], chempot=se[0][k].chempot)
+        Notes
+        -----
+        If there is no dynamic part of the self-energy (`self.se` is
+        `None`), this method simply diagonalises the Fock matrix and
+        returns the Lehmann representation of the resulting zeroth-order
+        Green's function.
+        """
 
-                        se[1][k].chempot = chempot_α
-                        w, v = se[1][k].diagonalise_matrix(fock[1][k], out=buf)
-                        gf[1][k] = Lehmann(w, v[: nmo[1]], chempot=se[1][k].chempot)
+        if se is None:
+            se = self.se
 
-                    rdm1 = gf_to_dm(gf)
-                    fock = integrals.get_fock(rdm1, h1e)
-                    fock = diis.update(fock, xerr=None)
+        if se is None:
+            e, c = np.linalg.eigh(fock)
+        else:
+            e_α, c_α = zip(*[s.diagonalise_matrix(f, chempot=0.0) for s, f in zip(se[0], fock[0])])
+            e_β, c_β = zip(*[s.diagonalise_matrix(f, chempot=0.0) for s, f in zip(se[1], fock[1])])
+            e = (e_α, e_β)
+            c = (c_α, c_β)
 
-                    derr = np.max(np.absolute(rdm1 - rdm1_prev))
-                    if niter2 in {1, 5, 10, 50, 100, max_cycle_inner} or derr < conv_tol_rdm1:
-                        nerr_α_style = logging.rate(nerr_α, conv_tol_nelec, conv_tol_nelec * 1e2)
-                        nerr_β_style = logging.rate(nerr_β, conv_tol_nelec, conv_tol_nelec * 1e2)
-                        derr_style = logging.rate(derr, conv_tol_rdm1, conv_tol_rdm1 * 1e2)
-                        table.add_row(
-                            f"{niter1}",
-                            f"{niter2}",
-                            f"[{nerr_α_style}]{nerr_α:.3g}[/]",
-                            f"[{nerr_β_style}]{nerr_β:.3g}[/]",
-                            f"[{derr_style}]{derr:.3g}[/]",
-                        )
-                    if derr < conv_tol_rdm1:
-                        break
+        e = [
+            [mpi_helper.bcast(ek, root=0) for ek in e[0]],
+            [mpi_helper.bcast(ek, root=0) for ek in e[1]],
+        ]
+        c = [
+            [mpi_helper.bcast(ck, root=0) for ck in c[0]],
+            [mpi_helper.bcast(ck, root=0) for ck in c[1]],
+        ]
 
-                    rdm1_prev = rdm1.copy()
+        gf = [
+            [Lehmann(ek, ck[:self.nmo[0]], chempot=0.0) for ek, ck in zip(e[0], c[0])],
+            [Lehmann(ek, ck[:self.nmo[1]], chempot=0.0) for ek, ck in zip(e[1], c[1])],
+        ]
 
-            if derr < conv_tol_rdm1 and (nerr_α + nerr_β) < conv_tol_nelec:
-                converged = True
-                break
+        chempot_α, nerr_α = search_chempot(
+            [g.energies for g in gf[0]],
+            [g.couplings for g in gf[0]],
+            self.nmo[0],
+            sum(self.nelec[0]),
+            occupancy=1,
+        )
+        chempot_β, nerr_β = search_chempot(
+            [g.energies for g in gf[1]],
+            [g.couplings for g in gf[1]],
+            self.nmo[1],
+            sum(self.nelec[1]),
+            occupancy=1,
+        )
 
-        logging.write(table)
+        nerr = abs(nerr_α) + abs(nerr_β)
 
-    return gf, se, converged
+        for k in self.kpts.loop(1):
+            gf[0][k].chempot = chempot_α
+            gf[1][k].chempot = chempot_β
+
+        return tuple(tuple(gf_s) for gf_s in gf), nerr
+
+    def _density_error(self, rdm1, rdm1_prev):
+        """Calculate the density error."""
+        return max(
+            np.max(np.abs(rdm1[0] - rdm1_prev[0])).real,
+            np.max(np.abs(rdm1[1] - rdm1_prev[1])).real,
+        )
+
+    @property
+    def naux(self):
+        """Get the number of auxiliary states."""
+        return (tuple(s.naux for s in self.se[0]), tuple(s.naux for s in self.se[1]))
+
+    @property
+    def nqmo(self):
+        """Get the number of quasiparticle MOs."""
+        return (
+            tuple(s.nphys + s.naux for s in self.se[0]),
+            tuple(s.nphys + s.naux for s in self.se[1]),
+        )
+
+    @property
+    def nelec(self):
+        """Get the number of electrons."""
+        return self.nocc

--- a/momentGW/pbc/uhf/fock.py
+++ b/momentGW/pbc/uhf/fock.py
@@ -6,8 +6,8 @@ conditions and unrestricted references.
 import numpy as np
 from dyson import Lehmann
 
-from momentGW import logging, mpi_helper, util
-from momentGW.pbc.fock import minimize_chempot, search_chempot, FockLoop
+from momentGW import mpi_helper
+from momentGW.pbc.fock import FockLoop, minimize_chempot, search_chempot
 
 
 class FockLoop(FockLoop):
@@ -144,8 +144,8 @@ class FockLoop(FockLoop):
         ]
 
         gf = [
-            [Lehmann(ek, ck[:self.nmo[0]], chempot=0.0) for ek, ck in zip(e[0], c[0])],
-            [Lehmann(ek, ck[:self.nmo[1]], chempot=0.0) for ek, ck in zip(e[1], c[1])],
+            [Lehmann(ek, ck[: self.nmo[0]], chempot=0.0) for ek, ck in zip(e[0], c[0])],
+            [Lehmann(ek, ck[: self.nmo[1]], chempot=0.0) for ek, ck in zip(e[1], c[1])],
         ]
 
         chempot_α, nerr_α = search_chempot(

--- a/momentGW/pbc/uhf/gw.py
+++ b/momentGW/pbc/uhf/gw.py
@@ -4,7 +4,7 @@ periodic systems.
 """
 
 import numpy as np
-from dyson import MBLSE, Lehmann, MixedMBLSE, NullLogger
+from dyson import MBLSE, Lehmann, MixedMBLSE
 
 from momentGW import energy, logging, mpi_helper, util
 from momentGW.pbc.fock import minimize_chempot, search_chempot, search_chempot_unconstrained
@@ -134,27 +134,19 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
         with logging.with_modifiers(status="Solving Dyson equation", timer="Dyson equation"):
             se = [[], []]
             for k in self.kpts.loop(1):
-                solver_occ = MBLSE(
-                    se_static[0][k], np.array(se_moments_hole[0][k]), log=NullLogger()
-                )
+                solver_occ = MBLSE(se_static[0][k], np.array(se_moments_hole[0][k]))
                 solver_occ.kernel()
 
-                solver_vir = MBLSE(
-                    se_static[0][k], np.array(se_moments_part[0][k]), log=NullLogger()
-                )
+                solver_vir = MBLSE(se_static[0][k], np.array(se_moments_part[0][k]))
                 solver_vir.kernel()
 
                 solver = MixedMBLSE(solver_occ, solver_vir)
                 se[0].append(solver.get_self_energy())
 
-                solver_occ = MBLSE(
-                    se_static[1][k], np.array(se_moments_hole[1][k]), log=NullLogger()
-                )
+                solver_occ = MBLSE(se_static[1][k], np.array(se_moments_hole[1][k]))
                 solver_occ.kernel()
 
-                solver_vir = MBLSE(
-                    se_static[1][k], np.array(se_moments_part[1][k]), log=NullLogger()
-                )
+                solver_vir = MBLSE(se_static[1][k], np.array(se_moments_part[1][k]))
                 solver_vir.kernel()
 
                 solver = MixedMBLSE(solver_occ, solver_vir)

--- a/momentGW/pbc/uhf/gw.py
+++ b/momentGW/pbc/uhf/gw.py
@@ -10,7 +10,7 @@ from momentGW import energy, logging, mpi_helper, util
 from momentGW.pbc.fock import minimize_chempot, search_chempot, search_chempot_unconstrained
 from momentGW.pbc.gw import KGW
 from momentGW.pbc.uhf.base import BaseKUGW
-from momentGW.pbc.uhf.fock import fock_loop
+from momentGW.pbc.uhf.fock import FockLoop
 from momentGW.pbc.uhf.ints import KUIntegrals
 from momentGW.pbc.uhf.tda import dTDA
 from momentGW.uhf.gw import UGW
@@ -194,7 +194,8 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
         if self.fock_loop:
             logging.write("")
             with logging.with_status("Running Fock loop"):
-                gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
+                solver = FockLoop(self, gf=gf, se=se, **self.fock_opts)
+                conv, gf, se = solver.kernel(integrals=integrals)
 
         cpt_α, error_α = search_chempot(
             [g.energies for g in gf[0]],

--- a/momentGW/pbc/uhf/gw.py
+++ b/momentGW/pbc/uhf/gw.py
@@ -6,8 +6,8 @@ periodic systems.
 import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE
 
-from momentGW import energy, logging, mpi_helper, util
-from momentGW.pbc.fock import minimize_chempot, search_chempot, search_chempot_unconstrained
+from momentGW import energy, logging, util
+from momentGW.pbc.fock import search_chempot_unconstrained
 from momentGW.pbc.gw import KGW
 from momentGW.pbc.uhf.base import BaseKUGW
 from momentGW.pbc.uhf.fock import FockLoop
@@ -152,10 +152,10 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
                 solver = MixedMBLSE(solver_occ, solver_vir)
                 se[1].append(solver.get_self_energy())
 
+        solver = FockLoop(self, se=se, **self.fock_opts)
+
         if self.optimise_chempot:
-            with logging.with_status("Optimising chemical potential"):
-                se[0], opt = minimize_chempot(se[0], se_static[0], sum(self.nocc[0]), occupancy=1)
-                se[1], opt = minimize_chempot(se[1], se_static[1], sum(self.nocc[1]), occupancy=1)
+            se = solver.auxiliary_shift(se_static)
 
         error_h, error_p = zip(
             *(
@@ -182,52 +182,27 @@ class KUGW(BaseKUGW, KGW, UGW):  # noqa: D101
                 f"particle = [{logging.rate(error[s][1], 1e-12, 1e-8)}]{error[s][1]:.3e}[/])"
             )
 
-        gf = [[], []]
-        for s in range(2):
-            for k in self.kpts.loop(1):
-                g = Lehmann(*se[s][k].diagonalise_matrix_with_projection(se_static[s][k]))
-                g.energies = mpi_helper.bcast(g.energies, root=0)
-                g.couplings = mpi_helper.bcast(g.couplings, root=0)
-                g.chempot = se[s][k].chempot
-                gf[s].append(g)
+        gf, error = solver.solve_dyson(se_static)
+        for g, s in zip(gf, se):
+            s[0].chempot = g[0].chempot
+            s[1].chempot = g[1].chempot
 
         if self.fock_loop:
             logging.write("")
-            with logging.with_status("Running Fock loop"):
-                solver = FockLoop(self, gf=gf, se=se, **self.fock_opts)
-                conv, gf, se = solver.kernel(integrals=integrals)
-
-        cpt_α, error_α = search_chempot(
-            [g.energies for g in gf[0]],
-            [g.couplings for g in gf[0]],
-            self.nmo[0],
-            sum(self.nocc[0]),
-            occupancy=1,
-        )
-        cpt_β, error_β = search_chempot(
-            [g.energies for g in gf[1]],
-            [g.couplings for g in gf[1]],
-            self.nmo[1],
-            sum(self.nocc[1]),
-            occupancy=1,
-        )
-        cpt = (cpt_α, cpt_β)
-        error = (error_α, error_β)
-        for s in range(2):
-            for k in self.kpts.loop(1):
-                gf[s][k].chempot = cpt[s]
-                se[s][k].chempot = cpt[s]
+            solver.gf = gf
+            solver.se = se
+            conv, gf, se = solver.kernel(integrals=integrals)
+            _, error = solver.search_chempot(gf)
 
         logging.write("")
+        color = logging.rate(
+            abs(error),
+            1e-6,
+            1e-6 if self.fock_loop or self.optimise_chempot else 1e-1,
+        )
+        logging.write(f"Error in number of electrons ({spin}):  [{color}]{error:.3e}[/]")
         for s, spin in enumerate(["α", "β"]):
-            color = logging.rate(
-                abs(error[s]),
-                1e-6,
-                1e-6 if self.fock_loop or self.optimise_chempot else 1e-1,
-            )
-            logging.write(f"Error in number of electrons ({spin}):  [{color}]{error[s]:.3e}[/]")
-        for s, spin in enumerate(["α", "β"]):
-            logging.write(f"Chemical potential (Γ, {spin}):  {cpt[s]:.6f}")
+            logging.write(f"Chemical potential (Γ, {spin}):  {gf[s][0].chempot:.6f}")
 
         return tuple(tuple(g) for g in gf), tuple(tuple(s) for s in se)
 

--- a/momentGW/uhf/fock.py
+++ b/momentGW/uhf/fock.py
@@ -5,39 +5,27 @@ Fock matrix self-consistent loop for unrestricted references.
 import numpy as np
 from dyson import Lehmann
 
-from momentGW import logging, mpi_helper, util
-from momentGW.fock import minimize_chempot, search_chempot
+from momentGW import mpi_helper
+from momentGW.fock import FockLoop, minimize_chempot, search_chempot
 
 
-@logging.with_timer("Fock loop")
-@logging.with_status("Running Fock loop")
-def fock_loop(
-    gw,
-    gf,
-    se,
-    integrals=None,
-    fock_diis_space=10,
-    fock_diis_min_space=1,
-    conv_tol_nelec=1e-6,
-    conv_tol_rdm1=1e-8,
-    max_cycle_inner=100,
-    max_cycle_outer=20,
-):
+class FockLoop(FockLoop):
     """
     Self-consistent loop for the density matrix via the Hartree--Fock
-    self-consistent field.
+    self-consistent field for spin-unrestricted molecular systems.
 
     Parameters
     ----------
-    gw : BaseUGW
+    gw : BaseGW
         GW object.
-    gf : tuple of dyson.Lehmann
-        Green's function object for each spin channel.
-    se : tuple of dyson.Lehmann
-        Self-energy object for each spin channel.
-    integrals : UIntegrals, optional
-        Integrals object. If `None`, generate from scratch. Default
-        value is `None`.
+    gf : tuple of dyson.Lehmann, optional
+        Initial Green's function object for each spin channel. If
+        `None`, use `gw.init_gf()`. Default value is `None`.
+    se : tuple of dyson.Lehmann, optional
+        Initial self-energy object for each spin channel. If passed,
+        use as dynamic part of the self-energy. If `None`, self-energy
+        is assumed to be static and fully defined by the Fock matrix.
+        Default value is `None`.
     fock_diis_space : int, optional
         DIIS space size for the Fock matrix. Default value is `10`.
     fock_diis_min_space : int, optional
@@ -55,92 +43,141 @@ def fock_loop(
         Maximum number of outer iterations. Default value is `20`.
     """
 
-    if integrals is None:
-        integrals = gw.ao2mo()
+    def auxiliary_shift(self, fock, se=None):
+        """
+        Optimise a shift in the auxiliary energies to best satisfy the
+        electron number.
 
-    with util.SilentSCF(gw._scf):
-        h1e = util.einsum("pq,spi,sqj->sij", gw._scf.get_hcore(), gw.mo_coeff, gw.mo_coeff)
-    nmo = gw.nmo
-    nocc = gw.nocc
-    naux = (se[0].naux, se[1].naux)
-    nqmo = (nmo[0] + naux[0], nmo[0] + naux[1])
-    nelec = nocc
+        Parameters
+        ----------
+        fock : numpy.ndarray
+            Fock matrix for each spin channel.
+        se : tuple of dyson.Lehmann, optional
+            Self-energy for each spin channel. If `None`, use `self.se`.
+            Default value is `None`.
 
-    diis = util.DIIS()
-    diis.space = fock_diis_space
-    diis.min_space = fock_diis_min_space
-    gf_to_dm = lambda gf: np.array([g.occupied().moment(0) for g in gf])
-    rdm1 = gf_to_dm(gf)
-    fock = integrals.get_fock(rdm1, h1e)
-    gf = list(gf)
-    se = list(se)
+        Returns
+        -------
+        se : tuple of dyson.Lehmann
+            Self-energy for each spin channel.
 
-    buf = np.zeros((max(nqmo), max(nqmo)))
-    converged = False
-    opts = dict(tol=conv_tol_nelec, maxiter=max_cycle_inner, occupancy=1)
-    rdm1_prev = rdm1
+        Notes
+        -----
+        If there is no dynamic part of the self-energy (`self.se` is
+        `None`), this method returns `None`.
+        """
 
-    with logging.with_table(title="Fock loop") as table:
-        table.add_column("Iter", justify="right")
-        table.add_column("Cycle", justify="right")
-        table.add_column("Error (nα)", justify="right")
-        table.add_column("Error (nβ)", justify="right")
-        table.add_column("Δ (density)", justify="right")
+        if se is None:
+            se = self.se
+        if se is None:
+            return None
 
-        for niter1 in range(1, max_cycle_outer + 1):
-            se_α, opt = minimize_chempot(se[0], fock[0], nelec[0], x0=se[0].chempot, **opts)
-            se_β, opt = minimize_chempot(se[1], fock[1], nelec[1], x0=se[1].chempot, **opts)
-            se = [se_α, se_β]
+        se_α, opt_α = minimize_chempot(
+            se[0],
+            fock[0],
+            self.nelec[0],
+            x0=se[0].chempot,
+            tol=self.conv_tol_nelec,
+            maxiter=self.max_cycle_inner,
+            occupancy=1,
+        )
 
-            for niter2 in range(1, max_cycle_inner + 1):
-                with logging.with_status(f"Iteration [{niter1}, {niter2}]"):
-                    w, v = se[0].diagonalise_matrix(fock[0], chempot=0.0, out=buf)
-                    w = mpi_helper.bcast(w, root=0)
-                    v = mpi_helper.bcast(v, root=0)
-                    se[0].chempot, nerr_α = search_chempot(w, v, nmo[0], nelec[0], occupancy=1)
-                    nerr_α = abs(nerr_α)
+        se_β, opt_β = minimize_chempot(
+            se[1],
+            fock[1],
+            self.nelec[1],
+            x0=se[1].chempot,
+            tol=self.conv_tol_nelec,
+            maxiter=self.max_cycle_inner,
+            occupancy=1,
+        )
 
-                    w, v = se[1].diagonalise_matrix(fock[1], chempot=0.0, out=buf)
-                    w = mpi_helper.bcast(w, root=0)
-                    v = mpi_helper.bcast(v, root=0)
-                    se[1].chempot, nerr_β = search_chempot(w, v, nmo[1], nelec[1], occupancy=1)
-                    nerr_β = abs(nerr_β)
+        se = (se_α, se_β)
 
-                    w, v = se[0].diagonalise_matrix(fock[0], out=buf)
-                    w = mpi_helper.bcast(w, root=0)
-                    v = mpi_helper.bcast(v, root=0)
-                    gf[0] = Lehmann(w, v[: nmo[0]], chempot=se[0].chempot)
+        return se
 
-                    w, v = se[1].diagonalise_matrix(fock[1], out=buf)
-                    w = mpi_helper.bcast(w, root=0)
-                    v = mpi_helper.bcast(v, root=0)
-                    gf[1] = Lehmann(w, v[: nmo[1]], chempot=se[1].chempot)
+    def solve_dyson(self, fock, se=None):
+        """Solve the Dyson equation for a given Fock matrix.
 
-                    rdm1 = gf_to_dm(gf)
-                    fock = integrals.get_fock(rdm1, h1e)
-                    fock = diis.update(fock, xerr=None)
+        Parameters
+        ----------
+        fock : numpy.ndarray
+            Fock matrix for each spin channel.
+        se : dyson.Lehmann, optional
+            Self-energy for each spin channel. If `None`, use `self.se`.
+            Default value is `None`.
 
-                    derr = np.max(np.absolute(rdm1 - rdm1_prev))
-                    if niter2 in {1, 5, 10, 50, 100, max_cycle_inner} or derr < conv_tol_rdm1:
-                        nerr_α_style = logging.rate(nerr_α, conv_tol_nelec, conv_tol_nelec * 1e2)
-                        nerr_β_style = logging.rate(nerr_β, conv_tol_nelec, conv_tol_nelec * 1e2)
-                        derr_style = logging.rate(derr, conv_tol_rdm1, conv_tol_rdm1 * 1e2)
-                        table.add_row(
-                            f"{niter1}",
-                            f"{niter2}",
-                            f"[{nerr_α_style}]{nerr_α:.3g}[/]",
-                            f"[{nerr_β_style}]{nerr_β:.3g}[/]",
-                            f"[{derr_style}]{derr:.3g}[/]",
-                        )
-                    if derr < conv_tol_rdm1:
-                        break
+        Returns
+        -------
+        gf : tuple of dyson.Lehmann
+            Green's function for each spin channel.
+        nerr : float
+            Error in the number of electrons.
 
-                    rdm1_prev = rdm1.copy()
+        Notes
+        -----
+        If there is no dynamic part of the self-energy (`self.se` is
+        `None`), this method simply diagonalises the Fock matrix and
+        returns the Lehmann representation of the resulting zeroth-order
+        Green's function.
+        """
 
-            if derr < conv_tol_rdm1 and (nerr_α + nerr_β) < conv_tol_nelec:
-                converged = True
-                break
+        if se is None:
+            se = self.se
 
-        logging.write(table)
+        if se is None:
+            e, c = np.linalg.eigh(fock)
+        else:
+            e_α, c_α = se[0].diagonalise_matrix(fock[0], chempot=0.0)
+            e_β, c_β = se[1].diagonalise_matrix(fock[1], chempot=0.0)
+            e = (e_α, e_β)
+            c = (c_α, c_β)
 
-    return tuple(gf), tuple(se), converged
+        e = (mpi_helper.bcast(e[0], root=0), mpi_helper.bcast(e[1], root=0))
+        c = (mpi_helper.bcast(c[0], root=0), mpi_helper.bcast(c[1], root=0))
+
+        gf = [
+            Lehmann(e[0], c[0][: self.nmo[0]], chempot=se[0].chempot if se is not None else 0.0),
+            Lehmann(e[1], c[1][: self.nmo[1]], chempot=se[1].chempot if se is not None else 0.0),
+        ]
+
+        gf[0].chempot, nerr_α = search_chempot(
+            gf[0].energies,
+            gf[0].couplings,
+            self.nmo[0],
+            self.nelec[0],
+            occupancy=1,
+        )
+        gf[1].chempot, nerr_β = search_chempot(
+            gf[1].energies,
+            gf[1].couplings,
+            self.nmo[1],
+            self.nelec[1],
+            occupancy=1,
+        )
+
+        nerr = abs(nerr_α) + abs(nerr_β)
+
+        return tuple(gf), nerr
+
+    def _density_error(self, rdm1, rdm1_prev):
+        """Calculate the density error."""
+        return max(
+            np.max(np.abs(rdm1[0] - rdm1_prev[0])).real,
+            np.max(np.abs(rdm1[1] - rdm1_prev[1])).real,
+        )
+
+    @property
+    def naux(self):
+        """Get the number of auxiliary states."""
+        return (self.se[0].naux, self.se[1].naux)
+
+    @property
+    def nqmo(self):
+        """Get the number of quasiparticle MOs."""
+        return (self.nmo[0] + self.naux[0], self.nmo[1] + self.naux[1])
+
+    @property
+    def nelec(self):
+        """Get the number of electrons."""
+        return self.nocc

--- a/momentGW/uhf/fock.py
+++ b/momentGW/uhf/fock.py
@@ -16,7 +16,7 @@ class FockLoop(FockLoop):
 
     Parameters
     ----------
-    gw : BaseGW
+    gw : BaseUGW
         GW object.
     gf : tuple of dyson.Lehmann, optional
         Initial Green's function object for each spin channel. If

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -11,7 +11,7 @@ from momentGW.base import BaseGW
 from momentGW.fock import minimize_chempot, search_chempot
 from momentGW.gw import GW
 from momentGW.uhf.base import BaseUGW
-from momentGW.uhf.fock import fock_loop
+from momentGW.uhf.fock import FockLoop
 from momentGW.uhf.ints import UIntegrals
 from momentGW.uhf.rpa import dRPA
 from momentGW.uhf.tda import dTDA
@@ -180,7 +180,8 @@ class UGW(BaseUGW, GW):  # noqa: D101
         if self.fock_loop:
             logging.write("")
             with logging.with_status("Running Fock loop"):
-                gf, se, conv = fock_loop(self, gf, se, integrals=integrals, **self.fock_opts)
+                solver = FockLoop(self, gf=gf, se=se, **self.fock_opts)
+                conv, gf, se = solver.kernel(integrals=integrals)
 
         cpt_α, error_α = search_chempot(
             gf[0].energies,

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -4,7 +4,7 @@ molecular systems.
 """
 
 import numpy as np
-from dyson import MBLSE, Lehmann, MixedMBLSE, NullLogger
+from dyson import MBLSE, Lehmann, MixedMBLSE
 
 from momentGW import energy, logging, mpi_helper, util
 from momentGW.base import BaseGW
@@ -130,19 +130,19 @@ class UGW(BaseUGW, GW):  # noqa: D101
         """
 
         with logging.with_modifiers(status="Solving Dyson equation", timer="Dyson equation"):
-            solver_occ = MBLSE(se_static[0], np.array(se_moments_hole[0]), log=NullLogger())
+            solver_occ = MBLSE(se_static[0], np.array(se_moments_hole[0]))
             solver_occ.kernel()
 
-            solver_vir = MBLSE(se_static[0], np.array(se_moments_part[0]), log=NullLogger())
+            solver_vir = MBLSE(se_static[0], np.array(se_moments_part[0]))
             solver_vir.kernel()
 
             solver = MixedMBLSE(solver_occ, solver_vir)
             se_α = solver.get_self_energy()
 
-            solver_occ = MBLSE(se_static[1], np.array(se_moments_hole[1]), log=NullLogger())
+            solver_occ = MBLSE(se_static[1], np.array(se_moments_hole[1]))
             solver_occ.kernel()
 
-            solver_vir = MBLSE(se_static[1], np.array(se_moments_part[1]), log=NullLogger())
+            solver_vir = MBLSE(se_static[1], np.array(se_moments_part[1]))
             solver_vir.kernel()
 
             solver = MixedMBLSE(solver_occ, solver_vir)

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -6,9 +6,9 @@ molecular systems.
 import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE
 
-from momentGW import energy, logging, mpi_helper, util
+from momentGW import energy, logging, util
 from momentGW.base import BaseGW
-from momentGW.fock import minimize_chempot, search_chempot
+from momentGW.fock import search_chempot
 from momentGW.gw import GW
 from momentGW.uhf.base import BaseUGW
 from momentGW.uhf.fock import FockLoop
@@ -150,11 +150,10 @@ class UGW(BaseUGW, GW):  # noqa: D101
 
             se = (se_α, se_β)
 
+        solver = FockLoop(self, se=se, **self.fock_opts)
+
         if self.optimise_chempot:
-            with logging.with_status("Optimising chemical potential"):
-                se_α, opt = minimize_chempot(se[0], se_static[0], self.nocc[0], occupancy=1)
-                se_β, opt = minimize_chempot(se[1], se_static[1], self.nocc[1], occupancy=1)
-            se = (se_α, se_β)
+            se = solver.auxiliary_shift(se_static)
 
         error = (
             self.moment_error(se_moments_hole[0], se_moments_part[0], se[0]),
@@ -168,52 +167,26 @@ class UGW(BaseUGW, GW):  # noqa: D101
                 f"particle = [{logging.rate(error[s][1], 1e-12, 1e-8)}]{error[s][1]:.3e}[/])"
             )
 
-        gf = tuple(
-            Lehmann(*s.diagonalise_matrix_with_projection(s_static))
-            for s, s_static in zip(se, se_static)
-        )
-        for g, s in zip(gf, se):
-            g.energies = mpi_helper.bcast(g.energies, root=0)
-            g.couplings = mpi_helper.bcast(g.couplings, root=0)
-            g.chempot = s.chempot
+        gf, error = solver.solve_dyson(se_static)
+        se[0].chempot = gf[0].chempot
+        se[1].chempot = gf[1].chempot
 
         if self.fock_loop:
             logging.write("")
-            with logging.with_status("Running Fock loop"):
-                solver = FockLoop(self, gf=gf, se=se, **self.fock_opts)
-                conv, gf, se = solver.kernel(integrals=integrals)
-
-        cpt_α, error_α = search_chempot(
-            gf[0].energies,
-            gf[0].couplings,
-            gf[0].nphys,
-            self.nocc[0],
-            occupancy=1,
-        )
-        cpt_β, error_β = search_chempot(
-            gf[1].energies,
-            gf[1].couplings,
-            gf[1].nphys,
-            self.nocc[1],
-            occupancy=1,
-        )
-        cpt = (cpt_α, cpt_β)
-        error = (error_α, error_β)
-        se[0].chempot = cpt[0]
-        se[1].chempot = cpt[1]
-        gf[0].chempot = cpt[0]
-        gf[1].chempot = cpt[1]
+            solver.gf = gf
+            solver.se = se
+            conv, gf, se = solver.kernel(integrals=integrals)
+            _, error = solver.search_chempot(gf)
 
         logging.write("")
+        color = logging.rate(
+            abs(error),
+            1e-6,
+            1e-6 if self.fock_loop or self.optimise_chempot else 1e-1,
+        )
+        logging.write(f"Error in number of electrons:  [{color}]{error:.3e}[/]")
         for s, spin in enumerate(["α", "β"]):
-            color = logging.rate(
-                abs(error[s]),
-                1e-6,
-                1e-6 if self.fock_loop or self.optimise_chempot else 1e-1,
-            )
-            logging.write(f"Error in number of electrons ({spin}):  [{color}]{error[s]:.3e}[/]")
-        for s, spin in enumerate(["α", "β"]):
-            logging.write(f"Chemical potential ({spin}):  {cpt[s]:.6f}")
+            logging.write(f"Chemical potential ({spin}):  {gf[s].chempot:.6f}")
 
         return tuple(gf), tuple(se)
 

--- a/tests/test_kugw.py
+++ b/tests/test_kugw.py
@@ -71,6 +71,32 @@ class Test_KUGW_vs_KRGW(unittest.TestCase):
         np.testing.assert_allclose(krgw.qp_energy, kugw.qp_energy[0])
         np.testing.assert_allclose(krgw.qp_energy, kugw.qp_energy[1])
 
+    def test_dtda_fock_loop(self):
+        krgw = KGW(self.mf)
+        krgw.compression = None
+        krgw.polarizability = "dtda"
+        krgw.fock_loop = True
+        krgw.conv_tol_nelec = 1e-8
+        krgw.conv_tol_rdm1 = 1e-10
+        krgw.kernel(3)
+
+        uhf = self.mf.to_uhf()
+        uhf.with_df = self.mf.with_df
+
+        kugw = KUGW(uhf)
+        kugw.compression = None
+        kugw.polarizability = "dtda"
+        kugw.fock_loop = True
+        kugw.conv_tol_nelec = 1e-8
+        kugw.conv_tol_rdm1 = 1e-10
+        kugw.kernel(3)
+
+        self.assertTrue(krgw.converged)
+        self.assertTrue(kugw.converged)
+
+        np.testing.assert_allclose(krgw.qp_energy, kugw.qp_energy[0], atol=1e-8, rtol=1e-6)
+        np.testing.assert_allclose(krgw.qp_energy, kugw.qp_energy[1], atol=1e-8, rtol=1e-6)
+
     # def test_dtda_compression(self):
     #    krgw = KGW(self.mf)
     #    krgw.compression = "ov,oo"

--- a/tests/test_sckugw.py
+++ b/tests/test_sckugw.py
@@ -225,7 +225,7 @@ class Test_scKUGW_no_beta(unittest.TestCase):
         cell.spin = 2
         cell.a = [[1.5, 0, 0], [0, 25, 0], [0, 0, 25]]
         cell.max_memory = 1e10
-        cell.verbose = 5
+        cell.verbose = 0
         cell.precision = 1e-14
         cell.build()
 
@@ -263,14 +263,14 @@ class Test_scKUGW_no_beta(unittest.TestCase):
         kugw = scKUGW(self.mf)
         kugw.compression = None
         kugw.polarizability = "dtda"
-        kugw.conv_tol = 1e-7
-        kugw.conv_tol_moms = 1e-4
+        kugw.conv_tol = 1e-8
+        kugw.conv_tol_moms = 1e-5
         kugw.kernel(1)
 
         self.assertTrue(kugw.converged)
 
-        self.assertAlmostEqual(lib.fp(kugw.qp_energy[0]), -0.0608517192)
-        self.assertAlmostEqual(lib.fp(kugw.qp_energy[1]), 0.3247931034)
+        self.assertAlmostEqual(lib.fp(kugw.qp_energy[0]), -0.0608517348)
+        self.assertAlmostEqual(lib.fp(kugw.qp_energy[1]), 0.3247931514)
 
 
 if __name__ == "__main__":

--- a/tests/test_ugw.py
+++ b/tests/test_ugw.py
@@ -58,6 +58,32 @@ class Test_UGW_vs_RGW(unittest.TestCase):
         np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[0])
         np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[1])
 
+    def test_dtda_fock_loop(self):
+        rgw = GW(self.mf)
+        rgw.compression = None
+        rgw.polarizability = "dtda"
+        rgw.fock_loop = True
+        rgw.conv_tol_nelec = 1e-10
+        rgw.conv_tol_rdm1 = 1e-12
+        rgw.kernel(5)
+
+        uhf = self.mf.to_uks()
+        uhf.with_df = self.mf.with_df
+
+        ugw = UGW(uhf)
+        ugw.compression = None
+        ugw.polarizability = "dtda"
+        ugw.fock_loop = True
+        ugw.conv_tol_nelec = 1e-10
+        ugw.conv_tol_rdm1 = 1e-12
+        ugw.kernel(5)
+
+        self.assertTrue(rgw.converged)
+        self.assertTrue(ugw.converged)
+
+        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[0], atol=1e-8, rtol=1e-6)
+        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[1], atol=1e-8, rtol=1e-6)
+
     def test_drpa(self):
         rgw = GW(self.mf)
         rgw.compression = None


### PR DESCRIPTION
Implement solvers for Fock loops with proper inheritance. Merge after #50 and #51.

- Fock loops use solver classes with inheritance
- `solve_dyson` functions use these solvers additionally for the chemical potential searching
- Adds some R vs. U Fock loop tests