### PR TITLE
Clean up docstrings

### DIFF
--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -1,48 +1,30 @@
 """
-******************************
-momentGW: Moment-conserving GW
-******************************
+momentGW
+========
 
-This repository contains the code and implementation for the paper
-"A 'moment-conesrving' reformulation of GW theory".
+The `momentGW` package implements a wide range of GW methods according
+to the moment-conserving formalism.
 
-Installation
-------------
+Examples
+--------
+Examples of usage can be found in the `examples` directory of the
+repository::
 
-Install Vayesta, which includes other dependencies such as PySCF
-and NumPy:
+    $ python examples/00-moment_order.py
 
-    git clone git@github.com:BoothGroup/Vayesta.git
-    python -m pip install . --user
+Notes
+-----
+Publications using `momentGW` should cite [1]_.
 
-Install moment-conserving Dyson equation solver:
-
-    git clone git@github.com:BoothGroup/dyson.git
-
-Clone the momentGW repository:
-
-    git clone git@github.com:BoothGroup/momentGW.git --depth 1
-    python -m pip install . --user
-
+References
+----------
+.. [1] C. J. C. Scott, O. J. Backhouse, and G. H. Booth, 158, 12, 2023.
 """
 
 import sys
 import logging
 
 __version__ = "1.0.0"
-
-
-# --- Check dependencies
-
-try:
-    import pyscf
-except ImportError:
-    raise ImportError("Missing dependency: https://github.com/pyscf/pyscf")
-
-try:
-    from dyson import MBLSE
-except ImportError:
-    raise ImportError("Missing dependency: https://github.com/BoothGroup/dyson")
 
 
 # --- Patch `dyson` to suppress logging

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -306,12 +306,21 @@ class BaseGW(Base):
         self.gf = None
         self._qp_energy = None
 
+    @property
+    def name(self):
+        """Abstract property for the solver name."""
+        raise NotImplementedError
+
     def build_se_static(self, *args, **kwargs):
         """Abstract method for building the static self-energy."""
         raise NotImplementedError
 
     def build_se_moments(self, *args, **kwargs):
         """Abstract method for building the self-energy moments."""
+        raise NotImplementedError
+
+    def ao2mo(self, transform=True):
+        """Abstract method for getting the integrals object."""
         raise NotImplementedError
 
     def solve_dyson(self, *args, **kwargs):

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -5,7 +5,6 @@ constraints for molecular systems.
 
 import numpy as np
 from dyson import CPGF, MBLGF
-from pyscf import lib
 
 from momentGW import logging, mpi_helper, util
 from momentGW.base import Base

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -478,7 +478,7 @@ class cpBSE(BSE):
     grid : numpy.ndarray
         Grid to plot spectral function on.
     eta : float, optional
-        Regularisation parameter.  Default value is `0.1`.
+        Regularisation parameter. Default value is `0.1`.
     polarizability : str, optional
         Type of polarizability to use, can be one of `("drpa",
         "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -31,11 +31,17 @@ def kernel(
     moments : numpy.ndarray, optional
         Moments of the dynamic polarizability, if passed then they will
         be used instead of calculating them. Default value is `None`.
-    integrals : Integrals, optional
+    integrals : BaseIntegrals, optional
         Integrals object. If `None`, generate from scratch. Default
         value is `None`.
+
+    Returns
+    -------
+    gf : dyson.Lehmann
+        Green's function object.
     """
 
+    # Get the integrals
     if integrals is None:
         integrals = bse.ao2mo()
 
@@ -65,7 +71,7 @@ class BSE(Base):
         Default value is `"singlet"`.
     """
 
-    # --- Extra BSE options
+    # --- Default BSE options
 
     excitation = "singlet"
     polarizability = None
@@ -85,7 +91,7 @@ class BSE(Base):
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-BSE"
 
@@ -103,10 +109,11 @@ class BSE(Base):
 
         Returns
         -------
-        integrals : Integrals
+        integrals : BaseIntegrals
             Integrals object.
         """
 
+        # Get the integrals
         integrals = Integrals(
             self.with_df,
             self.mo_coeff,
@@ -116,6 +123,7 @@ class BSE(Base):
             store_full=True,
         )
 
+        # Check compression
         compression = integrals._parse_compression()
         if compression and compression != {"oo", "vv", "ov"}:
             logging.warn(
@@ -123,6 +131,7 @@ class BSE(Base):
                 "is not recommended[/]. See example 17.",
             )
 
+        # Transform the integrals
         if transform:
             integrals.transform()
 
@@ -134,10 +143,11 @@ class BSE(Base):
 
         Parameters
         ----------
-        integrals : Integrals
+        integrals : BaseIntegrals
             Integrals object.
-
-        See functions in `momentGW.rpa` for `kwargs` options.
+        **kwargs : dict, optional
+            Additional keyword arguments to pass to the RPA or TDA
+            solver. See `momentGW.tda` and `momentGW.rpa` for options.
 
         Returns
         -------
@@ -166,7 +176,7 @@ class BSE(Base):
 
         Parameters
         ----------
-        integrals : Integrals
+        integrals : BaseIntegrals
             Integrals object.
         moment : numpy.ndarray, optional
             First inverse (`n=-1`) moment of the density-density
@@ -176,8 +186,8 @@ class BSE(Base):
         Returns
         -------
         matvec : callable
-            Function that takes a vector `x` and returns the matrix-
-            vector product `xA`.
+            Function that takes a vector ``x`` and returns the matrix-
+            vector product ``xA``.
         """
 
         # Developer note: this is not parallelised much, I just made
@@ -192,11 +202,8 @@ class BSE(Base):
             # the basis of the GW solution but that's more annoying
             qp_energy = self.gw.qp_energy
 
-        d = lib.direct_sum(
-            "a-i->ia",
-            self.mo_energy[self.mo_occ == 0],
-            self.mo_energy[self.mo_occ > 0],
-        )
+        # Get the 1h1p energies
+        d = util.build_1h1p_energies(self.mo_energy, self.mo_occ)
         nocc, nvir = d.shape
 
         # Get the inverse moment
@@ -265,7 +272,7 @@ class BSE(Base):
         ----------
         nmom_max : int
             Maximum moment number to calculate.
-        integrals : Integrals
+        integrals : BaseIntegrals
             Integrals object.
         matvec : callable, optional
             Function that computes the matrix-vector product between
@@ -302,6 +309,7 @@ class BSE(Base):
         for n in range(1, nmom_max + 1):
             moments_dp[n] = matvec(moments_dp[n - 1])
 
+        # Rotate basis
         moments_dp = util.einsum("px,nqx->npq", dip.conj(), moments_dp)
 
         return moments_dp
@@ -313,6 +321,11 @@ class BSE(Base):
         ----------
         moments : numpy.ndarray
             Moments of the dynamic polarizability.
+
+        Returns
+        -------
+        gf : dyson.Lehmann
+            Green's function object.
         """
 
         solver = MBLGF(np.array(moments))
@@ -339,12 +352,20 @@ class BSE(Base):
             Chebyshev moments of the dynamic polarizability, if passed
             then they will be used instead of calculating them. Default
             value is `None`.
-        integrals : Integrals, optional
+        integrals : BaseIntegrals, optional
             Integrals object. If `None`, generate from scratch. Default
             value is `None`.
+
+        Returns
+        -------
+        gf : dyson.Lehmann
+            Green's function object.
         """
 
+        # Start a timer
         timer = util.Timer()
+
+        # Write the header
         logging.write("")
         logging.write(f"[bold underline]{self.name}[/]", comment="Solver options")
         logging.write("")
@@ -352,6 +373,11 @@ class BSE(Base):
         logging.write("", comment=f"Start of {self.name} kernel")
         logging.write(f"Solving for nmom_max = [option]{nmom_max}[/] ({nmom_max + 1} moments)")
 
+        # Get the integrals
+        if integrals is None:
+            integrals = self.ao2mo()
+
+        # Run the kernel
         logging.write("")
         with logging.with_status(f"Running {self.name} kernel"):
             self.gf = self._kernel(
@@ -366,29 +392,43 @@ class BSE(Base):
 
         return self.gf
 
-    def _opt_is_used(self, key):
-        """
-        Check if an option is used by the solver. This is useful for
-        determining whether to print the option in the table.
-        """
-        return True
-
     def _get_summary_panel(self, timer):
-        """Return the summary as a panel."""
+        """Return the summary as a panel.
 
+        Parameters
+        ----------
+        timer : Timer
+            Timer object.
+
+        Returns
+        -------
+        panel : rich.Panel
+            Panel with the summary.
+        """
+
+        # Get the summary message
         msg = f"{self.name} ran in {timer.format_time(timer.total())}."
 
+        # Build the table
         table = logging._Table.grid()
         table.add_row(msg)
         table.add_row("")
         table.add_row(self._get_excitations_table())
 
+        # Build the panel
         panel = logging.Panel(table, title="Summary", padding=(1, 2), expand=False)
 
         return panel
 
     def _get_excitations_table(self):
-        """Print the excitations as a table."""
+        """Return the excitations as a table.
+
+        Returns
+        -------
+        table : rich.Table
+            Table with the excitations.
+        """
+
         # TODO check nomenclature
 
         # Build table
@@ -418,26 +458,28 @@ class BSE(Base):
 
 
 class cpBSE(BSE):
-    """Chebyshev-polynomial Bethe-Salpeter equation.
+    r"""Chebyshev-polynomial Bethe-Salpeter equation.
 
     Parameters
     ----------
     mf : pyscf.scf.SCF
         PySCF mean-field class.
     scale : tuple of int
-        Scaling parameters used to scale the spectrum to [-1, 1],
+        Scaling parameters used to scale the spectrum to ``[-1, 1]``,
         given as `(a, b)` where
 
-            a = (ωmax - ωmin) / (2 - ε)
-            b = (ωmax + ωmin) / 2
+        .. math::
+            a = \\frac{\omega_{\max} - \omega_{\min}}{2 - \epsilon},
+            b = \\frac{\omega_{\max} + \omega_{\min}}{2}.
 
-        where ωmax and ωmin are the maximum and minimum energies in
-        the spectrum, respectively, and ε is a small number shifting
-        the spectrum values away from the boundaries.
+        where :math:`\omega_{\max}` and :math:`\omega_{\min}` are the
+        maximum and minimum energies in the spectrum, respectively, and
+        :math:`\epsilon` is a small number shifting the spectrum values
+        away from the boundaries.
     grid : numpy.ndarray
         Grid to plot spectral function on.
     eta : float, optional
-        Regularisation parameter.  Default value is 0.1.
+        Regularisation parameter.  Default value is `0.1`.
     polarizability : str, optional
         Type of polarizability to use, can be one of `("drpa",
         "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
@@ -465,7 +507,7 @@ class cpBSE(BSE):
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-cpBSE"
 
@@ -478,7 +520,7 @@ class cpBSE(BSE):
         ----------
         nmom_max : int
             Maximum moment number to calculate.
-        integrals : Integrals
+        integrals : BaseIntegrals
             Integrals object.
         matvec : callable, optional
             Function that computes the matrix-vector product between
@@ -529,6 +571,11 @@ class cpBSE(BSE):
         ----------
         moments : numpy.ndarray
             Chebyshev moments of the dynamic polarizability.
+
+        Returns
+        -------
+        gf : numpy.ndarray
+            Green's function object.
         """
 
         solver = CPGF(
@@ -545,13 +592,27 @@ class cpBSE(BSE):
         return gf
 
     def _get_summary_panel(self, timer):
-        """Return the summary as a panel."""
+        """Return the summary as a panel.
 
+        Parameters
+        ----------
+        timer : Timer
+            Timer object.
+
+        Returns
+        -------
+        panel : rich.Panel
+            Panel with the summary.
+        """
+
+        # Get the summary message
         msg = f"{self.name} ran in {timer.format_time(timer.total())}."
 
+        # Build the table
         table = logging._Table.grid()
         table.add_row(msg)
 
+        # Build the panel
         panel = logging.Panel(table, title="Summary", padding=(1, 2), expand=False)
 
         return panel

--- a/momentGW/energy.py
+++ b/momentGW/energy.py
@@ -9,7 +9,22 @@ from momentGW import util
 
 
 def hartree_fock(rdm1, fock, h1e):
-    """Hartree--Fock energy functional."""
+    """Hartree--Fock energy functional.
+
+    Parameters
+    ----------
+    rdm1 : numpy.ndarray
+        One-particle reduced density matrix.
+    fock : numpy.ndarray
+        Fock matrix.
+    h1e : numpy.ndarray
+        One-electron Hamiltonian.
+
+    Returns
+    -------
+    e_1b : float
+        Hartree--Fock energy.
+    """
     return util.einsum("ij,ji->", rdm1, h1e + fock) * 0.5
 
 
@@ -19,9 +34,9 @@ def galitskii_migdal(gf, se, flip=False):
     Parameters
     ----------
     gf : dyson.Lehmann
-        Green's function.
+        Green's function object.
     se : dyson.Lehmann
-        Self-energy.
+        Self-energy object.
     flip : bool, optional
         Default option is to use the occupied Green's function and the
         virtual self-energy. If `flip=True`, the virtual Green's
@@ -44,6 +59,7 @@ def galitskii_migdal(gf, se, flip=False):
     This scales as :math:`\mathcal{O}(N^4)` with system size.
     """
 
+    # Get the correct Green's function and self-energy sectors
     if flip:
         gf = gf.virtual()
         se = se.occupied()
@@ -51,13 +67,14 @@ def galitskii_migdal(gf, se, flip=False):
         gf = gf.occupied()
         se = se.virtual()
 
+    # Compute the Galitskii--Migdal energy in blocks
     e_2b = 0.0
     for p0, p1 in lib.prange(0, se.naux, 256):
         vu = util.einsum("pk,px->kx", se.couplings[:, p0:p1], gf.couplings)
         denom = lib.direct_sum("x-k->kx", gf.energies, se.energies[p0:p1])
-
         e_2b += np.ravel(util.einsum("kx,kx,kx->", vu, vu.conj(), 1.0 / denom))[0]
 
+    # Apply the factor 2
     e_2b *= 2.0
 
     return e_2b
@@ -100,6 +117,7 @@ def galitskii_migdal_g0(mo_energy, mo_occ, se, flip=False):
     size.
     """
 
+    # Get the correct Green's function and self-energy sectors
     if flip:
         mo = mo_energy[mo_occ == 0]
         se = se.occupied()
@@ -109,9 +127,11 @@ def galitskii_migdal_g0(mo_energy, mo_occ, se, flip=False):
         se = se.virtual()
         se.couplings = se.couplings[mo_occ > 0]
 
+    # Compute the Galitskii--Migdal energy in blocks
     denom = lib.direct_sum("i-j->ij", mo, se.energies)
-
     e_2b = np.ravel(util.einsum("xk,xk,xk->", se.couplings, se.couplings.conj(), 1.0 / denom))[0]
+
+    # Apply the factor 2
     e_2b *= 2.0
 
     return e_2b

--- a/momentGW/energy.py
+++ b/momentGW/energy.py
@@ -50,13 +50,21 @@ def galitskii_migdal(gf, se, flip=False):
 
     Notes
     -----
-    This functional is the analytically integrated version of
+    This functional is the analytically integrated version of [1]_
 
     .. math::
-        \frac{\pi}{4} \int d\omega \mathrm{Tr}[G(i\omega) \Sigma(i\omega)]
+        \frac{\pi}{4} \int d\omega \mathrm{Tr}[G(i\omega)
+        \Sigma(i\omega)]
 
     in terms of the poles of the Green's function and the self-energy.
-    This scales as :math:`\mathcal{O}(N^4)` with system size.
+    This scales as :math:`\mathcal{O}(N^4)` with system size [2]_.
+
+    References
+    ----------
+    .. [1] V. M. Galitskii and A. B. Migdal, Sov. Phys. JETP 7, 96,
+        1958.
+    .. [2] O. J. Backhouse, M. Nusspickel, and G. H. Booth, J. Chem.
+        Theory Comput. 16, 2, 2020.
     """
 
     # Get the correct Green's function and self-energy sectors
@@ -106,7 +114,7 @@ def galitskii_migdal_g0(mo_energy, mo_occ, se, flip=False):
 
     Notes
     -----
-    This functional is the analytically integrated version of
+    This functional is the analytically integrated version of [1]_
 
     .. math::
         \frac{\pi}{4} \int d\omega \\
@@ -114,7 +122,14 @@ def galitskii_migdal_g0(mo_energy, mo_occ, se, flip=False):
 
     in terms of the poles of the mean-field Green's function and the
     self-energy. This scales as :math:`\mathcal{O}(N^3)` with system
-    size.
+    size [2]_.
+
+    References
+    ----------
+    .. [1] V. M. Galitskii and A. B. Migdal, Sov. Phys. JETP 7, 96,
+        1958.
+    .. [2] O. J. Backhouse, M. Nusspickel, and G. H. Booth, J. Chem.
+        Theory Comput. 16, 2, 2020.
     """
 
     # Get the correct Green's function and self-energy sectors

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -209,13 +209,13 @@ class evGW(GW):
         "weight_tol",
     ]
 
+    _kernel = kernel
+
     @property
     def name(self):
         """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-evG{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"
-
-    _kernel = kernel
 
     def check_convergence(self, mo_energy, mo_energy_prev, th, th_prev, tp, tp_prev):
         """Check for convergence, and print a summary of changes.

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -6,7 +6,6 @@ constraints for molecular systems.
 import numpy as np
 
 from momentGW import logging, util
-from momentGW.base import BaseGW
 from momentGW.gw import GW
 
 

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -157,12 +157,12 @@ class evGW(GW):
         implementation requires a filepath to import the THC integrals.
     g0 : bool, optional
         If `True`, do not self-consistently update the eigenvalues in
-        the Green's function.  Default value is `False`.
+        the Green's function. Default value is `False`.
     w0 : bool, optional
         If `True`, do not self-consistently update the eigenvalues in
-        the screened Coulomb interaction.  Default value is `False`.
+        the screened Coulomb interaction. Default value is `False`.
     max_cycle : int, optional
-        Maximum number of iterations.  Default value is `50`.
+        Maximum number of iterations. Default value is `50`.
     conv_tol : float, optional
         Convergence threshold in the change in the HOMO and LUMO.
         Default value is `1e-8`.
@@ -177,9 +177,9 @@ class evGW(GW):
         both metrics to be met, and `any` requires just one. Default
         value is `all`.
     diis_space : int, optional
-        Size of the DIIS extrapolation space.  Default value is `8`.
+        Size of the DIIS extrapolation space. Default value is `8`.
     damping : float, optional
-        Damping parameter.  Default value is `0.0`.
+        Damping parameter. Default value is `0.0`.
     weight_tol : float, optional
         Threshold in physical weight of Green's function poles, below
         which they are considered zero. Default value is `1e-11`.

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -29,7 +29,7 @@ def kernel(
         Tuple of (hole, particle) moments, if passed then they will
         be used  as the initial guess instead of calculating them.
         Default value is `None`.
-    integrals : Integrals, optional
+    integrals : BaseIntegrals, optional
         Integrals object. If `None`, generate from scratch. Default
         value is `None`.
 
@@ -38,9 +38,9 @@ def kernel(
     conv : bool
         Convergence flag.
     gf : dyson.Lehmann
-        Green's function object
+        Green's function object.
     se : dyson.Lehmann
-        Self-energy object
+        Self-energy object.
     qp_energy : numpy.ndarray
         Quasiparticle energies. Always None for evGW, returned for
         compatibility with other evGW methods.
@@ -49,19 +49,24 @@ def kernel(
     if gw.polarizability.lower() == "drpa-exact":
         raise NotImplementedError("%s for polarizability=%s" % (gw.name, gw.polarizability))
 
+    # Get the integrals
     if integrals is None:
         integrals = gw.ao2mo()
 
+    # Initialise the orbitals
     mo_energy = gw.mo_energy.copy()
 
+    # Get the DIIS object
     diis = util.DIIS()
     diis.space = gw.diis_space
 
     # Get the static part of the SE
     se_static = gw.build_se_static(integrals)
 
+    # Initialise convergence quantities
     conv = False
     th_prev = tp_prev = None
+
     for cycle in range(1, gw.max_cycle + 1):
         with logging.with_status(f"Iteration {cycle}"):
             with logging.with_comment(f"Start of iteration {cycle}"):
@@ -111,11 +116,47 @@ def kernel(
     return conv, gf, se, None
 
 
-class evGW(GW):  # noqa: D101
-    __doc__ = BaseGW.__doc__.format(
-        description="Spin-restricted eigenvalue self-consistent GW via self-energy moment "
-        + "constraints for molecules.",
-        extra_parameters="""g0 : bool, optional
+class evGW(GW):
+    """
+    Spin-restricted eigenvalue self-consistent GW via self-energy moment
+    constraints for molecules.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.SCF
+        PySCF mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    g0 : bool, optional
         If `True`, do not self-consistently update the eigenvalues in
         the Green's function.  Default value is `False`.
     w0 : bool, optional
@@ -143,8 +184,7 @@ class evGW(GW):  # noqa: D101
     weight_tol : float, optional
         Threshold in physical weight of Green's function poles, below
         which they are considered zero. Default value is `1e-11`.
-    """,
-    )
+    """
 
     # --- Extra evGW options
 
@@ -172,7 +212,7 @@ class evGW(GW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-evG{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"
 
@@ -203,17 +243,21 @@ class evGW(GW):  # noqa: D101
             Convergence flag.
         """
 
+        # Get the previous moments
         if th_prev is None:
             th_prev = np.zeros_like(th)
         if tp_prev is None:
             tp_prev = np.zeros_like(tp)
 
+        # Get the HOMO and LUMO errors
         error_homo = abs(mo_energy[self.nocc - 1] - mo_energy_prev[self.nocc - 1])
         error_lumo = abs(mo_energy[self.nocc] - mo_energy_prev[self.nocc])
 
+        # Get the moment errors
         error_th = self._moment_error(th, th_prev)
         error_tp = self._moment_error(tp, tp_prev)
 
+        # Print the table
         style_homo = logging.rate(error_homo, self.conv_tol, self.conv_tol * 1e2)
         style_lumo = logging.rate(error_lumo, self.conv_tol, self.conv_tol * 1e2)
         style_th = logging.rate(error_th, self.conv_tol_moms, self.conv_tol_moms * 1e2)
@@ -246,7 +290,7 @@ class evGW(GW):  # noqa: D101
         Parameters
         ----------
         gf : dyson.Lehmann
-            Green's function.
+            Green's function object.
 
         Returns
         -------

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -192,21 +192,8 @@ class BaseFockLoop:
         raise NotImplementedError
 
     def _density_error(self, rdm1, rdm1_prev):
-        """Calculate the density error.
-
-        Parameters
-        ----------
-        rdm1 : numpy.ndarray
-            Current density matrix.
-        rdm1_prev : numpy.ndarray
-            Previous density matrix.
-
-        Returns
-        -------
-        error : float
-            Density error.
-        """
-        return np.max(np.abs(rdm1 - rdm1_prev)).real
+        """Calculate the density error."""
+        raise NotImplementedError
 
     def _kernel_dynamic(self, integrals=None):
         """Driver for the Fock loop with a self-energy."""
@@ -592,6 +579,23 @@ class FockLoop(BaseFockLoop):
         gf.chempot, nerr = self.search_chempot(gf)
 
         return gf, nerr
+
+    def _density_error(self, rdm1, rdm1_prev):
+        """Calculate the density error.
+
+        Parameters
+        ----------
+        rdm1 : numpy.ndarray
+            Current density matrix.
+        rdm1_prev : numpy.ndarray
+            Previous density matrix.
+
+        Returns
+        -------
+        error : float
+            Density error.
+        """
+        return np.max(np.abs(rdm1 - rdm1_prev)).real
 
     @property
     def naux(self):

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -17,10 +17,10 @@ class ChemicalPotentialError(ValueError):
 
 
 def _gradient(x, se, fock, nelec, occupancy=2, buf=None):
-    """Gradient of the number of electrons w.r.t shift in auxiliary
+    """
+    Gradient of the number of electrons w.r.t shift in auxiliary
     energies.
     """
-    # TODO buf
 
     w, v = se.diagonalise_matrix(fock, chempot=x)
     chempot, error = search_chempot(w, v, se.nphys, nelec, occupancy=occupancy)
@@ -39,6 +39,26 @@ def _gradient(x, se, fock, nelec, occupancy=2, buf=None):
 def search_chempot(w, v, nphys, nelec, occupancy=2):
     """
     Search for a chemical potential.
+
+    Parameters
+    ----------
+    w : numpy.ndarray
+        Eigenvalues.
+    v : numpy.ndarray
+        Eigenvectors.
+    nphys : int
+        Number of physical states.
+    nelec : int
+        Number of electrons.
+    occupancy : int, optional
+        Number of electrons per state. Default value is `2`.
+
+    Returns
+    -------
+    chempot : float
+        Chemical potential.
+    error : float
+        Error in the number of electrons.
     """
 
     if nelec == 0:
@@ -77,6 +97,30 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
     """
     Optimise the shift in auxiliary energies to satisfy the electron
     number.
+
+    Parameters
+    ----------
+    se : dyson.Lehmann
+        Self-energy object.
+    fock : numpy.ndarray
+        Fock matrix.
+    nelec : int
+        Number of electrons.
+    occupancy : int, optional
+        Number of electrons per state. Default value is `2`.
+    x0 : float, optional
+        Initial guess value. Default value is `0.0`.
+    tol : float, optional
+        Threshold in the number of electrons. Default value is `1e-6`.
+    maxiter : int, optional
+        Maximum number of iterations. Default value is `200`.
+
+    Returns
+    -------
+    se : dyson.Lehmann
+        Self-energy object.
+    opt : scipy.optimize.OptimizeResult
+        Result of the optimisation.
     """
 
     tol = tol**2  # we minimize the squared error
@@ -154,7 +198,7 @@ class BaseFockLoop:
 
         Parameters
         ----------
-        integrals : Integrals, optional
+        integrals : BaseIntegrals, optional
             Integrals object. If `None`, generate from scratch. Default
             value is `None`.
 
@@ -163,9 +207,9 @@ class BaseFockLoop:
         converged : bool
             Whether the loop has converged.
         gf : dyson.Lehmann
-            Green's function.
+            Green's function object.
         se : dyson.Lehmann
-            Self-energy.
+            Self-energy object.
         """
 
         if self.se is None:
@@ -311,8 +355,8 @@ class BaseFockLoop:
         Parameters
         ----------
         gf : dyson.Lehmann, optional
-            Green's function. If `None`, use either `self.gf`, or the
-            mean-field Green's function. Default value is `None`.
+            Green's function object. If `None`, use either `self.gf`, or
+            the mean-field Green's function. Default value is `None`.
 
         Returns
         -------

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -328,38 +328,6 @@ class BaseFockLoop:
 
         return converged, gf, None
 
-    @logging.with_timer("Fock loop")
-    @logging.with_status("Running Fock loop")
-    def kernel(self, integrals=None):
-        """Driver for the Fock loop.
-
-        Parameters
-        ----------
-        integrals : BaseIntegrals, optional
-            Integrals object. If `None`, generate from scratch. Default
-            value is `None`.
-
-        Returns
-        -------
-        converged : bool
-            Whether the loop has converged.
-        gf : dyson.Lehmann
-            Green's function object.
-        se : dyson.Lehmann
-            Self-energy object.
-        """
-
-        # Get the kernel
-        if self.se is None:
-            kernel = self._kernel_static
-        else:
-            kernel = self._kernel_dynamic
-
-        # Run the kernel
-        self.converged, self.gf, self.se = kernel(integrals=integrals)
-
-        return self.converged, self.gf, self.se
-
     @property
     def h1e(self):
         """Get the core Hamiltonian."""
@@ -579,6 +547,38 @@ class FockLoop(BaseFockLoop):
         gf.chempot, nerr = self.search_chempot(gf)
 
         return gf, nerr
+
+    @logging.with_timer("Fock loop")
+    @logging.with_status("Running Fock loop")
+    def kernel(self, integrals=None):
+        """Driver for the Fock loop.
+
+        Parameters
+        ----------
+        integrals : Integrals, optional
+            Integrals object. If `None`, generate from scratch. Default
+            value is `None`.
+
+        Returns
+        -------
+        converged : bool
+            Whether the loop has converged.
+        gf : dyson.Lehmann
+            Green's function object.
+        se : dyson.Lehmann
+            Self-energy object.
+        """
+
+        # Get the kernel
+        if self.se is None:
+            kernel = self._kernel_static
+        else:
+            kernel = self._kernel_dynamic
+
+        # Run the kernel
+        self.converged, self.gf, self.se = kernel(integrals=integrals)
+
+        return self.converged, self.gf, self.se
 
     def _density_error(self, rdm1, rdm1_prev):
         """Calculate the density error.

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -6,7 +6,6 @@ constraints for molecular systems.
 import numpy as np
 
 from momentGW import logging, mpi_helper, util
-from momentGW.base import BaseGW
 from momentGW.gw import GW
 from momentGW.qsgw import qsGW
 

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -214,14 +214,14 @@ class fsGW(GW):  # noqa: D101
         "solver_options",
     ]
 
-    @property
-    def name(self):
-        """Get the method name."""
-        polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
-        return f"{polarizability}-fsGW"
-
     _kernel = kernel
 
     project_basis = staticmethod(qsGW.project_basis)
     self_energy_to_moments = staticmethod(qsGW.self_energy_to_moments)
     check_convergence = qsGW.check_convergence
+
+    @property
+    def name(self):
+        """Get the method name."""
+        polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
+        return f"{polarizability}-fsGW"

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -120,7 +120,7 @@ def kernel(
     return conv, gf, se, mo_energy
 
 
-class fsGW(GW):  # noqa: D101
+class fsGW(GW):
     """
     Spin-restricted Fock matrix self-consistent GW via self-energy
     moment constraints for molecules.

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -30,7 +30,7 @@ def kernel(
         Tuple of (hole, particle) moments, if passed then they will
         be used  as the initial guess instead of calculating them.
         Default value is `None`.
-    integrals : Integrals, optional
+    integrals : BaseIntegrals, optional
         Integrals object. If `None`, generate from scratch. Default
         value is `None`.
 
@@ -39,16 +39,18 @@ def kernel(
     conv : bool
         Convergence flag.
     gf : dyson.Lehmann
-        Green's function object
+        Green's function object.
     se : dyson.Lehmann
-        Self-energy object
+        Self-energy object.
     qp_energy : numpy.ndarray
         Quasiparticle energies.
     """
 
+    # Get the integrals
     if integrals is None:
         integrals = gw.ao2mo()
 
+    # Initialise the orbitals
     mo_energy = gw.mo_energy.copy()
     mo_coeff = gw.mo_coeff.copy()
 
@@ -60,6 +62,7 @@ def kernel(
         h1e_ao = gw._scf.get_hcore()
         h1e = util.einsum("...pq,...pi,...qj->...ij", h1e_ao, np.conj(gw.mo_coeff), gw.mo_coeff)
 
+    # Initialise the DIIS object
     diis = util.DIIS()
     diis.space = gw.diis_space
 
@@ -71,8 +74,10 @@ def kernel(
         subgw = gw.solver(gw._scf, **solver_options)
         gf = subgw.init_gf()
 
+    # Initialise convergence quantities
     conv = False
     mo_energy_prev = th_prev = tp_prev = None
+
     for cycle in range(1, gw.max_cycle + 1):
         with logging.with_comment(f"Start of iteration {cycle}"):
             logging.write("")
@@ -117,10 +122,46 @@ def kernel(
 
 
 class fsGW(GW):  # noqa: D101
-    __doc__ = BaseGW.__doc__.format(
-        description="Spin-restricted Fock matrix self-consistent GW via self-energy moment "
-        + "constraints for molecules.",
-        extra_parameters="""max_cycle : int, optional
+    """
+    Spin-restricted Fock matrix self-consistent GW via self-energy
+    moment constraints for molecules.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.SCF
+        PySCF mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    max_cycle : int, optional
         Maximum number of iterations. Default value is `50`.
     conv_tol : float, optional
         Convergence threshold in the change in the HOMO and LUMO.
@@ -145,8 +186,7 @@ class fsGW(GW):  # noqa: D101
     solver_options : dict, optional
         Keyword arguments to pass to the solver. Default value is an
         empty `dict`.
-    """,
-    )
+    """
 
     # --- Default fsGW options
 
@@ -177,7 +217,7 @@ class fsGW(GW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-fsGW"
 

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -178,7 +178,7 @@ class fsGW(GW):
     diis_space : int, optional
         Size of the DIIS extrapolation space. Default value is `8`.
     damping : float, optional
-        Damping parameter.  Default value is `0.0`.
+        Damping parameter. Default value is `0.0`.
     solver : BaseGW, optional
         Solver to use to obtain the self-energy. Compatible with any
         `BaseGW`-like class. Default value is `momentGW.gw.GW`.

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -31,7 +31,7 @@ def kernel(
     moments : tuple of numpy.ndarray, optional
         Tuple of (hole, particle) moments, if passed then they will
         be used instead of calculating them. Default value is `None`.
-    integrals : Integrals, optional
+    integrals : BaseIntegrals, optional
         Integrals object. If `None`, generate from scratch. Default
         value is `None`.
 
@@ -405,7 +405,7 @@ class GW(BaseGW):
         se : dyson.Lehmann
             Self-energy object.
         qp_energy : NoneType
-            Quasiparticle energies. For one-shot GW, this is `None`.
+            Quasiparticle energies. For most GW methods, this is `None`.
         """
         return super().kernel(nmom_max, moments=moments, integrals=integrals)
 

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -212,6 +212,7 @@ class GW(BaseGW):
         --------
         momentGW.rpa.dRPA
         momentGW.tda.dTDA
+        momentGW.thc.dTDA
         """
 
         if self.polarizability.lower() == "drpa":
@@ -247,6 +248,11 @@ class GW(BaseGW):
         -------
         integrals : Integrals
             Integrals object.
+
+        See Also
+        --------
+        momentGW.ints.Integrals
+        momentGW.thc.Integrals
         """
 
         # Get the integrals class
@@ -312,6 +318,10 @@ class GW(BaseGW):
             Green's function object.
         se : dyson.Lehmann
             Self-energy object.
+
+        See Also
+        --------
+        momentGW.fock.FockLoop
         """
 
         # Solve the Dyson equation for the moments

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -47,6 +47,15 @@ def kernel(
     qp_energy : numpy.ndarray
         Quasiparticle energies. Always `None` for GW, returned for
         compatibility with other GW methods.
+
+    Notes
+    -----
+    This approach is described in [1]_.
+
+    References
+    ----------
+    .. [1] C. J. C. Scott, O. J. Backhouse, and G. H. Booth, 158, 12,
+        2023.
     """
 
     # Get the integrals
@@ -116,6 +125,15 @@ class GW(BaseGW):
     thc_opts : dict, optional
         Dictionary of options to be used for THC calculations. Current
         implementation requires a filepath to import the THC integrals.
+
+    Notes
+    -----
+    This approach is described in [1]_.
+
+    References
+    ----------
+    .. [1] C. J. C. Scott, O. J. Backhouse, and G. H. Booth, 158, 12,
+        2023.
     """
 
     @property

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -136,13 +136,13 @@ class GW(BaseGW):
         2023.
     """
 
+    _kernel = kernel
+
     @property
     def name(self):
         """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-G0W0"
-
-    _kernel = kernel
 
     @logging.with_timer("Static self-energy")
     @logging.with_status("Building static self-energy")

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -56,7 +56,12 @@ def require_compression_metric():
     return decorator
 
 
-class Integrals:
+class BaseIntegrals:
+    """Base class for integral containers."""
+    pass
+
+
+class Integrals(BaseIntegrals):
     """
     Container for the density-fitted integrals required for GW methods.
 

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -144,8 +144,7 @@ class Integrals(BaseIntegrals):
 
     @logging.with_status("Computing compression metric")
     def get_compression_metric(self):
-        """
-        Return the compression metric.
+        """Return the compression metric.
 
         Returns
         -------
@@ -578,17 +577,17 @@ class Integrals(BaseIntegrals):
 
     @property
     def Lpq(self):
-        """Get the full uncompressed ``(aux, MO, MO)`` array."""
+        """Get the full uncompressed ``(aux, MO, MO)`` integrals."""
         return self._blocks["Lpq"]
 
     @property
     def Lpx(self):
-        """Get the compressed ``(aux, MO, G)`` array."""
+        """Get the compressed ``(aux, MO, G)`` integrals."""
         return self._blocks["Lpx"]
 
     @property
     def Lia(self):
-        """Get the compressed ``(aux, W occ, W vir)`` array."""
+        """Get the compressed ``(aux, W occ, W vir)`` integrals."""
         return self._blocks["Lia"]
 
     @property

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -48,7 +48,19 @@ COMMENT = ""
 
 
 def write(msg, *args, **kwargs):
-    """Print a message to the console."""
+    """Print a message to the console.
+
+    Parameters
+    ----------
+    msg : str
+        The message to print.
+    args : tuple
+        The arguments to format the message with.
+    comment : str, optional
+        A comment to print alongside the message.
+    **kwargs : dict, optional
+        Additional keyword arguments to pass to `console.print`.
+    """
 
     # Check if we need to print the message
     if silent:
@@ -71,7 +83,17 @@ def write(msg, *args, **kwargs):
 
 
 def warn(msg, *args, **kwargs):
-    """Print a message to the console with a warning comment."""
+    """Print a message to the console with a warning comment.
+
+    Parameters
+    ----------
+    msg : str
+        The message to print.
+    args : tuple
+        The arguments to format the message with.
+    **kwargs : dict, optional
+        Additional keyword arguments to pass to `console.print`.
+    """
 
     # Add a warning comment
     kwargs["comment"] = "[bad]Warning![/]"
@@ -81,7 +103,24 @@ def warn(msg, *args, **kwargs):
 
 
 def rate(value, good_threshold, ok_threshold, invert=False):
-    """Return a colour rating based on a value and thresholds."""
+    """Return a colour rating based on a value and thresholds.
+
+    Parameters
+    ----------
+    value : float
+        The value to rate.
+    good_threshold : float
+        The threshold for a good rating.
+    ok_threshold : float
+        The threshold for an ok rating.
+    invert : bool, optional
+        Invert the rating. Default value is `False`.
+
+    Returns
+    -------
+    style : str
+        The style to use for the rating.
+    """
     if value < good_threshold:
         rating = "good" if not invert else "bad"
     elif value < ok_threshold:
@@ -222,14 +261,22 @@ class Table(_Table):
 
 
 def time(msg, elapsed):
-    """Record a time."""
+    """Record a time.
+
+    Parameters
+    ----------
+    msg : str
+        The message to record.
+    elapsed : float
+        The time elapsed.
+    """
     if "_times" not in time.__dict__:
         time._times = {}
     time._times[msg] = time._times.get(msg, 0) + elapsed
 
 
 def dump_times():
-    """Print the times."""
+    """Print a table with the timings."""
     if "_times" in time.__dict__:
         table = Table(title="Timings")
         table.add_column("Task", justify="right")

--- a/momentGW/logging.py
+++ b/momentGW/logging.py
@@ -212,6 +212,22 @@ class Table(_Table):
     to the console if they are required to be displayed afterwards.
     """
 
+    def add_column(self, *args, **kwargs):
+        """Add a column to the table."""
+        super().add_column(*args, **kwargs)
+        if self._is_live and not silent:
+            _update_live()
+
+    add_column.__doc__ = _Table.add_column.__doc__
+
+    def add_row(self, *args, **kwargs):
+        """Add a row to the table."""
+        super().add_row(*args, **kwargs)
+        if self._is_live and not silent:
+            _update_live()
+
+    add_row.__doc__ = _Table.add_row.__doc__
+
     def __init__(self, *args, **kwargs):
         kwargs["show_edge"] = kwargs.get("show_edge", False)
         kwargs["show_header"] = kwargs.get("show_header", True)
@@ -242,22 +258,6 @@ class Table(_Table):
             TABLE = None
             self._is_live = False
             _update_live()
-
-    def add_column(self, *args, **kwargs):
-        """Add a column to the table."""
-        super().add_column(*args, **kwargs)
-        if self._is_live and not silent:
-            _update_live()
-
-    add_column.__doc__ = _Table.add_column.__doc__
-
-    def add_row(self, *args, **kwargs):
-        """Add a row to the table."""
-        super().add_row(*args, **kwargs)
-        if self._is_live and not silent:
-            _update_live()
-
-    add_row.__doc__ = _Table.add_row.__doc__
 
 
 def time(msg, elapsed):

--- a/momentGW/pbc/__init__.py
+++ b/momentGW/pbc/__init__.py
@@ -1,4 +1,5 @@
-"""Periodic methods.
+"""
+Methods for periodic systems.
 """
 
 from momentGW.pbc.tda import dTDA

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -61,6 +61,17 @@ class BaseKGW(BaseGW):
         "fc",
     ]
 
+    @property
+    def cell(self):
+        """Return the unit cell."""
+        return self._scf.cell
+
+    mol = cell
+
+    get_nmo = get_nmo
+    get_nocc = get_nocc
+    get_frozen_mask = get_frozen_mask
+
     def __init__(self, mf, **kwargs):
         super().__init__(mf, **kwargs)
 
@@ -177,17 +188,6 @@ class BaseKGW(BaseGW):
                 logging.warn(f"[bad]Inconsistent quasiparticle weights at k-point {k}![/]")
 
         return mo_energy
-
-    @property
-    def cell(self):
-        """Return the unit cell."""
-        return self._scf.cell
-
-    mol = cell
-
-    get_nmo = get_nmo
-    get_nocc = get_nocc
-    get_frozen_mask = get_frozen_mask
 
     @property
     def kpts(self):

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -236,7 +236,7 @@ class BaseKGW(BaseGW):
 
         Returns
         -------
-        mo_energy : ndarray
+        mo_energy : numpy.ndarray
             Updated MO energies at each k-point.
         """
 

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -44,9 +44,9 @@ class BaseKGW(BaseGW):
         a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
         compression on the initial ERIs, whereas `"ia"` refers to
         compression on the ERIs entering RPA, which may change under a
-        self-consistent scheme.  Default value is `"ia"`.
+        self-consistent scheme. Default value is `"ia"`.
     compression_tol : float, optional
-        Tolerance for the compression.  Default value is `1e-10`.
+        Tolerance for the compression. Default value is `1e-10`.
     thc_opts : dict, optional
         Dictionary of options to be used for THC calculations. Current
         implementation requires a filepath to import the THC integrals.

--- a/momentGW/pbc/evgw.py
+++ b/momentGW/pbc/evgw.py
@@ -10,14 +10,84 @@ from momentGW.evgw import evGW
 from momentGW.pbc.gw import KGW
 
 
-class evKGW(KGW, evGW):  # noqa: D101
-    __doc__ = evGW.__doc__.replace("molecules", "periodic systems", 1)
+class evKGW(KGW, evGW):
+    """
+    Spin-restricted eigenvalue self-consistent GW via self-energy moment
+    constraints for periodic systems.
+
+    Parameters
+    ----------
+    mf : pyscf.pbc.scf.KSCF
+        PySCF periodic mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    fc : bool, optional
+        If `True`, apply finite size corrections. Default value is
+        `False`.
+    g0 : bool, optional
+        If `True`, do not self-consistently update the eigenvalues in
+        the Green's function.  Default value is `False`.
+    w0 : bool, optional
+        If `True`, do not self-consistently update the eigenvalues in
+        the screened Coulomb interaction.  Default value is `False`.
+    max_cycle : int, optional
+        Maximum number of iterations.  Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    conv_logical : callable, optional
+        Function that takes an iterable of booleans as input indicating
+        whether the individual `conv_tol` and `conv_tol_moms` have been
+        satisfied, respectively, and returns a boolean indicating
+        overall convergence. For example, the function `all` requires
+        both metrics to be met, and `any` requires just one. Default
+        value is `all`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space.  Default value is `8`.
+    damping : float, optional
+        Damping parameter.  Default value is `0.0`.
+    weight_tol : float, optional
+        Threshold in physical weight of Green's function poles, below
+        which they are considered zero. Default value is `1e-11`.
+    """
 
     _opts = util.list_union(KGW._opts, evGW._opts)
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-evKG{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"
 
@@ -48,11 +118,13 @@ class evKGW(KGW, evGW):  # noqa: D101
             Convergence flag.
         """
 
+        # Get the previous moments
         if th_prev is None:
             th_prev = np.zeros_like(th)
         if tp_prev is None:
             tp_prev = np.zeros_like(tp)
 
+        # Get the HOMO and LUMO errors
         error_homo = max(
             abs(mo[n - 1] - mo_prev[n - 1])
             for mo, mo_prev, n in zip(mo_energy, mo_energy_prev, self.nocc)
@@ -61,9 +133,11 @@ class evKGW(KGW, evGW):  # noqa: D101
             abs(mo[n] - mo_prev[n]) for mo, mo_prev, n in zip(mo_energy, mo_energy_prev, self.nocc)
         )
 
+        # Get the moment errors
         error_th = max(abs(self._moment_error(t, t_prev)) for t, t_prev in zip(th, th_prev))
         error_tp = max(abs(self._moment_error(t, t_prev)) for t, t_prev in zip(tp, tp_prev))
 
+        # Print the table
         style_homo = logging.rate(error_homo, self.conv_tol, self.conv_tol * 1e2)
         style_lumo = logging.rate(error_lumo, self.conv_tol, self.conv_tol * 1e2)
         style_th = logging.rate(error_th, self.conv_tol_moms, self.conv_tol_moms * 1e2)

--- a/momentGW/pbc/evgw.py
+++ b/momentGW/pbc/evgw.py
@@ -55,12 +55,12 @@ class evKGW(KGW, evGW):
         `False`.
     g0 : bool, optional
         If `True`, do not self-consistently update the eigenvalues in
-        the Green's function.  Default value is `False`.
+        the Green's function. Default value is `False`.
     w0 : bool, optional
         If `True`, do not self-consistently update the eigenvalues in
-        the screened Coulomb interaction.  Default value is `False`.
+        the screened Coulomb interaction. Default value is `False`.
     max_cycle : int, optional
-        Maximum number of iterations.  Default value is `50`.
+        Maximum number of iterations. Default value is `50`.
     conv_tol : float, optional
         Convergence threshold in the change in the HOMO and LUMO.
         Default value is `1e-8`.
@@ -75,9 +75,9 @@ class evKGW(KGW, evGW):
         both metrics to be met, and `any` requires just one. Default
         value is `all`.
     diis_space : int, optional
-        Size of the DIIS extrapolation space.  Default value is `8`.
+        Size of the DIIS extrapolation space. Default value is `8`.
     damping : float, optional
-        Damping parameter.  Default value is `0.0`.
+        Damping parameter. Default value is `0.0`.
     weight_tol : float, optional
         Threshold in physical weight of Green's function poles, below
         which they are considered zero. Default value is `1e-11`.

--- a/momentGW/pbc/fock.py
+++ b/momentGW/pbc/fock.py
@@ -17,6 +17,26 @@ def search_chempot_constrained(w, v, nphys, nelec, occupancy=2):
     Search for a chemical potential, constraining the k-point
     dependent occupancy to ensure no crossover of states. If this
     is not possible, a ValueError will be raised.
+
+    Parameters
+    ----------
+    w : numpy.ndarray
+        Eigenvalues at each k-point.
+    v : numpy.ndarray
+        Eigenvectors at each k-point.
+    nphys : int
+        Number of physical states.
+    nelec : int
+        Number of electrons.
+    occupancy : int, optional
+        Number of electrons per state. Default value is `2`.
+
+    Returns
+    -------
+    chempot : float
+        Chemical potential.
+    error : float
+        Error in the number of electrons.
     """
 
     if nelec == 0:
@@ -66,6 +86,26 @@ def search_chempot_unconstrained(w, v, nphys, nelec, occupancy=2):
     """
     Search for a chemical potential, without constraining the
     k-point dependent occupancy.
+
+    Parameters
+    ----------
+    w : numpy.ndarray
+        Eigenvalues at each k-point.
+    v : numpy.ndarray
+        Eigenvectors at each k-point.
+    nphys : int
+        Number of physical states.
+    nelec : int
+        Number of electrons.
+    occupancy : int, optional
+        Number of electrons per state. Default value is `2`.
+
+    Returns
+    -------
+    chempot : float
+        Chemical potential.
+    error : float
+        Error in the number of electrons.
     """
 
     w = np.concatenate(w)
@@ -106,6 +146,26 @@ def search_chempot(w, v, nphys, nelec, occupancy=2):
     """
     Search for a chemical potential, first trying with k-point
     restraints and if that doesn't succeed then without.
+
+    Parameters
+    ----------
+    w : numpy.ndarray
+        Eigenvalues at each k-point.
+    v : numpy.ndarray
+        Eigenvectors at each k-point.
+    nphys : int
+        Number of physical states.
+    nelec : int
+        Number of electrons.
+    occupancy : int, optional
+        Number of electrons per state. Default value is `2`.
+
+    Returns
+    -------
+    chempot : float
+        Chemical potential.
+    error : float
+        Error in the number of electrons.
     """
 
     try:
@@ -116,12 +176,11 @@ def search_chempot(w, v, nphys, nelec, occupancy=2):
     return chempot, error
 
 
-# TODO inherit
 def _gradient(x, se, fock, nelec, occupancy=2, buf=None):
-    """Gradient of the number of electrons w.r.t shift in auxiliary
+    """
+    Gradient of the number of electrons w.r.t shift in auxiliary
     energies.
     """
-    # TODO buf
 
     ws, vs = zip(*[s.diagonalise_matrix(f, chempot=x) for s, f in zip(se, fock)])
     chempot, error = search_chempot(ws, vs, se[0].nphys, nelec, occupancy=occupancy)
@@ -149,6 +208,30 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
     """
     Optimise the shift in auxiliary energies to satisfy the electron
     number, ensuring that the same shift is applied at all k-points.
+
+    Parameters
+    ----------
+    se : tuple of dyson.Lehmann
+        Self-energy object at each k-point.
+    fock : numpy.ndarray
+        Fock matrix at each k-point.
+    nelec : int
+        Number of electrons.
+    occupancy : int, optional
+        Number of electrons per state. Default value is `2`.
+    x0 : float, optional
+        Initial guess value. Default value is `0.0`.
+    tol : float, optional
+        Threshold in the number of electrons. Default value is `1e-6`.
+    maxiter : int, optional
+        Maximum number of iterations. Default value is `200`.
+
+    Returns
+    -------
+    se : tuple of dyson.Lehmann
+        Self-energy object at each k-point.
+    opt : scipy.optimize.OptimizeResult
+        Result of the optimisation.
     """
 
     tol = tol**2  # we minimize the squared error
@@ -324,6 +407,28 @@ class FockLoop(FockLoop):
             gf[k].chempot = chempot
 
         return tuple(gf), nerr
+
+    @logging.with_timer("Fock loop")
+    @logging.with_status("Running Fock loop")
+    def kernel(self, integrals=None):
+        """Driver for the Fock loop.
+
+        Parameters
+        ----------
+        integrals : KIntegrals, optional
+            Integrals object. If `None`, generate from scratch. Default
+            value is `None`.
+
+        Returns
+        -------
+        converged : bool
+            Whether the loop has converged.
+        gf : tuple of dyson.Lehmann
+            Green's function object at each k-point.
+        se : tuple of dyson.Lehmann
+            Self-energy object at each k-point.
+        """
+        return super().kernel(integrals)
 
     def _density_error(self, rdm1, rdm1_prev):
         """Calculate the density error."""

--- a/momentGW/pbc/fsgw.py
+++ b/momentGW/pbc/fsgw.py
@@ -70,7 +70,7 @@ class fsKGW(KGW, fsGW):
     diis_space : int, optional
         Size of the DIIS extrapolation space. Default value is `8`.
     damping : float, optional
-        Damping parameter.  Default value is `0.0`.
+        Damping parameter. Default value is `0.0`.
     solver : BaseGW, optional
         Solver to use to obtain the self-energy. Compatible with any
         `BaseGW`-like class. Default value is `momentGW.gw.GW`.

--- a/momentGW/pbc/fsgw.py
+++ b/momentGW/pbc/fsgw.py
@@ -18,12 +18,12 @@ class fsKGW(KGW, fsGW):  # noqa: D101
 
     _opts = util.list_union(KGW._opts, fsGW._opts)
 
+    project_basis = staticmethod(qsKGW.project_basis)
+    self_energy_to_moments = staticmethod(qsKGW.self_energy_to_moments)
+    check_convergence = qsKGW.check_convergence
+
     @property
     def name(self):
         """Method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-fsKGW"
-
-    project_basis = staticmethod(qsKGW.project_basis)
-    self_energy_to_moments = staticmethod(qsKGW.self_energy_to_moments)
-    check_convergence = qsKGW.check_convergence

--- a/momentGW/pbc/fsgw.py
+++ b/momentGW/pbc/fsgw.py
@@ -9,8 +9,75 @@ from momentGW.pbc.gw import KGW
 from momentGW.pbc.qsgw import qsKGW
 
 
-class fsKGW(KGW, fsGW):  # noqa: D101
-    __doc__ = fsGW.__doc__.replace("molecules", "periodic systems", 1)
+class fsKGW(KGW, fsGW):
+    """
+    Spin-restricted Fock matrix self-consistent GW via self-energy
+    moment constraints for periodic systems.
+
+    Parameters
+    ----------
+    mf : pyscf.pbc.scf.KSCF
+        PySCF periodic mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    fc : bool, optional
+        If `True`, apply finite size corrections. Default value is
+        `False`.
+    max_cycle : int, optional
+        Maximum number of iterations. Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    conv_logical : callable, optional
+        Function that takes an iterable of booleans as input indicating
+        whether the individual `conv_tol`, `conv_tol_moms` have been
+        satisfied, respectively, and returns a boolean indicating
+        overall convergence. For example, the function `all` requires
+        both metrics to be met, and `any` requires just one. Default
+        value is `all`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space. Default value is `8`.
+    damping : float, optional
+        Damping parameter.  Default value is `0.0`.
+    solver : BaseGW, optional
+        Solver to use to obtain the self-energy. Compatible with any
+        `BaseGW`-like class. Default value is `momentGW.gw.GW`.
+    solver_options : dict, optional
+        Keyword arguments to pass to the solver. Default value is an
+        empty `dict`.
+    """
 
     # --- Default fsKGW options
 
@@ -24,6 +91,6 @@ class fsKGW(KGW, fsGW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-fsKGW"

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -16,63 +16,78 @@ from momentGW.pbc.rpa import dRPA
 from momentGW.pbc.tda import dTDA
 
 
-class KGW(BaseKGW, GW):  # noqa: D101
-    __doc__ = BaseKGW.__doc__.format(
-        description="Spin-restricted one-shot GW via self-energy moment constraints for "
-        + "periodic systems.",
-        extra_parameters="",
-    )
+class KGW(BaseKGW, GW):
+    """
+    Spin-restricted one-shot GW via self-energy moment constraints for
+    periodic systems.
+
+    Parameters
+    ----------
+    mf : pyscf.pbc.scf.KSCF
+        PySCF periodic mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.pbc.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme.  Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression.  Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    fc : bool, optional
+        If `True`, apply finite size corrections. Default value is
+        `False`.
+    """
 
     _opts = util.list_union(BaseKGW._opts, GW._opts)
 
     @property
     def name(self):
-        """Define the name of the method being used."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-KG0W0"
 
-    @logging.with_timer("Integral construction")
-    @logging.with_status("Constructing integrals")
-    def ao2mo(self, transform=True):
-        """Get the integrals object.
+    @logging.with_timer("Static self-energy")
+    @logging.with_status("Building static self-energy")
+    def build_se_static(self, integrals):
+        """
+        Build the static part of the self-energy, including the Fock
+        matrix.
 
         Parameters
         ----------
-        transform : bool, optional
-            Whether to transform the integrals object.
+        integrals : KIntegrals
+            Integrals object.
 
         Returns
         -------
-        integrals : KIntegrals
-            Integrals object.
+        se_static : numpy.ndarray
+            Static part of the self-energy at each k-point. If
+            `self.diagonal_se`, non-diagonal elements are set to zero.
         """
-
-        if self.polarizability.lower().startswith("thc"):
-            cls = thc.KIntegrals
-            kwargs = self.thc_opts
-        else:
-            cls = KIntegrals
-            kwargs = dict(
-                compression=self.compression,
-                compression_tol=self.compression_tol,
-                store_full=self.fock_loop,
-                input_path=self.thc_opts["file_path"],
-            )
-
-        integrals = cls(
-            self.with_df,
-            self.kpts,
-            self.mo_coeff,
-            self.mo_occ,
-            **kwargs,
-        )
-        if transform:
-            if "input_path" in kwargs and kwargs["input_path"] is not None:
-                integrals.get_cderi_from_thc()
-            else:
-                integrals.transform()
-
-        return integrals
+        return super().build_se_static(integrals)
 
     def build_se_moments(self, nmom_max, integrals, **kwargs):
         """Build the moments of the self-energy.
@@ -108,6 +123,58 @@ class KGW(BaseKGW, GW):  # noqa: D101
         else:
             raise NotImplementedError
 
+    @logging.with_timer("Integral construction")
+    @logging.with_status("Constructing integrals")
+    def ao2mo(self, transform=True):
+        """Get the integrals object.
+
+        Parameters
+        ----------
+        transform : bool, optional
+            Whether to transform the integrals object.
+
+        Returns
+        -------
+        integrals : KIntegrals
+            Integrals object.
+
+        See Also
+        --------
+        momentGW.pbc.ints.KIntegrals
+        momentGW.pbc.thc.KIntegrals
+        """
+
+        # Get the integrals class
+        if self.polarizability.lower().startswith("thc"):
+            cls = thc.KIntegrals
+            kwargs = self.thc_opts
+        else:
+            cls = KIntegrals
+            kwargs = dict(
+                compression=self.compression,
+                compression_tol=self.compression_tol,
+                store_full=self.fock_loop,
+                input_path=self.thc_opts["file_path"],
+            )
+
+        # Get the integrals
+        integrals = cls(
+            self.with_df,
+            self.kpts,
+            self.mo_coeff,
+            self.mo_occ,
+            **kwargs,
+        )
+
+        # Transform the integrals
+        if transform:
+            if "input_path" in kwargs and kwargs["input_path"] is not None:
+                integrals.get_cderi_from_thc()
+            else:
+                integrals.transform()
+
+        return integrals
+
     def solve_dyson(self, se_moments_hole, se_moments_part, se_static, integrals=None):
         """Solve the Dyson equation due to a self-energy resulting
         from a list of hole and particle moments, along with a static
@@ -137,12 +204,17 @@ class KGW(BaseKGW, GW):  # noqa: D101
 
         Returns
         -------
-        gf : list of dyson.Lehmann
+        gf : tuple of dyson.Lehmann
             Green's function at each k-point.
-        se : list of dyson.Lehmann
+        se : tuple of dyson.Lehmann
             Self-energy at each k-point.
+
+        See Also
+        --------
+        momentGW.pbc.fock.FockLoop
         """
 
+        # Solve the Dyson equation for the moments
         with logging.with_modifiers(status="Solving Dyson equation", timer="Dyson equation"):
             se = []
             for k in self.kpts.loop(1):
@@ -155,11 +227,15 @@ class KGW(BaseKGW, GW):  # noqa: D101
                 solver = MixedMBLSE(solver_occ, solver_vir)
                 se.append(solver.get_self_energy())
 
+        # Initialise the solver
         solver = FockLoop(self, se=se, **self.fock_opts)
 
+        # Shift the self-energy poles relative to the Green's function
+        # to better conserve the particle number
         if self.optimise_chempot:
             se = solver.auxiliary_shift(se_static)
 
+        # Find the error in the moments
         error_h, error_p = zip(
             *(
                 self.moment_error(th, tp, s)
@@ -173,10 +249,12 @@ class KGW(BaseKGW, GW):  # noqa: D101
             f"particle = [{logging.rate(error[1], 1e-12, 1e-8)}]{error[1]:.3e}[/])"
         )
 
+        # Solve the Dyson equation for the self-energy
         gf, error = solver.solve_dyson(se_static)
         for g, s in zip(gf, se):
             s.chempot = g.chempot
 
+        # Self-consistently renormalise the density matrix
         if self.fock_loop:
             logging.write("")
             solver.gf = gf
@@ -184,6 +262,7 @@ class KGW(BaseKGW, GW):  # noqa: D101
             conv, gf, se = solver.kernel(integrals=integrals)
             _, error = solver.search_chempot(gf)
 
+        # Print the error in the number of electrons
         logging.write("")
         style = logging.rate(
             error,
@@ -194,6 +273,40 @@ class KGW(BaseKGW, GW):  # noqa: D101
         logging.write(f"Chemical potential (Γ):  {gf[0].chempot:.6f}")
 
         return tuple(gf), tuple(se)
+
+    def kernel(
+        self,
+        nmom_max,
+        moments=None,
+        integrals=None,
+    ):
+        """Driver for the method.
+
+        Parameters
+        ----------
+        nmom_max : int
+            Maximum moment number to calculate.
+        moments : tuple of numpy.ndarray, optional
+            Tuple of (hole, particle) moments at each k-point, if passed
+            then they will be used instead of calculating them. Default
+            value is `None`.
+        integrals : KIntegrals, optional
+            Integrals object. If `None`, generate from scratch. Default
+            value is `None`.
+
+        Returns
+        -------
+        converged : bool
+            Whether the solver converged. For single-shot calculations,
+            this is always `True`.
+        gf : tuple of dyson.Lehmann
+            Green's function object at each k-point.
+        se : tuple of dyson.Lehmann
+            Self-energy object at each k-point.
+        qp_energy : NoneType
+            Quasiparticle energies. For most GW methods, this is `None`.
+        """
+        return super().kernel(nmom_max, moments=moments, integrals=integrals)
 
     def make_rdm1(self, gf=None):
         """Get the first-order reduced density matrix.
@@ -211,6 +324,7 @@ class KGW(BaseKGW, GW):  # noqa: D101
             First-order reduced density matrix at each k-point.
         """
 
+        # Get the Green's function
         if gf is None:
             gf = self.gf
         if gf is None:
@@ -218,6 +332,8 @@ class KGW(BaseKGW, GW):  # noqa: D101
 
         return np.array([g.occupied().moment(0) for g in gf]) * 2
 
+    @logging.with_timer("Energy")
+    @logging.with_status("Calculating energy")
     def energy_hf(self, gf=None, integrals=None):
         """Calculate the one-body (Hartree--Fock) energy.
 
@@ -237,11 +353,15 @@ class KGW(BaseKGW, GW):  # noqa: D101
             One-body energy.
         """
 
+        # Get the Green's function
         if gf is None:
             gf = self.gf
+
+        # Get the integrals
         if integrals is None:
             integrals = self.ao2mo()
 
+        # Find the Fock matrix
         with util.SilentSCF(self._scf):
             h1e = util.einsum(
                 "kpq,kpi,kqj->kij", self._scf.get_hcore(), self.mo_coeff.conj(), self.mo_coeff
@@ -249,11 +369,14 @@ class KGW(BaseKGW, GW):  # noqa: D101
         rdm1 = self.make_rdm1()
         fock = integrals.get_fock(rdm1, h1e)
 
+        # Calculate the Hartree--Fock energy at each k-point
         e_1b = sum(energy.hartree_fock(rdm1[k], fock[k], h1e[k]) for k in self.kpts.loop(1))
         e_1b /= self.nkpts
 
         return e_1b.real
 
+    @logging.with_timer("Energy")
+    @logging.with_status("Calculating energy")
     def energy_gm(self, gf=None, se=None, g0=True):
         r"""Calculate the two-body (Galitskii--Migdal) energy.
 
@@ -273,19 +396,15 @@ class KGW(BaseKGW, GW):  # noqa: D101
         -------
         e_2b : float
             Two-body energy.
-
-        Notes
-        -----
-        With `g0=False`, this function scales as
-        :math:`\mathcal{O}(N^4)` with system size, whereas with
-        `g0=True`, it scales as :math:`\mathcal{O}(N^3)`.
         """
 
+        # Get the Green's function and self-energy
         if gf is None:
             gf = self.gf
         if se is None:
             se = self.se
 
+        # Calculate the Galitskii--Migdal energy
         if g0:
             e_2b = sum(
                 energy.galitskii_migdal_g0(self.mo_energy[k], self.mo_occ[k], se[k])

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -50,9 +50,9 @@ class KGW(BaseKGW, GW):
         a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
         compression on the initial ERIs, whereas `"ia"` refers to
         compression on the ERIs entering RPA, which may change under a
-        self-consistent scheme.  Default value is `"ia"`.
+        self-consistent scheme. Default value is `"ia"`.
     compression_tol : float, optional
-        Tolerance for the compression.  Default value is `1e-10`.
+        Tolerance for the compression. Default value is `1e-10`.
     thc_opts : dict, optional
         Dictionary of options to be used for THC calculations. Current
         implementation requires a filepath to import the THC integrals.
@@ -199,8 +199,8 @@ class KGW(BaseKGW, GW):
         se_static : numpy.ndarray
             Static part of the self-energy at each k-point.
         integrals : KIntegrals, optional
-            Density-fitted integrals.  Required if `self.fock_loop`
-            is `True`.  Default value is `None`.
+            Density-fitted integrals. Required if `self.fock_loop`
+            is `True`. Default value is `None`.
 
         Returns
         -------

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -382,12 +382,12 @@ class KGW(BaseKGW, GW):
 
         Parameters
         ----------
-        gf : tuple of dyson.Lehmann, optional
-            Green's function at each k-point. If `None`, use `self.gf`.
-            Default value is `None`.
-        se : tuple of dyson.Lehmann, optional
-            Self-energy at each k-point. If `None`, use `self.se`.
-            Default value is `None`.
+        gf : tuple of tuple of dyson.Lehmann, optional
+            Green's function at each k-point for each spin channel. If
+            `None`, use `self.gf`. Default value is `None`.
+        se : tuple of tuple of dyson.Lehmann, optional
+            Self-energy at each k-point for each spin channel. If
+            `None`, use `self.se`. Default value is `None`.
         g0 : bool, optional
             If `True`, use the mean-field Green's function. Default
             value is `True`.

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -79,10 +79,12 @@ class KIntegrals(Integrals):
 
         # TODO MPI
 
+        # Get the compression sectors
         compression = self._parse_compression()
         if not compression:
             return None
 
+        # Initialise the inner product matrix
         prod = np.zeros((len(self.kpts), self.naux_full, self.naux_full), dtype=complex)
 
         # ao2mo function for both real and complex integrals
@@ -100,6 +102,7 @@ class KIntegrals(Integrals):
         # Loop over required blocks
         for key in sorted(compression):
             with logging.with_status(f"{key} sector"):
+                # Get the coefficients
                 ci, cj = [
                     {
                         "o": [c[:, o > 0] for c, o in zip(self.mo_coeff, self.mo_occ)],
@@ -115,6 +118,7 @@ class KIntegrals(Integrals):
                 for q, ki in self.kpts.loop(2):
                     kj = self.kpts.member(self.kpts.wrap_around(self.kpts[ki] - self.kpts[q]))
 
+                    # Build the (L|xy) array
                     Lxy = np.zeros((self.naux_full, ni[ki] * nj[kj]), dtype=complex)
                     b1 = 0
                     for block in self.with_df.sr_loop((ki, kj), compact=False):
@@ -131,8 +135,10 @@ class KIntegrals(Integrals):
                             orb_slice = (0, ni[ki], ni[ki], ni[ki] + nj[kj])
                             _ao2mo_e2(block, coeffs, orb_slice, out=Lxy[b0:b1])
 
+                    # Update the inner product matrix
                     prod[q] += np.dot(Lxy, Lxy.T.conj()) / len(self.kpts)
 
+        # Diagonalise the inner product matrix
         rot = np.empty((len(self.kpts),), dtype=object)
         if mpi_helper.rank == 0:
             for q in self.kpts.loop(1):
@@ -144,6 +150,7 @@ class KIntegrals(Integrals):
                 rot[q] = np.zeros((0,), dtype=complex)
         del prod
 
+        # Print the compression status
         naux_total = sum(r.shape[-1] for r in rot)
         naux_full_total = self.naux_full * len(self.kpts)
         if naux_total == naux_full_total:
@@ -163,19 +170,19 @@ class KIntegrals(Integrals):
     @logging.with_status("Transforming integrals")
     def transform(self, do_Lpq=None, do_Lpx=True, do_Lia=True):
         """
-        Transform the integrals.
+        Transform the integrals in-place.
 
         Parameters
         ----------
         do_Lpq : bool, optional
-            Whether to compute the full (aux, MO, MO) array. Default
+            Whether to compute the full ``(aux, MO, MO)`` array. Default
             value is `True` if `store_full` is `True`, `False`
             otherwise.
         do_Lpx : bool, optional
-            Whether to compute the compressed (aux, MO, MO) array.
+            Whether to compute the compressed ``(aux, MO, MO)`` array.
             Default value is `True`.
         do_Lia : bool, optional
-            Whether to compute the compressed (aux, occ, vir) array.
+            Whether to compute the compressed ``(aux, occ, vir)`` array.
             Default value is `True`.
         """
 
@@ -188,6 +195,7 @@ class KIntegrals(Integrals):
             if rot[q] is None:
                 rot[q] = np.eye(self.naux_full)
 
+        # Check which arrays to build
         do_Lpq = self.store_full if do_Lpq is None else do_Lpq
         if not any([do_Lpq, do_Lpx, do_Lia]):
             return
@@ -203,6 +211,7 @@ class KIntegrals(Integrals):
                 out = _ao2mo.nr_e2(Lpq, mo_coeff, orb_slice, aosym="s1", mosym="s1")
             return out
 
+        # Prepare the outputs
         Lpq = {}
         Lpx = {}
         Lia = {}
@@ -282,6 +291,7 @@ class KIntegrals(Integrals):
                             tmp = _ao2mo_e2(block_comp, coeffs, orb_slice)
                             Lia_k += tmp.reshape(Lia_k.shape)
 
+                # Store the blocks
                 if do_Lpq:
                     Lpq[ki, kj] = Lpq_k
                 if do_Lpx:
@@ -329,6 +339,7 @@ class KIntegrals(Integrals):
 
                 Lai[ki, kj] = Lai_k
 
+        # Store the arrays
         if do_Lpq:
             self._blocks["Lpq"] = Lpq
         if do_Lpx:
@@ -407,6 +418,36 @@ class KIntegrals(Integrals):
         self._blocks["Lia"] = Lia
         self._blocks["Lai"] = Lai
 
+    def update_coeffs(self, mo_coeff_g=None, mo_coeff_w=None, mo_occ_w=None):
+        """
+        Update the MO coefficients in-place for the Green's function
+        and the screened Coulomb interaction.
+
+        Parameters
+        ----------
+        mo_coeff_g : numpy.ndarray, optional
+            Coefficients corresponding to the Green's function at each
+            k-point. Default value is `None`.
+        mo_coeff_w : numpy.ndarray, optional
+            Coefficients corresponding to the screened Coulomb
+            interaction at each k-point. Default value is `None`.
+        mo_occ_w : numpy.ndarray, optional
+            Occupations corresponding to the screened Coulomb
+            interaction at each k-point. Default value is `None`.
+
+        Notes
+        -----
+        If `mo_coeff_g` is `None`, the Green's function is assumed to
+        remain in the basis in which it was originally defined, and
+        vice-versa for `mo_coeff_w` and `mo_occ_w`. At least one of
+        `mo_coeff_g` and `mo_coeff_w` must be provided.
+        """
+        return super().update_coeffs(
+            mo_coeff_g=mo_coeff_g,
+            mo_coeff_w=mo_coeff_w,
+            mo_occ_w=mo_occ_w,
+        )
+
     @logging.with_timer("J matrix")
     @logging.with_status("Building J matrix")
     def get_j(self, dm, basis="mo", other=None):
@@ -436,14 +477,18 @@ class KIntegrals(Integrals):
         bases must reflect shared indices.
         """
 
+        # Check the input
         assert basis in ("ao", "mo")
 
+        # Get the other integrals
         if other is None:
             other = self
 
+        # Initialise the J matrix
         vj = np.zeros_like(dm, dtype=complex)
 
         if self.store_full and basis == "mo":
+            # Constuct J using the full MO basis integrals
             buf = 0.0
             for kk in self.kpts.loop(1, mpi=True):
                 buf += util.einsum("Lpq,pq->L", other.Lpq[kk, kk], dm[kk].conj())
@@ -456,6 +501,7 @@ class KIntegrals(Integrals):
             vj = mpi_helper.allreduce(vj)
 
         else:
+            # Transform the density into the AO basis
             if basis == "mo":
                 dm = util.einsum("kij,kpi,kqj->kpq", dm, other.mo_coeff, np.conj(other.mo_coeff))
 
@@ -485,6 +531,7 @@ class KIntegrals(Integrals):
 
             vj = mpi_helper.allreduce(vj)
 
+            # Transform the J matrix back to the MO basis
             if basis == "mo":
                 vj = util.einsum("kpq,kpi,kqj->kij", vj, np.conj(self.mo_coeff), self.mo_coeff)
 
@@ -517,12 +564,14 @@ class KIntegrals(Integrals):
         bases must reflect shared indices.
         """
 
+        # Check the input
         assert basis in ("ao", "mo")
 
+        # Initialise the K matrix
         vk = np.zeros_like(dm, dtype=complex)
 
         if self.store_full and basis == "mo":
-            # TODO is there a better way to distribute this?
+            # Constuct K using the full MO basis integrals
             for p0, p1 in lib.prange(0, self.naux_full, 240):
                 buf = np.zeros(
                     (len(self.kpts), len(self.kpts), p1 - p0, self.nmo, self.nmo), dtype=complex
@@ -540,6 +589,7 @@ class KIntegrals(Integrals):
             vk = mpi_helper.allreduce(vk)
 
         else:
+            # Transform the density into the AO basis
             if basis == "mo":
                 dm = util.einsum("kij,kpi,kqj->kpq", dm, self.mo_coeff, np.conj(self.mo_coeff))
 
@@ -569,6 +619,7 @@ class KIntegrals(Integrals):
 
             vk = mpi_helper.allreduce(vk)
 
+            # Transform the K matrix back to the MO basis
             if basis == "mo":
                 vk = util.einsum("kpq,kpi,kqj->kij", vk, np.conj(self.mo_coeff), self.mo_coeff)
 
@@ -598,16 +649,79 @@ class KIntegrals(Integrals):
             Ewald exchange divergence matrix for each k-point.
         """
 
+        # Check the input
         assert basis in ("ao", "mo")
 
+        # Get the overlap matrix
         if basis == "mo":
             ovlp = defaultdict(lambda: np.eye(self.nmo))
         else:
             ovlp = self.with_df.cell.pbc_intor("int1e_ovlp", hermi=1, kpts=self.kpts._kpts)
 
+        # Initialise the Ewald matrix
         ew = util.einsum("kpq,kpi,kqj->kij", dm, ovlp.conj(), ovlp)
 
         return ew
+
+    def get_jk(self, dm, **kwargs):
+        """Build the J and K matrices.
+
+        Returns
+        -------
+        vj : numpy.ndarray
+            J matrix at each k-point.
+        vk : numpy.ndarray
+            K matrix at each k-point.
+
+        Notes
+        -----
+        See `get_j` and `get_k` for more information.
+        """
+        return super().get_jk(dm, **kwargs)
+
+    def get_veff(self, dm, j=None, k=None, **kwargs):
+        """Build the effective potential.
+
+        Returns
+        -------
+        veff : numpy.ndarray
+            Effective potential at each k-point.
+        j : numpy.ndarray, optional
+            J matrix at each k-point. If `None`, compute it. Default
+            value is `None`.
+        k : numpy.ndarray, optional
+            K matrix at each k-point. If `None`, compute it. Default
+            value is `None`.
+
+        Notes
+        -----
+        See `get_jk` for more information.
+        """
+        return super().get_veff(dm, j=j, k=k, **kwargs)
+
+    def get_fock(self, dm, h1e, **kwargs):
+        """Build the Fock matrix.
+
+        Parameters
+        ----------
+        dm : numpy.ndarray
+            Density matrix at each k-point.
+        h1e : numpy.ndarray
+            Core Hamiltonian matrix at each k-point.
+        **kwargs : dict, optional
+            Additional keyword arguments for `get_jk`.
+
+        Returns
+        -------
+        fock : numpy.ndarray
+            Fock matrix at each k-point.
+
+        Notes
+        -----
+        See `get_jk` for more information. The basis of `h1e` must be
+        the same as `dm`.
+        """
+        return super().get_fock(dm, h1e, **kwargs)
 
     @property
     def madelung(self):
@@ -620,9 +734,7 @@ class KIntegrals(Integrals):
 
     @property
     def Lai(self):
-        """
-        Return the compressed (aux, W vir, W occ) array.
-        """
+        """Get the full uncompressed ``(aux, MO, MO)`` integrals."""
         return self._blocks["Lai"]
 
     @property

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -24,9 +24,9 @@ class KIntegrals(Integrals):
     with_df : pyscf.pbc.df.DF
         Density fitting object.
     mo_coeff : numpy.ndarray
-        Molecular orbital coefficients for each k-point.
+        Molecular orbital coefficients at each k-point.
     mo_occ : numpy.ndarray
-        Molecular orbital occupations for each k-point.
+        Molecular orbital occupations at each k-point.
     compression : str, optional
         Compression scheme to use. Default value is `'ia'`. See
         `momentGW.gw` for more details.
@@ -547,7 +547,7 @@ class KIntegrals(Integrals):
         Parameters
         ----------
         dm : numpy.ndarray
-            Density matrix for each k-point.
+            Density matrix at each k-point.
         basis : str, optional
             Basis in which to build the K matrix. One of
             `("ao", "mo")`. Default value is `"mo"`.
@@ -555,7 +555,7 @@ class KIntegrals(Integrals):
         Returns
         -------
         vk : numpy.ndarray
-            K matrix for each k-point.
+            K matrix at each k-point.
 
         Notes
         -----
@@ -638,7 +638,7 @@ class KIntegrals(Integrals):
         Parameters
         ----------
         dm : numpy.ndarray
-            Density matrix for each k-point.
+            Density matrix at each k-point.
         basis : str, optional
             Basis in which to build the K matrix. One of
             `("ao", "mo")`. Default value is `"mo"`.
@@ -646,7 +646,7 @@ class KIntegrals(Integrals):
         Returns
         -------
         ew : numpy.ndarray
-            Ewald exchange divergence matrix for each k-point.
+            Ewald exchange divergence matrix at each k-point.
         """
 
         # Check the input

--- a/momentGW/pbc/kpts.py
+++ b/momentGW/pbc/kpts.py
@@ -49,7 +49,7 @@ class KPoints:
     cell : pyscf.pbc.gto.Cell
         Unit cell.
     kpts : numpy.ndarray
-        Array of k-points.
+        K-points.
     tol : float, optional
         Threshold for determining if two k-points are equal. Default
         value is `1e-8`.
@@ -79,7 +79,7 @@ class KPoints:
         Parameters
         ----------
         kpt : numpy.ndarray
-            Array of the k-point.
+            The k-point.
 
         Returns
         -------
@@ -97,7 +97,7 @@ class KPoints:
         Parameters
         ----------
         kpt : numpy.ndarray
-            Array of the k-point.
+            The k-point.
 
         Returns
         -------
@@ -115,12 +115,12 @@ class KPoints:
         Parameters
         ----------
         kpts : numpy.ndarray
-            Array of absolute k-points.
+            Absolute k-points.
 
         Returns
         -------
         scaled_kpts : numpy.ndarray
-            Array of scaled k-points.
+            Scaled k-points.
         """
         return self.cell.get_scaled_kpts(kpts)
 
@@ -133,12 +133,12 @@ class KPoints:
         Parameters
         ----------
         kpts : numpy.ndarray
-            Array of scaled k-points.
+            Scaled k-points.
 
         Returns
         -------
         abs_kpts : numpy.ndarray
-            Array of absolute k-points.
+            Absolute k-points.
         """
         return self.cell.get_abs_kpts(kpts)
 
@@ -150,7 +150,7 @@ class KPoints:
         Parameters
         ----------
         kpts : numpy.ndarray
-            Array of absolute k-points.
+            Absolute k-points.
         window : tuple, optional
             Window within which to contain scaled k-points. Default value
             is `(-0.5, 0.5)`.
@@ -158,7 +158,7 @@ class KPoints:
         Returns
         -------
         wrapped_kpts : numpy.ndarray
-            Array of wrapped k-points.
+            Wrapped k-points.
         """
 
         kpts = self.get_scaled_kpts(kpts) % 1.0
@@ -180,7 +180,7 @@ class KPoints:
         Parameters
         ----------
         kpts : numpy.ndarray
-            Array of absolute k-points.
+            Absolute k-points.
 
         Returns
         -------
@@ -282,7 +282,7 @@ class KPoints:
         Parameters
         ----------
         kpts : numpy.ndarray
-            Array of absolute k-points.
+            Absolute k-points.
 
         Returns
         -------
@@ -313,7 +313,7 @@ class KPoints:
         Returns
         -------
         r_vec_abs : numpy.ndarray
-            Array of translation vectors.
+            Translation vectors.
         """
 
         kmesh = self.kmesh
@@ -399,7 +399,7 @@ class KPoints:
         Returns
         -------
         kpt : numpy.ndarray
-            Array of the k-point.
+            The k-point.
         """
         return self._kpts[index]
 
@@ -416,7 +416,7 @@ class KPoints:
         Parameters
         ----------
         kpt : numpy.ndarray
-            Array of the k-point.
+            The k-point.
 
         Returns
         -------

--- a/momentGW/pbc/kpts.py
+++ b/momentGW/pbc/kpts.py
@@ -52,6 +52,26 @@ class KPoints:
         value is `True`.
     """
 
+    def member(self, kpt):
+        """
+        Find the index of the k-point in the k-point list.
+
+        Parameters
+        ----------
+        kpt : numpy.ndarray
+            Array of the k-point.
+
+        Returns
+        -------
+        index : int
+            Index of the k-point.
+        """
+        if kpt not in self:
+            raise ValueError(f"{kpt} is not in list")
+        return self._kpts_hash[self.hash_kpts(kpt)]
+
+    index = member
+
     def __init__(self, cell, kpts, tol=1e-8, wrap_around=True):
         self.cell = cell
         self.tol = tol
@@ -334,41 +354,18 @@ class KPoints:
 
         return fl
 
-    def member(self, kpt):
+    def __array__(self):
         """
-        Find the index of the k-point in the k-point list.
-
-        Parameters
-        ----------
-        kpt : numpy.ndarray
-            Array of the k-point.
-
-        Returns
-        -------
-        index : int
-            Index of the k-point.
+        Get the k-points as a numpy array.
         """
-        if kpt not in self:
-            raise ValueError(f"{kpt} is not in list")
-        return self._kpts_hash[self.hash_kpts(kpt)]
+        return np.asarray(self._kpts)
 
-    index = member
-
-    def __contains__(self, kpt):
+    @property
+    def T(self):
         """
-        Check if the k-point is in the k-point list.
-
-        Parameters
-        ----------
-        kpt : numpy.ndarray
-            Array of the k-point.
-
-        Returns
-        -------
-        is_in : bool
-            Whether the k-point is in the list.
+        Get the transpose of the k-points.
         """
-        return self.hash_kpts(kpt) in self._kpts_hash
+        return self.__array__().T
 
     def __getitem__(self, index):
         """
@@ -385,6 +382,28 @@ class KPoints:
             Array of the k-point.
         """
         return self._kpts[index]
+
+    def __iter__(self):
+        """
+        Iterate over the k-points.
+        """
+        return iter(self._kpts)
+
+    def __contains__(self, kpt):
+        """
+        Check if the k-point is in the k-point list.
+
+        Parameters
+        ----------
+        kpt : numpy.ndarray
+            Array of the k-point.
+
+        Returns
+        -------
+        is_in : bool
+            Whether the k-point is in the list.
+        """
+        return self.hash_kpts(kpt) in self._kpts_hash
 
     def __len__(self):
         """
@@ -421,12 +440,6 @@ class KPoints:
         """
         return not self.__eq__(other)
 
-    def __iter__(self):
-        """
-        Iterate over the k-points.
-        """
-        return iter(self._kpts)
-
     def __repr__(self):
         """
         Get a string representation of the k-points.
@@ -438,16 +451,3 @@ class KPoints:
         Get a string representation of the k-points.
         """
         return str(self._kpts)
-
-    def __array__(self):
-        """
-        Get the k-points as a numpy array.
-        """
-        return np.asarray(self._kpts)
-
-    @property
-    def T(self):
-        """
-        Get the transpose of the k-points.
-        """
-        return self.__array__().T

--- a/momentGW/pbc/qsgw.py
+++ b/momentGW/pbc/qsgw.py
@@ -11,8 +11,92 @@ from momentGW.pbc.gw import KGW
 from momentGW.qsgw import qsGW
 
 
-class qsKGW(KGW, qsGW):  # noqa: D101
-    __doc__ = qsGW.__doc__.replace("molecules", "periodic systems", 1)
+class qsKGW(KGW, qsGW):
+    """
+    Spin-restricted quasiparticle self-consistent GW via self-energy
+    moment constraints for periodic systems.
+
+    Parameters
+    ----------
+    mf : pyscf.pbc.scf.KSCF
+        PySCF periodic mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    fc : bool, optional
+        If `True`, apply finite size corrections. Default value is
+        `False`.
+    max_cycle : int, optional
+        Maximum number of iterations. Default value is `50`.
+    max_cycle_qp : int, optional
+        Maximum number of iterations in the quasiparticle equation
+        loop. Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    conv_tol_qp : float, optional
+        Convergence threshold in the change in the density matrix in
+        the quasiparticle equation loop. Default value is `1e-8`.
+    conv_logical : callable, optional
+        Function that takes an iterable of booleans as input indicating
+        whether the individual `conv_tol`, `conv_tol_moms`,
+        `conv_tol_qp` have been satisfied, respectively, and returns a
+        boolean indicating overall convergence. For example, the
+        function `all` requires both metrics to be met, and `any`
+        requires just one. Default value is `all`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space. Default value is `8`.
+    diis_space_qp : int, optional
+        Size of the DIIS extrapolation space in the quasiparticle
+        loop. Default value is `8`.
+    damping : float, optional
+        Damping parameter. Default value is `0.0`.
+    eta : float, optional
+        Small value to regularise the self-energy. Default value is
+        `1e-1`.
+    srg : float, optional
+        If non-zero, use the similarity renormalisation group approach
+        of Marie and Loos in place of the `eta` regularisation. For
+        value recommendations refer to their paper (arXiv:2303.05984).
+        Default value is `0.0`.
+    solver : BaseGW, optional
+        Solver to use to obtain the self-energy. Compatible with any
+        `BaseGW`-like class. Default value is `momentGW.gw.GW`.
+    solver_options : dict, optional
+        Keyword arguments to pass to the solver. Default value is an
+        empty `dict`.
+    """
 
     # --- Default qsKGW options
 
@@ -24,7 +108,7 @@ class qsKGW(KGW, qsGW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-qsKGW"
 

--- a/momentGW/pbc/qsgw.py
+++ b/momentGW/pbc/qsgw.py
@@ -138,8 +138,10 @@ class qsKGW(KGW, qsGW):
             Matrix projected into the desired basis at each k-point.
         """
 
+        # Build the projection matrix
         proj = util.einsum("k...pq,k...pi,k...qj->k...ij", ovlp, np.conj(mo1), mo2)
 
+        # Project the matrix
         if isinstance(matrix, np.ndarray):
             projected_matrix = util.einsum(
                 "k...pq,k...pi,k...qj->k...ij", matrix, np.conj(proj), proj

--- a/momentGW/pbc/qsgw.py
+++ b/momentGW/pbc/qsgw.py
@@ -20,6 +20,8 @@ class qsKGW(KGW, qsGW):  # noqa: D101
 
     _opts = util.list_union(KGW._opts, qsGW._opts)
 
+    check_convergence = evKGW.check_convergence
+
     @property
     def name(self):
         """Method name."""
@@ -107,5 +109,3 @@ class qsKGW(KGW, qsGW):  # noqa: D101
             k-point.
         """
         return np.array([qsGW.build_static_potential(self, mo, s) for mo, s in zip(mo_energy, se)])
-
-    check_convergence = evKGW.check_convergence

--- a/momentGW/pbc/rpa.py
+++ b/momentGW/pbc/rpa.py
@@ -21,7 +21,7 @@ class dRPA(dTDA, MoldRPA):
     nmom_max : int
         Maximum moment number to calculate.
     integrals : KIntegrals
-        Density-fitted integrals for each k-point.
+        Density-fitted integrals at each k-point.
     mo_energy : dict, optional
         Molecular orbital energies. Keys are "g" and "w" for the Green's
         function and screened Coulomb interaction, respectively.
@@ -43,7 +43,7 @@ class dRPA(dTDA, MoldRPA):
         Returns
         -------
         d : numpy.ndarray
-            Orbital energy differences for each k-point.
+            Orbital energy differences at each k-point.
         """
 
         d = np.zeros((self.nkpts, self.nkpts), dtype=object)
@@ -59,12 +59,12 @@ class dRPA(dTDA, MoldRPA):
         return d
 
     def _build_diag_eri(self):
-        """Construct the diagonal of the ERIs for each k-point.
+        """Construct the diagonal of the ERIs at each k-point.
 
         Returns
         -------
         diag_eri : numpy.ndarray
-            Diagonal of the ERIs for each k-point.
+            Diagonal of the ERIs at each k-point.
         """
 
         diag_eri = np.zeros((self.nkpts, self.nkpts), dtype=object)
@@ -246,9 +246,9 @@ class dRPA(dTDA, MoldRPA):
         Parameters
         ----------
         d : numpy.ndarray
-            Orbital energy differences for each k-point.
+            Orbital energy differences at each k-point.
         diag_eri : numpy.ndarray
-            Diagonal of the ERIs for each k-point.
+            Diagonal of the ERIs at each k-point.
         name : str, optional
             Name of the integral. Default value is `"main"`.
 
@@ -287,9 +287,9 @@ class dRPA(dTDA, MoldRPA):
         quad : tuple
             The quadrature points and weights.
         d : numpy.ndarray
-            Orbital energy differences for each k-point.
+            Orbital energy differences at each k-point.
         diag_eri : numpy.ndarray
-            Diagonal of the ERIs for each k-point.
+            Diagonal of the ERIs at each k-point.
 
         Returns
         -------
@@ -319,7 +319,7 @@ class dRPA(dTDA, MoldRPA):
         quad : tuple
             The quadrature points and weights.
         d : numpy.ndarray
-            Orbital energy differences for each k-point.
+            Orbital energy differences at each k-point.
         Lia : dict of numpy.ndarray
             Dict. with keys that are pairs of k-point indices (Nkpt, Nkpt)
             with an array of form (aux, W occ, W vir) at this k-point pair.
@@ -373,9 +373,9 @@ class dRPA(dTDA, MoldRPA):
         Parameters
         ----------
         d : numpy.ndarray
-            Orbital energy differences for each k-point.
+            Orbital energy differences at each k-point.
         diag_eri : numpy.ndarray
-            Diagonal of the ERIs for each k-point.
+            Diagonal of the ERIs at each k-point.
 
         Returns
         -------
@@ -420,17 +420,17 @@ class dRPA(dTDA, MoldRPA):
         quad : tuple
             The quadrature points and weights.
         d : numpy.ndarray
-            Orbital energy differences for each k-point.
+            Orbital energy differences at each k-point.
         d_sq : numpy.ndarray
-            Orbital energy differences squared for each k-point.
+            Orbital energy differences squared at each k-point.
             See "optimise_main_quad" for more details.
         d_eri : numpy.ndarray
             Orbital energy differences times the diagonal of the
-            ERIs for each k-point.
+            ERIs at each k-point.
             See "optimise_main_quad" for more details.
         d_sq_eri : numpy.ndarray
             Orbital energy differences times the diagonal of the ERIs plus
-            the orbital energy differences for each k-point.
+            the orbital energy differences at each k-point.
             See "optimise_main_quad" for more details.
 
         Returns
@@ -476,7 +476,7 @@ class dRPA(dTDA, MoldRPA):
         Variables
         ----------
         d : numpy.ndarray
-            Orbital energy differences for each k-point.
+            Orbital energy differences at each k-point.
         Lia : dict of numpy.ndarray
             Dict. with keys that are pairs of k-point indices (Nkpt, Nkpt)
             with an array of form (aux, W occ, W vir) at this k-point pair.

--- a/momentGW/pbc/scgw.py
+++ b/momentGW/pbc/scgw.py
@@ -9,8 +9,68 @@ from momentGW.pbc.gw import KGW
 from momentGW.scgw import scGW
 
 
-class scKGW(KGW, scGW):  # noqa: D101
-    __doc__ = scGW.__doc__.replace("molecules", "periodic systems", 1)
+class scKGW(KGW, scGW):
+    """
+    Spin-restricted self-consistent GW via self-energy moment
+    constraints for periodic systems.
+
+    Parameters
+    ----------
+    mf : pyscf.pbc.scf.KSCF
+        PySCF periodic mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    fc : bool, optional
+        If `True`, apply finite size corrections. Default value is
+        `False`.
+    g0 : bool, optional
+        If `True`, do not self-consistently update the eigenvalues in
+        the Green's function. Default value is `False`.
+    w0 : bool, optional
+        If `True`, do not self-consistently update the eigenvalues in
+        the screened Coulomb interaction. Default value is `False`.
+    max_cycle : int, optional
+        Maximum number of iterations. Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space. Default value is `8`.
+    damping : float, optional
+        Damping parameter. Default value is `0.0`.
+    """
 
     _opts = util.list_union(KGW._opts, scGW._opts)
 
@@ -19,6 +79,6 @@ class scKGW(KGW, scGW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-KG{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"

--- a/momentGW/pbc/scgw.py
+++ b/momentGW/pbc/scgw.py
@@ -14,11 +14,11 @@ class scKGW(KGW, scGW):  # noqa: D101
 
     _opts = util.list_union(KGW._opts, scGW._opts)
 
+    check_convergence = evKGW.check_convergence
+    remove_unphysical_poles = evKGW.remove_unphysical_poles
+
     @property
     def name(self):
         """Method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-KG{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"
-
-    check_convergence = evKGW.check_convergence
-    remove_unphysical_poles = evKGW.remove_unphysical_poles

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -90,6 +90,8 @@ class dTDA(MoldTDA):
 
     build_dd_moments_exact = build_dd_moments
 
+    build_dd_moments_exact = build_dd_moments
+
     @logging.with_timer("Moment convolution")
     @logging.with_status("Convoluting moments")
     def convolve(self, eta, mo_energy_g=None, mo_occ_g=None):
@@ -225,8 +227,6 @@ class dTDA(MoldTDA):
         moments_occ, moments_vir = self.convolve(eta)
 
         return moments_occ, moments_vir
-
-    build_dd_moments_exact = build_dd_moments
 
     @property
     def nov(self):  # TODO: Does nov need to be redefined like this? vs mTDA

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -21,22 +21,17 @@ class dTDA(MoldTDA):
     nmom_max : int
         Maximum moment number to calculate.
     integrals : KIntegrals
-        Density-fitted integrals for each k-point.
+        Density-fitted integrals at each k-point.
     mo_energy : dict, optional
-        Molecular orbital energies for each k-point. Keys are "g" and
+        Molecular orbital energies at each k-point. Keys are "g" and
         "w" for the Green's function and screened Coulomb interaction,
         respectively. If `None`, use `gw.mo_energy` for both. Default
         value is `None`.
     mo_occ : dict, optional
-        Molecular orbital occupancies for each k-point. Keys are "g"
+        Molecular orbital occupancies at each k-point. Keys are "g"
         and "w" for the Green's function and screened Coulomb
         interaction, respectively. If `None`, use `gw.mo_occ` for both.
         Default value is `None`.
-
-    Notes
-    -----
-    See `momentGW.tda.dTDA.__init__` for initialisation details and
-    `momentGW.tda.dTDA.kernel` for calculation run details.
     """
 
     @logging.with_timer("Density-density moments")
@@ -47,9 +42,10 @@ class dTDA(MoldTDA):
         Returns
         -------
         moments : numpy.ndarray
-            Moments of the density-density response for each k-point.
+            Moments of the density-density response at each k-point.
         """
 
+        # Initialise the moments
         kpts = self.kpts
         moments = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
 
@@ -88,9 +84,25 @@ class dTDA(MoldTDA):
 
         return moments
 
-    build_dd_moments_exact = build_dd_moments
+    def kernel(self, exact=False):
+        """
+        Run the polarizability calculation to compute moments of the
+        self-energy.
 
-    build_dd_moments_exact = build_dd_moments
+        Parameters
+        ----------
+        exact : bool, optional
+            Has no effect and is only present for compatibility with
+            `dRPA`. Default value is `False`.
+
+        Returns
+        -------
+        moments_occ : numpy.ndarray
+            Moments of the occupied self-energy at each k-point.
+        moments_vir : numpy.ndarray
+            Moments of the virtual self-energy at each k-point.
+        """
+        return super().kernel(exact=exact)
 
     @logging.with_timer("Moment convolution")
     @logging.with_status("Convoluting moments")
@@ -103,23 +115,24 @@ class dTDA(MoldTDA):
         ----------
         eta : numpy.ndarray
             Moments of the density-density response partly transformed
-            into moments of the screened Coulomb interaction for each
+            into moments of the screened Coulomb interaction at each
             k-point.
         mo_energy_g : numpy.ndarray, optional
-            Energies of the Green's function for each k-point. If
+            Energies of the Green's function at each k-point. If
             `None`, use `self.mo_energy_g`. Default value is `None`.
         mo_occ_g : numpy.ndarray, optional
-            Occupancies of the Green's function for each k-point. If
+            Occupancies of the Green's function at each k-point. If
             `None`, use `self.mo_occ_g`. Default value is `None`.
 
         Returns
         -------
         moments_occ : numpy.ndarray
-            Moments of the occupied self-energy for each k-point.
+            Moments of the occupied self-energy at each k-point.
         moments_vir : numpy.ndarray
-            Moments of the virtual self-energy for each k-point.
+            Moments of the virtual self-energy at each k-point.
         """
 
+        # Get the orbitals
         if mo_energy_g is None:
             mo_energy_g = self.mo_energy_g
         if mo_occ_g is None:
@@ -141,21 +154,27 @@ class dTDA(MoldTDA):
                 nmo = part.shape[-1]
                 break
 
+        # Initialise the moments
         moments_occ = np.zeros((self.nkpts, self.nmom_max + 1, nmo, nmo), dtype=complex)
         moments_vir = np.zeros((self.nkpts, self.nmom_max + 1, nmo, nmo), dtype=complex)
+
         moms = np.arange(self.nmom_max + 1)
         for n in moms:
+            # Get the binomial coefficients
             fp = scipy.special.binom(n, moms)
             fh = fp * (-1) ** moms
+
             for q in kpts.loop(1):
                 for kp in kpts.loop(1, mpi=True):
                     kx = kpts.member(kpts.wrap_around(kpts[kp] - kpts[q]))
                     subscript = f"t,kt,kt{pqchar}->{pqchar}"
 
+                    # Construct the occupied moments for this order
                     eo = np.power.outer(mo_energy_g[kx][mo_occ_g[kx] > 0], n - moms)
                     to = util.einsum(subscript, fh, eo, eta[kp, q][mo_occ_g[kx] > 0])
                     moments_occ[kp, n] += fproc(to)
 
+                    # Construct the virtual moments for this order
                     ev = np.power.outer(mo_energy_g[kx][mo_occ_g[kx] == 0], n - moms)
                     tv = util.einsum(subscript, fp, ev, eta[kp, q][mo_occ_g[kx] == 0])
                     moments_vir[kp, n] += fproc(tv)
@@ -166,6 +185,7 @@ class dTDA(MoldTDA):
                 moments_occ[k, n] = 0.5 * (moments_occ[k, n] + moments_occ[k, n].T.conj())
                 moments_vir[k, n] = 0.5 * (moments_vir[k, n] + moments_vir[k, n].T.conj())
 
+        # Sum over all processes
         moments_occ = mpi_helper.allreduce(moments_occ)
         moments_vir = mpi_helper.allreduce(moments_vir)
 
@@ -179,14 +199,14 @@ class dTDA(MoldTDA):
         Parameters
         ----------
         moments_dd : numpy.ndarray
-            Moments of the density-density response for each k-point.
+            Moments of the density-density response at each k-point.
 
         Returns
         -------
         moments_occ : numpy.ndarray
-            Moments of the occupied self-energy for each k-point.
+            Moments of the occupied self-energy at each k-point.
         moments_vir : numpy.ndarray
-            Moments of the virtual self-energy for each k-point.
+            Moments of the virtual self-energy at each k-point.
         """
 
         kpts = self.kpts
@@ -229,8 +249,8 @@ class dTDA(MoldTDA):
         return moments_occ, moments_vir
 
     @property
-    def nov(self):  # TODO: Does nov need to be redefined like this? vs mTDA
-        """Number of ov states in W."""
+    def nov(self):
+        """Get the number of ov states in W."""
         return np.multiply.outer(
             [np.sum(occ > 0) for occ in self.mo_occ_w],
             [np.sum(occ == 0) for occ in self.mo_occ_w],
@@ -238,10 +258,10 @@ class dTDA(MoldTDA):
 
     @property
     def kpts(self):
-        """k-points."""
+        """Get the k-points."""
         return self.gw.kpts
 
     @property
     def nkpts(self):
-        """Number of k-points."""
+        """Get the number of k-points."""
         return self.gw.nkpts

--- a/momentGW/pbc/thc.py
+++ b/momentGW/pbc/thc.py
@@ -275,14 +275,14 @@ class dTDA(MolTDA, TDA_gen):
     integrals : KIntegrals
         Density-fitted integrals.
     mo_energy : numpy.ndarray or tuple of numpy.ndarray, optional
-        Molecular orbital energies at each k-point.  If a tuple is passed,
+        Molecular orbital energies at each k-point. If a tuple is passed,
         the first element corresponds to the Green's function basis and
-        the second to the screened Coulomb interaction.  Default value is
+        the second to the screened Coulomb interaction. Default value is
         that of `gw.mo_energy`.
     mo_occ : numpy.ndarray or tuple of numpy.ndarray, optional
-        Molecular orbital occupancies at each k-point.  If a tuple is
+        Molecular orbital occupancies at each k-point. If a tuple is
         passed, the first element corresponds to the Green's function basis
-        and the second to the screened Coulomb interaction.  Default value
+        and the second to the screened Coulomb interaction. Default value
         is that of `gw.mo_occ`.
     """
 

--- a/momentGW/pbc/thc.py
+++ b/momentGW/pbc/thc.py
@@ -252,7 +252,7 @@ class KIntegrals(Integrals, KIntegrals_gen):
 
     @property
     def nkpts(self):
-        """Get the number of k points"""
+        """Get the number of k-points"""
         return len(self.kpts)
 
     @property

--- a/momentGW/pbc/uhf/__init__.py
+++ b/momentGW/pbc/uhf/__init__.py
@@ -1,4 +1,5 @@
-"""Unrestricted periodic methods.
+"""
+Methods for periodic systems with unrestricted references.
 """
 
 from momentGW.pbc.uhf.tda import dTDA

--- a/momentGW/pbc/uhf/base.py
+++ b/momentGW/pbc/uhf/base.py
@@ -15,6 +15,10 @@ from momentGW.uhf.base import BaseUGW
 class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
     __doc__ = BaseKGW.__doc__
 
+    get_nmo = get_nmo
+    get_nocc = get_nocc
+    get_frozen_mask = get_frozen_mask
+
     def _get_header(self):
         """
         Get the header for the solver, with the name, options, and
@@ -150,10 +154,6 @@ class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
                     )
 
         return mo_energy
-
-    get_nmo = get_nmo
-    get_nocc = get_nocc
-    get_frozen_mask = get_frozen_mask
 
     @property
     def nmo(self):

--- a/momentGW/pbc/uhf/base.py
+++ b/momentGW/pbc/uhf/base.py
@@ -12,8 +12,50 @@ from momentGW.pbc.base import BaseKGW
 from momentGW.uhf.base import BaseUGW
 
 
-class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
-    __doc__ = BaseKGW.__doc__
+class BaseKUGW(BaseKGW, BaseUGW):
+    """
+    Base class for moment-constrained GW solvers for periodic systems
+    with unrestricted references.
+
+    Parameters
+    ----------
+    mf : pyscf.pbc.scf.KSCF
+        PySCF periodic mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.pbc.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme.  Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression.  Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    fc : bool, optional
+        If `True`, apply finite size corrections. Default value is
+        `False`.
+    """
 
     get_nmo = get_nmo
     get_nocc = get_nocc
@@ -21,8 +63,13 @@ class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
 
     def _get_header(self):
         """
-        Get the header for the solver, with the name, options, and
+        Extend the header given by `Base._get_header` to include the
         problem size.
+
+        Returns
+        -------
+        panel : rich.Table
+            Panel with the solver name, options, and problem size.
         """
 
         # Get the options table
@@ -49,7 +96,13 @@ class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
         return panel
 
     def _get_excitations_table(self):
-        """Return the excitations as a table."""
+        """Return the excitations as a table.
+
+        Returns
+        -------
+        table : rich.Table
+            Table with the excitations.
+        """
 
         # Separate the occupied and virtual GFs
         gf_occ = (
@@ -107,14 +160,65 @@ class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
 
     @staticmethod
     def _gf_to_occ(gf):
+        """
+        Convert a `dyson.Lehmann` to an `mo_occ` at each k-point for
+        each spin channel.
+
+        Parameters
+        ----------
+        gf : tuple of tuple of dyson.Lehmann
+            Green's function object at each k-point for each spin
+            channel.
+
+        Returns
+        -------
+        occ : tuple of tuple of numpy.ndarray
+            Orbital occupation numbers at each k-point for each spin
+            channel.
+        """
         return tuple(tuple(BaseGW._gf_to_occ(g, occupancy=1) for g in gs) for gs in gf)
 
     @staticmethod
     def _gf_to_energy(gf):
+        """
+        Convert a `dyson.Lehmann` to an `mo_energy` for each spin
+        channel.
+
+        Parameters
+        ----------
+        gf : tuple of tuple of dyson.Lehmann
+            Green's function object at each k-point for each spin
+            channel.
+
+        Returns
+        -------
+        energy : tuple of tuple of numpy.ndarray
+            Orbital energies at each k-point for each spin channel.
+        """
         return tuple(tuple(BaseGW._gf_to_energy(g) for g in gs) for gs in gf)
 
     @staticmethod
     def _gf_to_coupling(gf, mo_coeff=None):
+        """
+        Convert a `dyson.Lehmann` to an `mo_coeff`.
+
+        Parameters
+        ----------
+        gf : tuple of tuple of dyson.Lehmann
+            Green's function object at each k-point for each spin
+            channel.
+        mo_coeff : tuple of tuple of numpy.ndarray, optional
+            Molecular orbital coefficients at each k-point for each
+            spin channel. If passed, rotate the Green's function
+            couplings from the MO basis into the AO basis. Default
+            value is `None`.
+
+        Returns
+        -------
+        couplings : tuple of tuple of numpy.ndarray
+            Couplings of the Green's function at each k-point for each
+            spin channel.
+        """
         if mo_coeff is None:
             mo_coeff = [[None] * len(gf[0])] * 2
         return tuple(
@@ -127,14 +231,14 @@ class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
 
         Parameters
         ----------
-        gf : tuple of dyson.Lehmann
-            Green's function object for each k-point for each spin
+        gf : tuple of tuple of dyson.Lehmann
+            Green's function object at each k-point for each spin
             channel.
 
         Returns
         -------
         mo_energy : ndarray
-            Updated MO energies for each k-point for each spin channel.
+            Updated MO energies at each k-point for each spin channel.
         """
 
         mo_energy = np.zeros_like(self.mo_energy)
@@ -157,7 +261,7 @@ class BaseKUGW(BaseKGW, BaseUGW):  # noqa: D101
 
     @property
     def nmo(self):
-        """Return the number of molecular orbitals."""
+        """Get the number of molecular orbitals."""
         # PySCF returns jagged nmo with `per_kpoint=False` depending on
         # whether there is k-point dependent occupancy:
         nmo = self.get_nmo(per_kpoint=True)

--- a/momentGW/pbc/uhf/base.py
+++ b/momentGW/pbc/uhf/base.py
@@ -237,7 +237,7 @@ class BaseKUGW(BaseKGW, BaseUGW):
 
         Returns
         -------
-        mo_energy : ndarray
+        mo_energy : numpy.ndarray
             Updated MO energies at each k-point for each spin channel.
         """
 

--- a/momentGW/pbc/uhf/base.py
+++ b/momentGW/pbc/uhf/base.py
@@ -46,9 +46,9 @@ class BaseKUGW(BaseKGW, BaseUGW):
         a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
         compression on the initial ERIs, whereas `"ia"` refers to
         compression on the ERIs entering RPA, which may change under a
-        self-consistent scheme.  Default value is `"ia"`.
+        self-consistent scheme. Default value is `"ia"`.
     compression_tol : float, optional
-        Tolerance for the compression.  Default value is `1e-10`.
+        Tolerance for the compression. Default value is `1e-10`.
     thc_opts : dict, optional
         Dictionary of options to be used for THC calculations. Current
         implementation requires a filepath to import the THC integrals.

--- a/momentGW/pbc/uhf/evgw.py
+++ b/momentGW/pbc/uhf/evgw.py
@@ -56,12 +56,12 @@ class evKUGW(KUGW, evKGW, evUGW):
         `False`.
     g0 : bool, optional
         If `True`, do not self-consistently update the eigenvalues in
-        the Green's function.  Default value is `False`.
+        the Green's function. Default value is `False`.
     w0 : bool, optional
         If `True`, do not self-consistently update the eigenvalues in
-        the screened Coulomb interaction.  Default value is `False`.
+        the screened Coulomb interaction. Default value is `False`.
     max_cycle : int, optional
-        Maximum number of iterations.  Default value is `50`.
+        Maximum number of iterations. Default value is `50`.
     conv_tol : float, optional
         Convergence threshold in the change in the HOMO and LUMO.
         Default value is `1e-8`.
@@ -76,9 +76,9 @@ class evKUGW(KUGW, evKGW, evUGW):
         both metrics to be met, and `any` requires just one. Default
         value is `all`.
     diis_space : int, optional
-        Size of the DIIS extrapolation space.  Default value is `8`.
+        Size of the DIIS extrapolation space. Default value is `8`.
     damping : float, optional
-        Damping parameter.  Default value is `0.0`.
+        Damping parameter. Default value is `0.0`.
     weight_tol : float, optional
         Threshold in physical weight of Green's function poles, below
         which they are considered zero. Default value is `1e-11`.

--- a/momentGW/pbc/uhf/fock.py
+++ b/momentGW/pbc/uhf/fock.py
@@ -6,7 +6,7 @@ conditions and unrestricted references.
 import numpy as np
 from dyson import Lehmann
 
-from momentGW import mpi_helper
+from momentGW import logging, mpi_helper
 from momentGW.pbc.fock import FockLoop, minimize_chempot, search_chempot
 
 
@@ -68,11 +68,13 @@ class FockLoop(FockLoop):
         `None`), this method returns `None`.
         """
 
+        # Get the self-energy
         if se is None:
             se = self.se
         if se is None:
             return None
 
+        # Optimise the shift in the auxiliary energies
         se_α, opt_α = minimize_chempot(
             se[0],
             fock[0],
@@ -82,7 +84,6 @@ class FockLoop(FockLoop):
             maxiter=self.max_cycle_inner,
             occupancy=1,
         )
-
         se_β, opt_β = minimize_chempot(
             se[1],
             fock[1],
@@ -92,7 +93,6 @@ class FockLoop(FockLoop):
             maxiter=self.max_cycle_inner,
             occupancy=1,
         )
-
         se = (se_α, se_β)
 
         return se
@@ -114,9 +114,11 @@ class FockLoop(FockLoop):
             Error in the number of electrons for each spin channel.
         """
 
+        # Get the Green's function
         if gf is None:
             gf = self.gf
 
+        # Search for the chemical potential
         chempot_α, nerr_α = search_chempot(
             [g.energies for g in gf[0]],
             [g.couplings for g in gf[0]],
@@ -165,6 +167,7 @@ class FockLoop(FockLoop):
         if se is None:
             se = self.se
 
+        # Diagonalise the (extended) Fock matrix
         if se is None:
             e, c = np.linalg.eigh(fock)
         else:
@@ -173,6 +176,8 @@ class FockLoop(FockLoop):
             e = (e_α, e_β)
             c = (c_α, c_β)
 
+        # Broadcast the eigenvalues and eigenvectors in case of
+        # hybrid parallelisation introducing non-determinism
         e = [
             [mpi_helper.bcast(ek, root=0) for ek in e[0]],
             [mpi_helper.bcast(ek, root=0) for ek in e[1]],
@@ -182,17 +187,42 @@ class FockLoop(FockLoop):
             [mpi_helper.bcast(ck, root=0) for ck in c[1]],
         ]
 
+        # Construct the Green's function
         gf = [
             [Lehmann(ek, ck[: self.nmo[0]], chempot=0.0) for ek, ck in zip(e[0], c[0])],
             [Lehmann(ek, ck[: self.nmo[1]], chempot=0.0) for ek, ck in zip(e[1], c[1])],
         ]
 
+        # Search for the chemical potential
         chempot, nerr = self.search_chempot(gf)
         for k in self.kpts.loop(1):
             gf[0][k].chempot = chempot[0]
             gf[1][k].chempot = chempot[1]
 
         return tuple(tuple(gf_s) for gf_s in gf), nerr
+
+    @logging.with_timer("Fock loop")
+    @logging.with_status("Running Fock loop")
+    def kernel(self, integrals=None):
+        """Driver for the Fock loop.
+
+        Parameters
+        ----------
+        integrals : KUIntegrals, optional
+            Integrals object. If `None`, generate from scratch. Default
+            value is `None`.
+
+        Returns
+        -------
+        converged : bool
+            Whether the loop has converged.
+        gf : tuple of tuple of dyson.Lehmann
+            Green's function object at each k-point for each spin
+            channel.
+        se : tuple of tuple of dyson.Lehmann
+            Self-energy object at each k-point for each spin channel.
+        """
+        return super().kernel(integrals)
 
     def _density_error(self, rdm1, rdm1_prev):
         """Calculate the density error."""

--- a/momentGW/pbc/uhf/fsgw.py
+++ b/momentGW/pbc/uhf/fsgw.py
@@ -71,7 +71,7 @@ class fsKUGW(KUGW, fsKGW, fsUGW):
     diis_space : int, optional
         Size of the DIIS extrapolation space. Default value is `8`.
     damping : float, optional
-        Damping parameter.  Default value is `0.0`.
+        Damping parameter. Default value is `0.0`.
     solver : BaseGW, optional
         Solver to use to obtain the self-energy. Compatible with any
         `BaseGW`-like class. Default value is `momentGW.gw.GW`.

--- a/momentGW/pbc/uhf/fsgw.py
+++ b/momentGW/pbc/uhf/fsgw.py
@@ -10,8 +10,75 @@ from momentGW.pbc.uhf.qsgw import qsKUGW
 from momentGW.uhf.fsgw import fsUGW
 
 
-class fsKUGW(KUGW, fsKGW, fsUGW):  # noqa: D101
-    __doc__ = fsKGW.__doc__.replace("Spin-restricted", "Spin-unrestricted", 1)
+class fsKUGW(KUGW, fsKGW, fsUGW):
+    """
+    Spin-unrestricted Fock matrix self-consistent GW via self-energy
+    moment constraints for periodic systems.
+
+    Parameters
+    ----------
+    mf : pyscf.pbc.scf.KSCF
+        PySCF periodic mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    fc : bool, optional
+        If `True`, apply finite size corrections. Default value is
+        `False`.
+    max_cycle : int, optional
+        Maximum number of iterations. Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    conv_logical : callable, optional
+        Function that takes an iterable of booleans as input indicating
+        whether the individual `conv_tol`, `conv_tol_moms` have been
+        satisfied, respectively, and returns a boolean indicating
+        overall convergence. For example, the function `all` requires
+        both metrics to be met, and `any` requires just one. Default
+        value is `all`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space. Default value is `8`.
+    damping : float, optional
+        Damping parameter.  Default value is `0.0`.
+    solver : BaseGW, optional
+        Solver to use to obtain the self-energy. Compatible with any
+        `BaseGW`-like class. Default value is `momentGW.gw.GW`.
+    solver_options : dict, optional
+        Keyword arguments to pass to the solver. Default value is an
+        empty `dict`.
+    """
 
     # --- Default fsKUGW options
 
@@ -25,6 +92,6 @@ class fsKUGW(KUGW, fsKGW, fsUGW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-fsKUGW"

--- a/momentGW/pbc/uhf/fsgw.py
+++ b/momentGW/pbc/uhf/fsgw.py
@@ -19,12 +19,12 @@ class fsKUGW(KUGW, fsKGW, fsUGW):  # noqa: D101
 
     _opts = util.list_union(KUGW._opts, fsKGW._opts, fsUGW._opts)
 
+    project_basis = staticmethod(qsKUGW.project_basis)
+    self_energy_to_moments = staticmethod(qsKUGW.self_energy_to_moments)
+    check_convergence = qsKUGW.check_convergence
+
     @property
     def name(self):
         """Method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-fsKUGW"
-
-    project_basis = staticmethod(qsKUGW.project_basis)
-    self_energy_to_moments = staticmethod(qsKUGW.self_energy_to_moments)
-    check_convergence = qsKUGW.check_convergence

--- a/momentGW/pbc/uhf/gw.py
+++ b/momentGW/pbc/uhf/gw.py
@@ -50,9 +50,9 @@ class KUGW(BaseKUGW, KGW, UGW):
         a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
         compression on the initial ERIs, whereas `"ia"` refers to
         compression on the ERIs entering RPA, which may change under a
-        self-consistent scheme.  Default value is `"ia"`.
+        self-consistent scheme. Default value is `"ia"`.
     compression_tol : float, optional
-        Tolerance for the compression.  Default value is `1e-10`.
+        Tolerance for the compression. Default value is `1e-10`.
     thc_opts : dict, optional
         Dictionary of options to be used for THC calculations. Current
         implementation requires a filepath to import the THC integrals.
@@ -180,8 +180,8 @@ class KUGW(BaseKUGW, KGW, UGW):
             Static part of the self-energy at each k-point for each
             spin channel.
         integrals : KUIntegrals, optional
-            Density-fitted integrals.  Required if `self.fock_loop`
-            is `True`.  Default value is `None`.
+            Density-fitted integrals. Required if `self.fock_loop`
+            is `True`. Default value is `None`.
 
         Returns
         -------

--- a/momentGW/pbc/uhf/ints.py
+++ b/momentGW/pbc/uhf/ints.py
@@ -50,10 +50,10 @@ class KUIntegrals(UIntegrals, KIntegrals):
     with_df : pyscf.pbc.df.DF
         Density fitting object.
     mo_coeff : numpy.ndarray
-        Molecular orbital coefficients for each k-point for each spin
+        Molecular orbital coefficients at each k-point for each spin
         channel.
     mo_occ : numpy.ndarray
-        Molecular orbital occupations for each k-point for each spin
+        Molecular orbital occupations at each k-point for each spin
         channel.
     compression : str, optional
         Compression scheme to use. Default value is `'ia'`. See

--- a/momentGW/pbc/uhf/ints.py
+++ b/momentGW/pbc/uhf/ints.py
@@ -340,4 +340,4 @@ class KUIntegrals(UIntegrals, KIntegrals):
         See `get_jk` for more information. The basis of `h1e` must be
         the same as `dm`.
         """
-        return super().get_fock(dm, **kwargs)
+        return super().get_fock(dm, h1e, **kwargs)

--- a/momentGW/pbc/uhf/ints.py
+++ b/momentGW/pbc/uhf/ints.py
@@ -13,27 +13,27 @@ from momentGW.uhf.ints import UIntegrals
 class KIntegrals_α(KIntegrals):
     """Overload the `__name__` to signify α part"""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__class__.__name__ = "KIntegrals (α)"
-
     def get_compression_metric(self):  # noqa: D102
         return None
 
     get_compression_metric.__doc__ = KIntegrals.get_compression_metric.__doc__
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__class__.__name__ = "KIntegrals (α)"
 
 
 class KIntegrals_β(KIntegrals):
     """Overload the `__name__` to signify β part"""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__class__.__name__ = "KIntegrals (β)"
-
     def get_compression_metric(self):  # noqa: D102
         return None
 
     get_compression_metric.__doc__ = KIntegrals.get_compression_metric.__doc__
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__class__.__name__ = "KIntegrals (β)"
 
 
 class KUIntegrals(UIntegrals, KIntegrals):

--- a/momentGW/pbc/uhf/ints.py
+++ b/momentGW/pbc/uhf/ints.py
@@ -10,26 +10,30 @@ from momentGW.pbc.ints import KIntegrals
 from momentGW.uhf.ints import UIntegrals
 
 
-class KIntegrals_α(KIntegrals):
-    """Overload the `__name__` to signify α part"""
-
-    def get_compression_metric(self):  # noqa: D102
-        return None
-
-    get_compression_metric.__doc__ = KIntegrals.get_compression_metric.__doc__
+class _KIntegrals_α(KIntegrals):
+    """Extends `KIntegrals` to represent the α channel."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__class__.__name__ = "KIntegrals (α)"
 
+    def get_compression_metric(self):
+        """Return the compression metric.
 
-class KIntegrals_β(KIntegrals):
-    """Overload the `__name__` to signify β part"""
+        Overrides `KIntegrals.get_compression_metric` to return `None`,
+        as the compression metric should be calculated for spinless
+        auxiliaries.
 
-    def get_compression_metric(self):  # noqa: D102
+        Returns
+        -------
+        rot : numpy.ndarray
+            Rotation matrix into the compressed auxiliary space.
+        """
         return None
 
-    get_compression_metric.__doc__ = KIntegrals.get_compression_metric.__doc__
+
+class _KIntegrals_β(_KIntegrals_α):
+    """Extends `KIntegrals` to represent the β channel."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -38,7 +42,8 @@ class KIntegrals_β(KIntegrals):
 
 class KUIntegrals(UIntegrals, KIntegrals):
     """
-    Container for the integrals required for KUGW methods.
+    Container for the density-fitted integrals required for KUGW
+    methods.
 
     Parameters
     ----------
@@ -84,7 +89,7 @@ class KUIntegrals(UIntegrals, KIntegrals):
         # Attributes
         self.kpts = kpts
         self._spins = {
-            0: KIntegrals_α(
+            0: _KIntegrals_α(
                 self.with_df,
                 self.kpts,
                 self.mo_coeff[0],
@@ -93,7 +98,7 @@ class KUIntegrals(UIntegrals, KIntegrals):
                 compression_tol=self.compression_tol,
                 store_full=self.store_full,
             ),
-            1: KIntegrals_β(
+            1: _KIntegrals_β(
                 self.with_df,
                 self.kpts,
                 self.mo_coeff[1],
@@ -116,18 +121,19 @@ class KUIntegrals(UIntegrals, KIntegrals):
             Rotation matrix into the compressed auxiliary space.
         """
 
-        # TODO MPI
-
+        # Get the compression sectors
         compression = self._parse_compression()
         if not compression:
             return None
 
+        # Initialise the inner product matrix
         prod = np.zeros((len(self.kpts), self.naux_full, self.naux_full), dtype=complex)
 
         # Loop over required blocks
         for key in sorted(compression):
             for s, spin in enumerate(["α", "β"]):
                 with logging.with_status(f"{key} ({spin}) sector"):
+                    # Get the coefficients
                     ci, cj = [
                         {
                             "o": [c[:, o > 0] for c, o in zip(self.mo_coeff[s], self.mo_occ[s])],
@@ -147,6 +153,7 @@ class KUIntegrals(UIntegrals, KIntegrals):
                     for q, ki in self.kpts.loop(2):
                         kj = self.kpts.member(self.kpts.wrap_around(self.kpts[ki] - self.kpts[q]))
 
+                        # Build the (L|xy) array
                         Lxy = np.zeros((self.naux_full, ni[ki] * nj[kj]), dtype=complex)
                         b1 = 0
                         for block in self.with_df.sr_loop((ki, kj), compact=False):
@@ -166,10 +173,12 @@ class KUIntegrals(UIntegrals, KIntegrals):
                                 tmp = tmp.reshape(b1 - b0, -1)
                                 Lxy[b0:b1] = tmp
 
+                        # Update the inner product matrix
                         prod[q] += np.dot(Lxy, Lxy.T.conj()) / len(self.kpts)
 
         prod *= 0.5
 
+        # Diagonalise the inner product matrix
         rot = np.empty((len(self.kpts),), dtype=object)
         if mpi_helper.rank == 0:
             for q in self.kpts.loop(1):
@@ -181,6 +190,7 @@ class KUIntegrals(UIntegrals, KIntegrals):
                 rot[q] = np.zeros((0,), dtype=complex)
         del prod
 
+        # Print the compression status
         naux_total = sum(r.shape[-1] for r in rot)
         naux_full_total = self.naux_full * len(self.kpts)
         if naux_total == naux_full_total:
@@ -195,3 +205,139 @@ class KUIntegrals(UIntegrals, KIntegrals):
             )
 
         return rot
+
+    def update_coeffs(self, mo_coeff_g=None, mo_coeff_w=None, mo_occ_w=None):
+        """
+        Update the MO coefficients for the Green's function and the
+        screened Coulomb interaction.
+
+        Parameters
+        ----------
+        mo_coeff_g : numpy.ndarray, optional
+            Coefficients corresponding to the Green's function at each
+            k-point for each spin channel. Default value is `None`.
+        mo_coeff_w : numpy.ndarray, optional
+            Coefficients corresponding to the screened Coulomb
+            interaction at each k-point for each spin channel. Default
+            value is `None`.
+        mo_occ_w : numpy.ndarray, optional
+            Occupations corresponding to the screened Coulomb
+            interaction at each k-point for each spin channel. Default
+            value is `None`.
+
+        Notes
+        -----
+        If `mo_coeff_g` is `None`, the Green's function is assumed to
+        remain in the basis in which it was originally defined, and
+        vice-versa for `mo_coeff_w` and `mo_occ_w`. At least one of
+        `mo_coeff_g` and `mo_coeff_w` must be provided.
+        """
+        return super().update_coeffs(
+            mo_coeff_g=mo_coeff_g,
+            mo_coeff_w=mo_coeff_w,
+            mo_occ_w=mo_occ_w,
+        )
+
+    def get_j(self, dm, basis="mo"):
+        """Build the J matrix.
+
+        Parameters
+        ----------
+        dm : numpy.ndarray
+            Density matrix at each k-point for each spin channel.
+        basis : str, optional
+            Basis in which to build the J matrix. One of
+            `("ao", "mo")`. Default value is `"mo"`.
+
+        Returns
+        -------
+        vj : numpy.ndarray
+            J matrix at each k-point for each spin channel.
+        """
+        return super().get_j(dm, basis=basis)
+
+    def get_k(self, dm, basis="mo"):
+        """Build the K matrix.
+
+        Parameters
+        ----------
+        dm : numpy.ndarray
+            Density matrix at each k-point for each spin channel.
+        basis : str, optional
+            Basis in which to build the K matrix. One of
+            `("ao", "mo")`. Default value is `"mo"`.
+
+        Returns
+        -------
+        vk : numpy.ndarray
+            K matrix for each spin channel.
+        """
+        return super().get_k(dm, basis=basis)
+
+    def get_jk(self, dm, **kwargs):
+        """Build the J and K matrices.
+
+        Returns
+        -------
+        vj : numpy.ndarray
+            J matrix at each k-point for each spin channel.
+        vk : numpy.ndarray
+            K matrix at each k-point for each spin channel.
+
+        Notes
+        -----
+        See `get_j` and `get_k` for more information.
+        """
+        return super().get_jk(dm, **kwargs)
+
+    def get_veff(self, dm, j=None, k=None, **kwargs):
+        """Build the effective potential.
+
+        Parameters
+        ----------
+        dm : numpy.ndarray
+            Density matrix at each k-point for each spin channel.
+        j : numpy.ndarray, optional
+            J matrix at each k-point for each spin channel. If `None`,
+            compute it. Default value is `None`.
+        k : numpy.ndarray, optional
+            K matrix at each k-point for each spin channel. If `None`,
+            compute it. Default value is `None`.
+        **kwargs : dict, optional
+            Additional keyword arguments for `get_jk`.
+
+        Returns
+        -------
+        veff : numpy.ndarray
+            Effective potential at each k-point for each spin channel.
+
+        Notes
+        -----
+        See `get_jk` for more information.
+        """
+        return super().get_veff(dm, j=j, k=k, **kwargs)
+
+    def get_fock(self, dm, h1e, **kwargs):
+        """Build the Fock matrix.
+
+        Parameters
+        ----------
+        dm : numpy.ndarray
+            Density matrix at each k-point for each spin channel.
+        h1e : numpy.ndarray
+            Core Hamiltonian matrix at each k-point for each spin
+            channel.
+        **kwargs : dict, optional
+            Additional keyword arguments for `get_jk`.
+
+        Returns
+        -------
+        fock : numpy.ndarray
+            Fock matrix at each k-point for each spin channel.
+
+        Notes
+        -----
+        See `get_jk` for more information. The basis of `h1e` must be
+        the same as `dm`.
+        """
+        return super().get_fock(dm, **kwargs)

--- a/momentGW/pbc/uhf/qsgw.py
+++ b/momentGW/pbc/uhf/qsgw.py
@@ -21,6 +21,8 @@ class qsKUGW(KUGW, qsKGW, qsUGW):  # noqa: D101
 
     _opts = util.list_union(KUGW._opts, qsKGW._opts, qsUGW._opts)
 
+    check_convergence = evKUGW.check_convergence
+
     @property
     def name(self):
         """Method name."""
@@ -119,5 +121,3 @@ class qsKUGW(KUGW, qsKGW, qsUGW):  # noqa: D101
                 for mos, ses in zip(mo_energy, se)
             ]
         )
-
-    check_convergence = evKUGW.check_convergence

--- a/momentGW/pbc/uhf/qsgw.py
+++ b/momentGW/pbc/uhf/qsgw.py
@@ -12,8 +12,92 @@ from momentGW.pbc.uhf.gw import KUGW
 from momentGW.uhf.qsgw import qsUGW
 
 
-class qsKUGW(KUGW, qsKGW, qsUGW):  # noqa: D101
-    __doc__ = qsKGW.__doc__.replace("Spin-restricted", "Spin-unrestricted", 1)
+class qsKUGW(KUGW, qsKGW, qsUGW):
+    """
+    Spin-unrestricted quasiparticle self-consistent GW via self-energy
+    moment constraints for periodic systems.
+
+    Parameters
+    ----------
+    mf : pyscf.pbc.scf.KSCF
+        PySCF periodic mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    fc : bool, optional
+        If `True`, apply finite size corrections. Default value is
+        `False`.
+    max_cycle : int, optional
+        Maximum number of iterations. Default value is `50`.
+    max_cycle_qp : int, optional
+        Maximum number of iterations in the quasiparticle equation
+        loop. Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    conv_tol_qp : float, optional
+        Convergence threshold in the change in the density matrix in
+        the quasiparticle equation loop. Default value is `1e-8`.
+    conv_logical : callable, optional
+        Function that takes an iterable of booleans as input indicating
+        whether the individual `conv_tol`, `conv_tol_moms`,
+        `conv_tol_qp` have been satisfied, respectively, and returns a
+        boolean indicating overall convergence. For example, the
+        function `all` requires both metrics to be met, and `any`
+        requires just one. Default value is `all`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space. Default value is `8`.
+    diis_space_qp : int, optional
+        Size of the DIIS extrapolation space in the quasiparticle
+        loop. Default value is `8`.
+    damping : float, optional
+        Damping parameter. Default value is `0.0`.
+    eta : float, optional
+        Small value to regularise the self-energy. Default value is
+        `1e-1`.
+    srg : float, optional
+        If non-zero, use the similarity renormalisation group approach
+        of Marie and Loos in place of the `eta` regularisation. For
+        value recommendations refer to their paper (arXiv:2303.05984).
+        Default value is `0.0`.
+    solver : BaseGW, optional
+        Solver to use to obtain the self-energy. Compatible with any
+        `BaseGW`-like class. Default value is `momentGW.gw.GW`.
+    solver_options : dict, optional
+        Keyword arguments to pass to the solver. Default value is an
+        empty `dict`.
+    """
 
     # --- Default qsKUGW options
 
@@ -25,7 +109,7 @@ class qsKUGW(KUGW, qsKGW, qsUGW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-qsKUGW"
 
@@ -57,8 +141,10 @@ class qsKUGW(KUGW, qsKGW, qsUGW):  # noqa: D101
             for each spin channel.
         """
 
+        # Build the projection matrix
         proj = util.einsum("k...pq,sk...pi,sk...qj->sk...ij", ovlp, np.conj(mo1), mo2)
 
+        # Project the matrix
         if isinstance(matrix, np.ndarray):
             projected_matrix = util.einsum(
                 "sk...pq,sk...pi,sk...qj->sk...ij", matrix, np.conj(proj), proj

--- a/momentGW/pbc/uhf/scgw.py
+++ b/momentGW/pbc/uhf/scgw.py
@@ -10,8 +10,68 @@ from momentGW.pbc.uhf.gw import KUGW
 from momentGW.uhf.scgw import scUGW
 
 
-class scKUGW(KUGW, scKGW, scUGW):  # noqa: D101
-    __doc__ = scKGW.__doc__.replace("Spin-restricted", "Spin-unrestricted")
+class scKUGW(KUGW, scKGW, scUGW):
+    """
+    Spin-unrestricted self-consistent GW via self-energy moment
+    constraints for periodic systems.
+
+    Parameters
+    ----------
+    mf : pyscf.pbc.scf.KSCF
+        PySCF periodic mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    fc : bool, optional
+        If `True`, apply finite size corrections. Default value is
+        `False`.
+    g0 : bool, optional
+        If `True`, do not self-consistently update the eigenvalues in
+        the Green's function. Default value is `False`.
+    w0 : bool, optional
+        If `True`, do not self-consistently update the eigenvalues in
+        the screened Coulomb interaction. Default value is `False`.
+    max_cycle : int, optional
+        Maximum number of iterations. Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space. Default value is `8`.
+    damping : float, optional
+        Damping parameter. Default value is `0.0`.
+    """
 
     _opts = util.list_union(scKGW._opts, scKGW._opts, scUGW._opts)
 
@@ -20,6 +80,6 @@ class scKUGW(KUGW, scKGW, scUGW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-scKUG{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"

--- a/momentGW/pbc/uhf/scgw.py
+++ b/momentGW/pbc/uhf/scgw.py
@@ -15,11 +15,11 @@ class scKUGW(KUGW, scKGW, scUGW):  # noqa: D101
 
     _opts = util.list_union(scKGW._opts, scKGW._opts, scUGW._opts)
 
+    check_convergence = evKUGW.check_convergence
+    remove_unphysical_poles = evKUGW.remove_unphysical_poles
+
     @property
     def name(self):
         """Method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-scKUG{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"
-
-    check_convergence = evKUGW.check_convergence
-    remove_unphysical_poles = evKUGW.remove_unphysical_poles

--- a/momentGW/pbc/uhf/tda.py
+++ b/momentGW/pbc/uhf/tda.py
@@ -143,7 +143,7 @@ class dTDA(KdTDA, MolUdTDA):
 
     @logging.with_timer("Moment convolution")
     @logging.with_status("Convoluting moments")
-    def convolve(self, eta, eta_orders=None, mo_energy_g=None, mo_occ_g=None):
+    def convolve(self, eta, mo_energy_g=None, mo_occ_g=None):
         """
         Handle the convolution of the moments of the Green's function
         and screened Coulomb interaction.
@@ -158,10 +158,6 @@ class dTDA(KdTDA, MolUdTDA):
             Energies of the Green's function at each k-point for each
             spin channel. If `None`, use `self.mo_energy_g`. Default
             value is `None`.
-        eta_orders : list, optional
-            List of orders for the rotated density-density moments in
-            `eta`. If `None`, assume it spans all required orders.
-            Default value is `None`.
         mo_occ_g : numpy.ndarray, optional
             Occupancies of the Green's function at each k-point for each
             spin channel. If `None`, use `self.mo_occ_g`. Default value
@@ -178,7 +174,6 @@ class dTDA(KdTDA, MolUdTDA):
         """
         return super().convolve(
             eta,
-            eta_orders=eta_orders,
             mo_energy_g=mo_energy_g,
             mo_occ_g=mo_occ_g,
         )

--- a/momentGW/pbc/uhf/tda.py
+++ b/momentGW/pbc/uhf/tda.py
@@ -44,7 +44,7 @@ class dTDA(KdTDA, MolUdTDA):
         Returns
         -------
         moments : numpy.ndarray
-            Moments of the density-density response for each k-point
+            Moments of the density-density response at each k-point
             for each spin channel.
         """
 
@@ -191,7 +191,7 @@ class dTDA(KdTDA, MolUdTDA):
         Parameters
         ----------
         moments_dd : numpy.ndarray
-            Moments of the density-density response for each k-point.
+            Moments of the density-density response at each k-point.
 
         Returns
         -------

--- a/momentGW/pbc/uhf/tda.py
+++ b/momentGW/pbc/uhf/tda.py
@@ -48,6 +48,7 @@ class dTDA(KdTDA, MolUdTDA):
             for each spin channel.
         """
 
+        # Initialise the moments
         kpts = self.kpts
         moments = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
 
@@ -118,7 +119,69 @@ class dTDA(KdTDA, MolUdTDA):
 
         return moments
 
-    build_dd_moments_exact = build_dd_moments
+    def kernel(self, exact=False):
+        """
+        Run the polarizability calculation to compute moments of the
+        self-energy.
+
+        Parameters
+        ----------
+        exact : bool, optional
+            Has no effect and is only present for compatibility with
+            `dRPA`. Default value is `False`.
+
+        Returns
+        -------
+        moments_occ : numpy.ndarray
+            Moments of the occupied self-energy at each k-point for each
+            spin channel.
+        moments_vir : numpy.ndarray
+            Moments of the virtual self-energy at each k-point for each
+            spin channel.
+        """
+        return super().kernel(exact=exact)
+
+    @logging.with_timer("Moment convolution")
+    @logging.with_status("Convoluting moments")
+    def convolve(self, eta, eta_orders=None, mo_energy_g=None, mo_occ_g=None):
+        """
+        Handle the convolution of the moments of the Green's function
+        and screened Coulomb interaction.
+
+        Parameters
+        ----------
+        eta : numpy.ndarray
+            Moments of the density-density response partly transformed
+            into moments of the screened Coulomb interaction, at each
+            k-point for each spin channel.
+        mo_energy_g : numpy.ndarray, optional
+            Energies of the Green's function at each k-point for each
+            spin channel. If `None`, use `self.mo_energy_g`. Default
+            value is `None`.
+        eta_orders : list, optional
+            List of orders for the rotated density-density moments in
+            `eta`. If `None`, assume it spans all required orders.
+            Default value is `None`.
+        mo_occ_g : numpy.ndarray, optional
+            Occupancies of the Green's function at each k-point for each
+            spin channel. If `None`, use `self.mo_occ_g`. Default value
+            is `None`.
+
+        Returns
+        -------
+        moments_occ : numpy.ndarray
+            Moments of the occupied self-energy at each k-point for each
+            spin channel.
+        moments_vir : numpy.ndarray
+            Moments of the virtual self-energy at each k-point for each
+            spin channel.
+        """
+        return super().convolve(
+            eta,
+            eta_orders=eta_orders,
+            mo_energy_g=mo_energy_g,
+            mo_occ_g=mo_occ_g,
+        )
 
     @logging.with_timer("Self-energy moments")
     @logging.with_status("Constructing self-energy moments")
@@ -133,9 +196,11 @@ class dTDA(KdTDA, MolUdTDA):
         Returns
         -------
         moments_occ : numpy.ndarray
-            Moments of the occupied self-energy for each k-point.
+            Moments of the occupied self-energy at each k-point for each
+            spin channel.
         moments_vir : numpy.ndarray
-            Moments of the virtual self-energy for each k-point.
+            Moments of the virtual self-energy at each k-point for each
+            spin channel.
         """
 
         kpts = self.kpts

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -7,7 +7,6 @@ import numpy as np
 from pyscf import lib
 
 from momentGW import logging, mpi_helper, util
-from momentGW.base import BaseGW
 from momentGW.evgw import evGW
 from momentGW.gw import GW
 

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -334,6 +334,8 @@ class qsGW(GW):
         ----------
         se : dyson.Lehmann
             Self-energy to compute the moments of.
+        nmom_max : int
+            Maximum moment number to calculate.
 
         Returns
         -------

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -31,7 +31,7 @@ def kernel(
         Tuple of (hole, particle) moments, if passed then they will
         be used  as the initial guess instead of calculating them.
         Default value is `None`.
-    integrals : Integrals, optional
+    integrals : BaseIntegrals, optional
         Integrals object. If `None`, generate from scratch. Default
         value is `None`.
 
@@ -40,9 +40,9 @@ def kernel(
     conv : bool
         Convergence flag.
     gf : dyson.Lehmann
-        Green's function object
+        Green's function object.
     se : dyson.Lehmann
-        Self-energy object
+        Self-energy object.
     qp_energy : numpy.ndarray
         Quasiparticle energies.
     """
@@ -50,9 +50,11 @@ def kernel(
     if gw.polarizability.lower() == "drpa-exact":
         raise NotImplementedError("%s for polarizability=%s" % (gw.name, gw.polarizability))
 
+    # Get the integrals
     if integrals is None:
         integrals = gw.ao2mo()
 
+    # Initialise the orbital
     mo_energy = gw.mo_energy.copy()
     mo_coeff = gw.mo_coeff.copy()
 
@@ -69,23 +71,26 @@ def kernel(
         h1e = gw._scf.get_hcore()
         h1e = util.einsum("...pq,...pi,...qj->...ij", h1e, np.conj(mo_coeff), mo_coeff)
 
+    # Initialise the DIIS object
     diis = util.DIIS()
     diis.space = gw.diis_space
 
-    # Get the self-energy
+    # Get the solver
     solver_options = {} if not gw.solver_options else gw.solver_options.copy()
     for key in gw.solver._opts:
         solver_options[key] = solver_options.get(key, getattr(gw, key, getattr(gw.solver, key)))
     with logging.with_silent():
         subgw = gw.solver(gw._scf, **solver_options)
-    subconv, gf, se, _ = subgw._kernel(nmom_max, integrals=integrals)
-    logging.write("")
-    se_qp = None
 
     # Get the moments
+    subconv, gf, se, _ = subgw._kernel(nmom_max, integrals=integrals)
+    logging.write("")
     th, tp = gw.self_energy_to_moments(se, nmom_max)
 
+    # Initialise convergence quantities
     conv = False
+    se_qp = None
+
     for cycle in range(1, gw.max_cycle + 1):
         with logging.with_comment(f"Start of iteration {cycle}"):
             logging.write("")
@@ -110,15 +115,18 @@ def kernel(
 
             for qp_cycle in range(1, gw.max_cycle_qp + 1):
                 with logging.with_status(f"Iteration [{cycle}, {qp_cycle}]"):
+                    # Update the Fock matrix
                     fock = integrals.get_fock(dm, h1e)
                     fock_eff = fock + se_qp
                     fock_eff = diis_qp.update(fock_eff)
                     fock_eff = mpi_helper.bcast(fock_eff, root=0)
 
+                    # Update the MOs
                     mo_energy, u = np.linalg.eigh(fock_eff)
                     u = mpi_helper.bcast(u, root=0)
                     mo_coeff = util.einsum("...pq,...qi->...pi", gw.mo_coeff, u)
 
+                    # Update the density matrix
                     dm_prev = dm
                     dm = gw._scf.make_rdm1(u, gw.mo_occ)
                     error = np.max(np.abs(dm - dm_prev))
@@ -156,11 +164,47 @@ def kernel(
     return conv, gf, se, mo_energy
 
 
-class qsGW(GW):  # noqa: D101
-    __doc__ = BaseGW.__doc__.format(
-        description="Spin-restricted quasiparticle self-consistent GW via self-energy moment "
-        + "constraints for molecules.",
-        extra_parameters="""max_cycle : int, optional
+class qsGW(GW):
+    """
+    Spin-restricted quasiparticle self-consistent GW via self-energy
+    moment constraints for molecules.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.SCF
+        PySCF mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    max_cycle : int, optional
         Maximum number of iterations. Default value is `50`.
     max_cycle_qp : int, optional
         Maximum number of iterations in the quasiparticle equation
@@ -202,8 +246,7 @@ class qsGW(GW):  # noqa: D101
     solver_options : dict, optional
         Keyword arguments to pass to the solver. Default value is an
         empty `dict`.
-    """,
-    )
+    """
 
     # --- Extra qsGW options
 
@@ -239,7 +282,7 @@ class qsGW(GW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-qsGW"
 
@@ -247,8 +290,7 @@ class qsGW(GW):  # noqa: D101
 
     @staticmethod
     def project_basis(matrix, ovlp, mo1, mo2):
-        """
-        Project a matrix from one basis to another.
+        """Project a matrix from one basis to another.
 
         Parameters
         ----------
@@ -270,8 +312,10 @@ class qsGW(GW):  # noqa: D101
             Matrix projected into the desired basis.
         """
 
+        # Build the projection matrix
         proj = util.einsum("...pq,...pi,...qj->...ij", ovlp, mo1, mo2)
 
+        # Project the matrix
         if isinstance(matrix, np.ndarray):
             projected_matrix = util.einsum("...pq,...pi,...qj->...ij", matrix, proj, proj)
         else:
@@ -283,8 +327,7 @@ class qsGW(GW):  # noqa: D101
 
     @staticmethod
     def self_energy_to_moments(se, nmom_max):
-        """
-        Return the hole and particle moments for a self-energy.
+        """Return the hole and particle moments for a self-energy.
 
         Parameters
         ----------
@@ -303,8 +346,7 @@ class qsGW(GW):  # noqa: D101
         return th, tp
 
     def build_static_potential(self, mo_energy, se):
-        """
-        Build the static potential approximation to the self-energy.
+        """Build the static potential approximation to the self-energy.
 
         Parameters
         ----------
@@ -319,6 +361,7 @@ class qsGW(GW):  # noqa: D101
             Static potential approximation to the self-energy.
         """
 
+        # Get the static potential
         if self.srg == 0.0:
             eta = np.sign(se.energies) * self.eta * 1.0j
             denom = lib.direct_sum("p-q-q->pq", mo_energy, se.energies, eta)
@@ -337,8 +380,10 @@ class qsGW(GW):  # noqa: D101
                 se_i += util.einsum("pk,qk,pqk->pq", v, np.conj(v), reg)
                 se_j += se_i.T.conj()
 
+        # Find the Hermitian part
         se_ij = 0.5 * (se_i + se_j)
 
+        # Ensure the static potential is Hermitian
         if not np.iscomplexobj(se.couplings):
             se_ij = se_ij.real
         else:
@@ -351,7 +396,7 @@ class qsGW(GW):  # noqa: D101
     @property
     def has_fock_loop(self):
         """
-        Returns a boolean indicating whether the solver requires a Fock
+        Get a boolean indicating whether the solver requires a Fock
         loop. In qsGW, this is always `True`.
         """
         return True

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -279,13 +279,15 @@ class qsGW(GW):
         "solver_options",
     ]
 
+    _kernel = kernel
+
+    check_convergence = evGW.check_convergence
+
     @property
     def name(self):
         """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-qsGW"
-
-    _kernel = kernel
 
     @staticmethod
     def project_basis(matrix, ovlp, mo1, mo2):
@@ -389,8 +391,6 @@ class qsGW(GW):
             se_ij[np.diag_indices_from(se_ij)] = se_ij[np.diag_indices_from(se_ij)].real
 
         return se_ij
-
-    check_convergence = evGW.check_convergence
 
     @property
     def has_fock_loop(self):

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -18,7 +18,7 @@ class dRPA(dTDA):
         GW object.
     nmom_max : int
         Maximum moment number to calculate.
-    integrals : Integrals
+    integrals : BaseIntegrals
         Integrals object.
     mo_energy : dict, optional
         Molecular orbital energies. Keys are "g" and "w" for the Green's
@@ -179,7 +179,22 @@ class dRPA(dTDA):
 
     @staticmethod
     def rescale_quad(bare_quad, a):
-        """Rescale quadrature for grid space `a`."""
+        """Rescale quadrature for grid space `a`.
+
+        Parameters
+        ----------
+        bare_quad : tuple
+            The quadrature points and weights.
+        a : float
+            Grid spacing.
+
+        Returns
+        -------
+        points : numpy.ndarray
+            The quadrature points.
+        weights : numpy.ndarray
+            The quadrature weights.
+        """
         return bare_quad[0] * a, bare_quad[1] * a
 
     def optimise_main_quad(self, d, diag_eri, name="main"):
@@ -204,13 +219,18 @@ class dRPA(dTDA):
             The quadrature weights.
         """
 
+        # Generate the bare quadrature
         bare_quad = self.gen_clencur_quad_inf(even=True)
 
+        # Calculate the exact value of the integral for the diagonal
         exact = np.sum((d * (d + diag_eri)) ** 0.5)
         exact -= 0.5 * np.dot(1.0 / d, d * diag_eri)
         exact -= np.sum(d)
 
+        # Define the integrand
         integrand = lambda quad: self.eval_diag_main_integral(quad, d, diag_eri)
+
+        # Get the optimal quadrature
         quad = self.get_optimal_quad(bare_quad, integrand, exact, name=name)
 
         return quad
@@ -237,11 +257,16 @@ class dRPA(dTDA):
             The quadrature weights.
         """
 
+        # Generate the bare quadrature
         bare_quad = self.gen_gausslag_quad_semiinf()
 
+        # Calculate the exact value of the integral for the diagonal
         exact = 0.5 * np.dot(1.0 / d, d * diag_eri)
 
+        # Define the integrand
         integrand = lambda quad: self.eval_diag_offset_integral(quad, d, diag_eri)
+
+        # Get the optimal quadrature
         quad = self.get_optimal_quad(bare_quad, integrand, exact, name=name)
 
         return quad
@@ -269,13 +294,18 @@ class dRPA(dTDA):
         """
 
         def diag_err(spacing):
+            """Calculate the error in the diagonal integral."""
             return np.abs(integrand(self.rescale_quad(bare_quad, 10**spacing)) - exact)
 
+        # Optimise the grid spacing
         res = scipy.optimize.minimize_scalar(diag_err, bounds=(-6, 2), method="bounded")
         if not res.success:
             raise RuntimeError("Could not optimise `a` value.")
 
+        # Get the scale
         solve = 10**res.x
+
+        # Report the result
         full_name = f"{f'{name} ' if name else ''}quadrature".capitalize()
         style = logging.rate(res.fun, 1e-14, 1e-10)
         logging.write(f"{full_name} scale:  {solve:.2e} (error = [{style}]{res.fun:.2e}[/])")
@@ -302,8 +332,8 @@ class dRPA(dTDA):
 
         # TODO check this: is this still right, does it need a factor 4.0?
 
+        # Calculate the integral for each point
         integral = 0.0
-
         for point, weight in zip(*quad):
             expval = np.exp(-2 * point * d)
             res = np.dot(expval, d * diag_eri)
@@ -329,14 +359,15 @@ class dRPA(dTDA):
             Main integral.
         """
 
-        integral = 0.0
-
         def diag_contrib(x, freq):
+            """Calculate the diagonal contribution to the integral."""
             integral = np.ones_like(x)
             integral -= freq**2 / (x + freq**2)
             integral /= np.pi
             return integral
 
+        # Calculate the integral for each point
+        integral = 0.0
         for point, weight in zip(*quad):
             f = 1.0 / (d**2 + point**2)
 
@@ -358,7 +389,7 @@ class dRPA(dTDA):
             The quadrature points and weights.
         d : numpy.ndarray
             Array of orbital energy differences.
-        Lia : numpy.ndarray
+        Lia : numpy.ndarray, optional
             The (aux, W occ, W vir) integral array. If `None`, use
             `self.integrals.Lia`. Keyword argument allows for the use of
             this function with `uhf` and `pbc` modules.
@@ -369,12 +400,13 @@ class dRPA(dTDA):
             Offset integral.
         """
 
+        # Get the integral intermediates
         if Lia is None:
             Lia = self.integrals.Lia
-
         Liad = Lia * d[None]
-        integral = np.zeros_like(Liad)
 
+        # Calculate the integral for each point
+        integral = np.zeros_like(Liad)
         for point, weight in zip(*quad):
             expval = np.exp(-point * d)
             lhs = np.dot(Liad * expval[None], Lia.T)  # aux^2 o v
@@ -408,14 +440,17 @@ class dRPA(dTDA):
             Offset integral.
         """
 
+        # Get the integral intermediates
         if Lia is None:
             Lia = self.integrals.Lia
-
         naux, nov = Lia.shape  # This `nov` is actually self.mpi_size(nov)
-        dim = 3 if self.report_quadrature_error else 1
         Liad = Lia * d[None]
+
+        # Initialise the integral
+        dim = 3 if self.report_quadrature_error else 1
         integral = np.zeros((dim, naux, nov))
 
+        # Calculate the integral for each point
         for i, (point, weight) in enumerate(zip(*quad)):
             f = 1.0 / (d**2 + point**2)
             q = np.dot(Lia * f[None], Liad.T) * 4.0  # aux^2 o v
@@ -436,7 +471,7 @@ class dRPA(dTDA):
     def gen_clencur_quad_inf(self, even=False):
         """
         Generate quadrature points and weights for Clenshaw-Curtis
-        quadrature over an (-inf, +inf).
+        quadrature over an ``(-inf, +inf)``.
 
         Parameters
         ----------
@@ -465,7 +500,7 @@ class dRPA(dTDA):
     def gen_gausslag_quad_semiinf(self):
         """
         Generate quadrature points and weights for Gauss-Laguerre
-        quadrature over an (0, +inf).
+        quadrature over an ``(0, +inf)``.
 
         Returns
         -------
@@ -474,10 +509,8 @@ class dRPA(dTDA):
         weights : numpy.ndarray
             Quadrature weights.
         """
-
         points, weights = np.polynomial.laguerre.laggauss(self.gw.npoints)
         weights *= np.exp(points)
-
         return points, weights
 
     def estimate_error_clencur(self, i4, i2, imag_tol=1e-10):

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -225,11 +225,16 @@ class dRPA(dTDA):
             The quadrature weights.
         """
 
+        # Generate the bare quadrature
         bare_quad = self.gen_gausslag_quad_semiinf()
 
+        # Calculate the exact value of the integral for the diagonal
         exact = np.dot(1.0 / d, d * diag_eri)
 
+        # Define the integrand
         integrand = lambda quad: self.eval_diag_offset_integral(quad, d, diag_eri)
+
+        # Get the optimal quadrature
         quad = self.get_optimal_quad(bare_quad, integrand, exact, name=name)
 
         return quad
@@ -266,42 +271,6 @@ class dRPA(dTDA):
 
         # Define the integrand
         integrand = lambda quad: self.eval_diag_main_integral(quad, d, diag_eri)
-
-        # Get the optimal quadrature
-        quad = self.get_optimal_quad(bare_quad, integrand, exact, name=name)
-
-        return quad
-
-    def optimise_offset_quad(self, d, diag_eri, name="offset"):
-        """
-        Optimise the grid spacing of Clenshaw-Curtis quadrature for the
-        main integral.
-
-        Parameters
-        ----------
-        d : numpy.ndarray
-            Array of orbital energy differences.
-        diag_eri : numpy.ndarray
-            Diagonal of the ERIs.
-        name : str, optional
-            Name of the integral. Default value is `"offset"`.
-
-        Returns
-        -------
-        points : numpy.ndarray
-            The quadrature points.
-        weights : numpy.ndarray
-            The quadrature weights.
-        """
-
-        # Generate the bare quadrature
-        bare_quad = self.gen_gausslag_quad_semiinf()
-
-        # Calculate the exact value of the integral for the diagonal
-        exact = 0.5 * np.dot(1.0 / d, d * diag_eri)
-
-        # Define the integrand
-        integrand = lambda quad: self.eval_diag_offset_integral(quad, d, diag_eri)
 
         # Get the optimal quadrature
         quad = self.get_optimal_quad(bare_quad, integrand, exact, name=name)
@@ -454,44 +423,6 @@ class dRPA(dTDA):
 
         integral *= 4.0
         integral += Liad
-
-        return integral
-
-    def eval_diag_main_integral(self, quad, d, diag_eri):
-        """Evaluate the diagonal of the main integral.
-
-        Parameters
-        ----------
-        quad : tuple
-            The quadrature points and weights.
-        d : numpy.ndarray
-            Orbital energy differences.
-        diag_eri : numpy.ndarray
-            Diagonal of the ERIs.
-
-        Returns
-        -------
-        integral : numpy.ndarray
-            Main integral.
-        """
-
-        integral = 0.0
-
-        def diag_contrib(x, freq):
-            integral = np.ones_like(x)
-            integral -= freq**2 / (x + freq**2)
-            integral /= np.pi
-            return integral
-
-        for point, weight in zip(*quad):
-            f = 1.0 / (d**2 + point**2)
-
-            contrib = diag_contrib(d * (d + diag_eri), point)
-            contrib -= diag_contrib(d**2, point)
-            contrib = np.sum(contrib)
-            contrib -= point**2 * np.dot(f**2, d * diag_eri) / np.pi
-
-            integral += weight * contrib
 
         return integral
 

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -211,7 +211,7 @@ class dRPA(dTDA):
         Parameters
         ----------
         d : numpy.ndarray
-            Array of orbital energy differences.
+            Orbital energy differences.
         diag_eri : numpy.ndarray
             Diagonal of the ERIs.
         name : str, optional
@@ -247,7 +247,7 @@ class dRPA(dTDA):
         Parameters
         ----------
         d : numpy.ndarray
-            Array of orbital energy differences.
+            Orbital energy differences.
         diag_eri : numpy.ndarray
             Diagonal of the ERIs.
         name : str, optional
@@ -355,7 +355,7 @@ class dRPA(dTDA):
         quad : tuple
             The quadrature points and weights.
         d : numpy.ndarray
-            Array of orbital energy differences.
+            Orbital energy differences.
         diag_eri : numpy.ndarray
             Diagonal of the ERIs.
 
@@ -394,7 +394,7 @@ class dRPA(dTDA):
         quad : tuple
             The quadrature points and weights.
         d : numpy.ndarray
-            Array of orbital energy differences.
+            Orbital energy differences.
         Lia : numpy.ndarray, optional
             The ``(aux, W occ, W vir)`` integral array. If `None`, use
             `self.integrals.Lia`. Keyword argument allows for the use of

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -6,7 +6,6 @@ for molecular systems.
 import numpy as np
 
 from momentGW import logging, util
-from momentGW.base import BaseGW
 from momentGW.evgw import evGW
 
 
@@ -187,8 +186,7 @@ class scGW(evGW):
         Size of the DIIS extrapolation space. Default value is `8`.
     damping : float, optional
         Damping parameter. Default value is `0.0`.
-    """,
-    )
+    """
 
     @property
     def name(self):

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -188,10 +188,10 @@ class scGW(evGW):
         Damping parameter. Default value is `0.0`.
     """
 
+    _kernel = kernel
+
     @property
     def name(self):
         """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-G{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"
-
-    _kernel = kernel

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -29,7 +29,7 @@ def kernel(
         Tuple of (hole, particle) moments, if passed then they will
         be used  as the initial guess instead of calculating them.
         Default value is `None`.
-    integrals : Integrals, optional
+    integrals : BaseIntegrals, optional
         Integrals object. If `None`, generate from scratch. Default
         value is `None`.
 
@@ -38,9 +38,9 @@ def kernel(
     conv : bool
         Convergence flag.
     gf : dyson.Lehmann
-        Green's function object
+        Green's function object.
     se : dyson.Lehmann
-        Self-energy object
+        Self-energy object.
     qp_energy : numpy.ndarray
         Quasiparticle energies. Always `None` for scGW, returned for
         compatibility with other scGW methods.
@@ -49,20 +49,25 @@ def kernel(
     if gw.polarizability.lower() == "drpa-exact":
         raise NotImplementedError("%s for polarizability=%s" % (gw.name, gw.polarizability))
 
+    # Get the integrals
     if integrals is None:
         integrals = gw.ao2mo()
 
+    # Initialise the orbitals and the Green's function
     mo_energy = gw.mo_energy.copy()
     gf_ref = gf = gw.init_gf(gw.mo_energy)
 
+    # Initialise the DIIS object
     diis = util.DIIS()
     diis.space = gw.diis_space
 
     # Get the static part of the SE
     se_static = gw.build_se_static(integrals)
 
+    # Initialise convergence quantities
     conv = False
     th_prev = tp_prev = None
+
     for cycle in range(1, gw.max_cycle + 1):
         with logging.with_status(f"Iteration {cycle}"):
             with logging.with_comment(f"Start of iteration {cycle}"):
@@ -124,11 +129,47 @@ def kernel(
     return conv, gf, se, None
 
 
-class scGW(evGW):  # noqa: D101
-    __doc__ = BaseGW.__doc__.format(
-        description="Spin-restricted self-consistent GW via self-energy moment constraints for "
-        + "molecules.",
-        extra_parameters="""g0 : bool, optional
+class scGW(evGW):
+    """
+    Spin-restricted self-consistent GW via self-energy moment
+    constraints for molecules.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.SCF
+        PySCF mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    g0 : bool, optional
         If `True`, do not self-consistently update the eigenvalues in
         the Green's function. Default value is `False`.
     w0 : bool, optional
@@ -151,7 +192,7 @@ class scGW(evGW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-G{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"
 

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -125,7 +125,7 @@ class dTDA:
         """
 
         # Build the density-density response moments
-        moments_dd = self.build_dd_moments_exact()
+        moments_dd = self.build_dd_moments()
 
         # Build the self-energy moments
         moments_occ, moments_vir = self.build_se_moments(moments_dd)

--- a/momentGW/uhf/__init__.py
+++ b/momentGW/uhf/__init__.py
@@ -1,4 +1,5 @@
-"""Unrestricted methods.
+"""
+Methods for unrestricted references.
 """
 
 from momentGW.uhf.tda import dTDA

--- a/momentGW/uhf/base.py
+++ b/momentGW/uhf/base.py
@@ -13,8 +13,13 @@ from momentGW.base import Base, BaseGW
 class BaseUGW(BaseGW):  # noqa: D101
     def _get_header(self):
         """
-        Get the header for the solver, with the name, options, and
+        Extend the header given by `Base._get_header` to include the
         problem size.
+
+        Returns
+        -------
+        panel : rich.Table
+            Panel with the solver name, options, and problem size.
         """
 
         # Get the options table
@@ -40,7 +45,13 @@ class BaseUGW(BaseGW):  # noqa: D101
         return panel
 
     def _get_excitations_table(self):
-        """Return the excitations as a table."""
+        """Return the excitations as a table.
+
+        Returns
+        -------
+        table : rich.Table
+            Table with the excitations.
+        """
 
         # Separate the occupied and virtual GFs
         gf_occ = (
@@ -96,14 +107,59 @@ class BaseUGW(BaseGW):  # noqa: D101
 
     @staticmethod
     def _gf_to_occ(gf):
+        """
+        Convert a `dyson.Lehmann` to an `mo_occ` for each spin channel.
+
+        Parameters
+        ----------
+        gf : tuple of dyson.Lehmann
+            Green's function object for each spin channel.
+
+        Returns
+        -------
+        occ : tuple of numpy.ndarray
+            Orbital occupation numbers for each spin channel.
+        """
         return tuple(BaseGW._gf_to_occ(g, occupancy=1) for g in gf)
 
     @staticmethod
     def _gf_to_energy(gf):
+        """
+        Convert a `dyson.Lehmann` to an `mo_energy` for each spin
+        channel.
+
+        Parameters
+        ----------
+        gf : tuple of dyson.Lehmann
+            Green's function object for each spin channel.
+
+        Returns
+        -------
+        energy : tuple of numpy.ndarray
+            Orbital energies for each spin channel.
+        """
         return tuple(BaseGW._gf_to_energy(g) for g in gf)
 
     @staticmethod
     def _gf_to_coupling(gf, mo_coeff=None):
+        """
+        Convert a `dyson.Lehmann` to an `mo_coeff` for each spin
+        channel.
+
+        Parameters
+        ----------
+        gf : tuple of dyson.Lehmann
+            Green's function object for each spin channel.
+        mo_coeff : tuple of numpy.ndarray, optional
+            Molecular orbital coefficients for each spin channel. If
+            passed, rotate the Green's function couplings from the MO
+            basis into the AO basis. Default value is `None`.
+
+        Returns
+        -------
+        couplings : tuple of numpy.ndarray
+            Couplings of the Green's function for each spin channel.
+        """
         if mo_coeff is None:
             mo_coeff = [None] * 2
         return tuple(BaseGW._gf_to_coupling(g, mo) for g, mo in zip(gf, mo_coeff))
@@ -118,7 +174,7 @@ class BaseUGW(BaseGW):  # noqa: D101
 
         Returns
         -------
-        mo_energy : ndarray
+        mo_energy : numpy.ndarray
             Updated MO energies for each spin channel.
         """
 

--- a/momentGW/uhf/base.py
+++ b/momentGW/uhf/base.py
@@ -11,6 +11,10 @@ from momentGW.base import Base, BaseGW
 
 
 class BaseUGW(BaseGW):  # noqa: D101
+    get_nmo = get_nmo
+    get_nocc = get_nocc
+    get_frozen_mask = get_frozen_mask
+
     def _get_header(self):
         """
         Extend the header given by `Base._get_header` to include the
@@ -192,7 +196,3 @@ class BaseUGW(BaseGW):  # noqa: D101
                 logging.warn(f"[bad]Inconsistent quasiparticle weights for {spin}![/]")
 
         return mo_energy
-
-    get_nmo = get_nmo
-    get_nocc = get_nocc
-    get_frozen_mask = get_frozen_mask

--- a/momentGW/uhf/base.py
+++ b/momentGW/uhf/base.py
@@ -10,7 +10,48 @@ from momentGW import logging
 from momentGW.base import Base, BaseGW
 
 
-class BaseUGW(BaseGW):  # noqa: D101
+class BaseUGW(BaseGW):
+    """
+    Base class for moment-constrained GW solvers with unrestricted
+    references.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.SCF
+        PySCF mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    """
+
     get_nmo = get_nmo
     get_nocc = get_nocc
     get_frozen_mask = get_frozen_mask

--- a/momentGW/uhf/base.py
+++ b/momentGW/uhf/base.py
@@ -153,7 +153,7 @@ class BaseUGW(BaseGW):
     @staticmethod
     def _gf_to_occ(gf):
         """
-        Convert a `dyson.Lehmann` to an `mo_occ` for each spin channel.
+        Convert a `dyson.Lehmann` to an `mo_occ`.
 
         Parameters
         ----------
@@ -170,8 +170,7 @@ class BaseUGW(BaseGW):
     @staticmethod
     def _gf_to_energy(gf):
         """
-        Convert a `dyson.Lehmann` to an `mo_energy` for each spin
-        channel.
+        Convert a `dyson.Lehmann` to an `mo_energy`.
 
         Parameters
         ----------
@@ -188,8 +187,7 @@ class BaseUGW(BaseGW):
     @staticmethod
     def _gf_to_coupling(gf, mo_coeff=None):
         """
-        Convert a `dyson.Lehmann` to an `mo_coeff` for each spin
-        channel.
+        Convert a `dyson.Lehmann` to an `mo_coeff`.
 
         Parameters
         ----------

--- a/momentGW/uhf/evgw.py
+++ b/momentGW/uhf/evgw.py
@@ -52,12 +52,12 @@ class evUGW(UGW, evGW):
         implementation requires a filepath to import the THC integrals.
     g0 : bool, optional
         If `True`, do not self-consistently update the eigenvalues in
-        the Green's function.  Default value is `False`.
+        the Green's function. Default value is `False`.
     w0 : bool, optional
         If `True`, do not self-consistently update the eigenvalues in
-        the screened Coulomb interaction.  Default value is `False`.
+        the screened Coulomb interaction. Default value is `False`.
     max_cycle : int, optional
-        Maximum number of iterations.  Default value is `50`.
+        Maximum number of iterations. Default value is `50`.
     conv_tol : float, optional
         Convergence threshold in the change in the HOMO and LUMO.
         Default value is `1e-8`.
@@ -72,9 +72,9 @@ class evUGW(UGW, evGW):
         both metrics to be met, and `any` requires just one. Default
         value is `all`.
     diis_space : int, optional
-        Size of the DIIS extrapolation space.  Default value is `8`.
+        Size of the DIIS extrapolation space. Default value is `8`.
     damping : float, optional
-        Damping parameter.  Default value is `0.0`.
+        Damping parameter. Default value is `0.0`.
     weight_tol : float, optional
         Threshold in physical weight of Green's function poles, below
         which they are considered zero. Default value is `1e-11`.

--- a/momentGW/uhf/evgw.py
+++ b/momentGW/uhf/evgw.py
@@ -10,14 +10,81 @@ from momentGW.evgw import evGW
 from momentGW.uhf import UGW
 
 
-class evUGW(UGW, evGW):  # noqa: D101
-    __doc__ = evGW.__doc__.replace("Spin-restricted", "Spin-unrestricted", 1)
+class evUGW(UGW, evGW):
+    """
+    Spin-unrestricted eigenvalue self-consistent GW via self-energy
+    moment constraints for molecules.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.SCF
+        PySCF mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    g0 : bool, optional
+        If `True`, do not self-consistently update the eigenvalues in
+        the Green's function.  Default value is `False`.
+    w0 : bool, optional
+        If `True`, do not self-consistently update the eigenvalues in
+        the screened Coulomb interaction.  Default value is `False`.
+    max_cycle : int, optional
+        Maximum number of iterations.  Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    conv_logical : callable, optional
+        Function that takes an iterable of booleans as input indicating
+        whether the individual `conv_tol` and `conv_tol_moms` have been
+        satisfied, respectively, and returns a boolean indicating
+        overall convergence. For example, the function `all` requires
+        both metrics to be met, and `any` requires just one. Default
+        value is `all`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space.  Default value is `8`.
+    damping : float, optional
+        Damping parameter.  Default value is `0.0`.
+    weight_tol : float, optional
+        Threshold in physical weight of Green's function poles, below
+        which they are considered zero. Default value is `1e-11`.
+    """
 
     _opts = util.list_union(UGW._opts, evGW._opts)
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-evUG{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"
 
@@ -48,11 +115,13 @@ class evUGW(UGW, evGW):  # noqa: D101
             Convergence flag.
         """
 
+        # Get the previous moments
         if th_prev is None:
             th_prev = np.zeros_like(th)
         if tp_prev is None:
             tp_prev = np.zeros_like(tp)
 
+        # Get the HOMO and LUMO errors
         error_homo = (
             abs(mo_energy[0][self.nocc[0] - 1] - mo_energy_prev[0][self.nocc[0] - 1]),
             abs(mo_energy[1][self.nocc[1] - 1] - mo_energy_prev[1][self.nocc[1] - 1]),
@@ -62,9 +131,11 @@ class evUGW(UGW, evGW):  # noqa: D101
             abs(mo_energy[1][self.nocc[1]] - mo_energy_prev[1][self.nocc[1]]),
         )
 
+        # Get the moment errors
         error_th = (self._moment_error(th[0], th_prev[0]), self._moment_error(th[1], th_prev[1]))
         error_tp = (self._moment_error(tp[0], tp_prev[0]), self._moment_error(tp[1], tp_prev[1]))
 
+        # Print the table
         style_homo = tuple(logging.rate(e, self.conv_tol, self.conv_tol * 1e2) for e in error_homo)
         style_lumo = tuple(logging.rate(e, self.conv_tol, self.conv_tol * 1e2) for e in error_lumo)
         style_th = tuple(

--- a/momentGW/uhf/fock.py
+++ b/momentGW/uhf/fock.py
@@ -5,7 +5,7 @@ Fock matrix self-consistent loop for unrestricted references.
 import numpy as np
 from dyson import Lehmann
 
-from momentGW import mpi_helper
+from momentGW import logging, mpi_helper
 from momentGW.fock import FockLoop, minimize_chempot, search_chempot
 
 
@@ -193,6 +193,28 @@ class FockLoop(FockLoop):
         gf[1].chempot = chempot[1]
 
         return tuple(gf), nerr
+
+    @logging.with_timer("Fock loop")
+    @logging.with_status("Running Fock loop")
+    def kernel(self, integrals=None):
+        """Driver for the Fock loop.
+
+        Parameters
+        ----------
+        integrals : UIntegrals, optional
+            Integrals object. If `None`, generate from scratch. Default
+            value is `None`.
+
+        Returns
+        -------
+        converged : bool
+            Whether the loop has converged.
+        gf : tuple of dyson.Lehmann
+            Green's function object for each spin channel.
+        se : tuple of dyson.Lehmann
+            Self-energy object for each spin channel.
+        """
+        return super().kernel(integrals)
 
     def _density_error(self, rdm1, rdm1_prev):
         """Calculate the density error.

--- a/momentGW/uhf/fsgw.py
+++ b/momentGW/uhf/fsgw.py
@@ -18,12 +18,12 @@ class fsUGW(UGW, fsGW):  # noqa: D101
 
     _opts = util.list_union(UGW._opts, fsGW._opts)
 
+    project_basis = staticmethod(qsUGW.project_basis)
+    self_energy_to_moments = staticmethod(qsUGW.self_energy_to_moments)
+    check_convergence = qsUGW.check_convergence
+
     @property
     def name(self):
         """Method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-fsUGW"
-
-    project_basis = staticmethod(qsUGW.project_basis)
-    self_energy_to_moments = staticmethod(qsUGW.self_energy_to_moments)
-    check_convergence = qsUGW.check_convergence

--- a/momentGW/uhf/fsgw.py
+++ b/momentGW/uhf/fsgw.py
@@ -67,7 +67,7 @@ class fsUGW(UGW, fsGW):
     diis_space : int, optional
         Size of the DIIS extrapolation space. Default value is `8`.
     damping : float, optional
-        Damping parameter.  Default value is `0.0`.
+        Damping parameter. Default value is `0.0`.
     solver : BaseGW, optional
         Solver to use to obtain the self-energy. Compatible with any
         `BaseGW`-like class. Default value is `momentGW.gw.GW`.

--- a/momentGW/uhf/fsgw.py
+++ b/momentGW/uhf/fsgw.py
@@ -9,8 +9,72 @@ from momentGW.uhf.gw import UGW
 from momentGW.uhf.qsgw import qsUGW
 
 
-class fsUGW(UGW, fsGW):  # noqa: D101
-    __doc__ = fsGW.__doc__.replace("Spin-restricted", "Spin-unrestricted", 1)
+class fsUGW(UGW, fsGW):
+    """
+    Spin-unrestricted Fock matrix self-consistent GW via self-energy
+    moment constraints for molecules.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.SCF
+        PySCF mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    max_cycle : int, optional
+        Maximum number of iterations. Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    conv_logical : callable, optional
+        Function that takes an iterable of booleans as input indicating
+        whether the individual `conv_tol`, `conv_tol_moms` have been
+        satisfied, respectively, and returns a boolean indicating
+        overall convergence. For example, the function `all` requires
+        both metrics to be met, and `any` requires just one. Default
+        value is `all`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space. Default value is `8`.
+    damping : float, optional
+        Damping parameter.  Default value is `0.0`.
+    solver : BaseGW, optional
+        Solver to use to obtain the self-energy. Compatible with any
+        `BaseGW`-like class. Default value is `momentGW.gw.GW`.
+    solver_options : dict, optional
+        Keyword arguments to pass to the solver. Default value is an
+        empty `dict`.
+    """
 
     # --- Default fsUGW options
 
@@ -24,6 +88,6 @@ class fsUGW(UGW, fsGW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-fsUGW"

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -147,6 +147,10 @@ class UGW(BaseUGW, GW):
         -------
         integrals : UIntegrals
             Integrals object.
+
+        See Also
+        --------
+        momentGW.uhf.ints.UIntegrals
         """
 
         # Get the integrals
@@ -199,6 +203,10 @@ class UGW(BaseUGW, GW):
             Green's function for each spin channel.
         se : tuple of dyson.Lehmann
             Self-energy for each spin channel.
+
+        See Also
+        --------
+        momentGW.uhf.fock.FockLoop
         """
 
         # Solve the Dyson equation for the moments
@@ -283,9 +291,9 @@ class UGW(BaseUGW, GW):
         nmom_max : int
             Maximum moment number to calculate.
         moments : tuple of numpy.ndarray, optional
-            Tuple of (hole, particle) moments, if passed then they will
-            be used instead of calculating them. Default value is
-            `None`.
+            Tuple of (hole, particle) moments for each spin channel, if
+            passed then they will be used instead of calculating them.
+            Default value is `None`.
         integrals : UIntegrals, optional
             Integrals object. If `None`, generate from scratch. Default
             value is `None`.
@@ -300,7 +308,7 @@ class UGW(BaseUGW, GW):
         se : tuple of dyson.Lehmann
             Self-energy object for each spin channel.
         qp_energy : NoneType
-            Quasiparticle energies. For one-shot GW, this is `None`.
+            Quasiparticle energies. For most GW methods, this is `None`.
         """
         return super().kernel(nmom_max, moments=moments, integrals=integrals)
 

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -74,8 +74,28 @@ class UGW(BaseUGW, GW):
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-UG0W0"
 
+    @logging.with_timer("Static self-energy")
+    @logging.with_status("Building static self-energy")
+    def build_se_static(self, integrals):
+        """
+        Build the static part of the self-energy, including the Fock
+        matrix.
+
+        Parameters
+        ----------
+        integrals : UIntegrals
+            Integrals object.
+
+        Returns
+        -------
+        se_static : numpy.ndarray
+            Static part of the self-energy for each spin channel. If
+            `self.diagonal_se`, non-diagonal elements are set to zero.
+        """
+        return super().build_se_static(integrals)
+
     def build_se_moments(self, nmom_max, integrals, **kwargs):
-        """Build the moments of the self-energy
+        """Build the moments of the self-energy.
 
         Parameters
         ----------

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -7,7 +7,6 @@ import numpy as np
 from dyson import MBLSE, Lehmann, MixedMBLSE
 
 from momentGW import energy, logging, util
-from momentGW.base import BaseGW
 from momentGW.fock import search_chempot
 from momentGW.gw import GW
 from momentGW.uhf.base import BaseUGW

--- a/momentGW/uhf/gw.py
+++ b/momentGW/uhf/gw.py
@@ -17,18 +17,101 @@ from momentGW.uhf.rpa import dRPA
 from momentGW.uhf.tda import dTDA
 
 
-class UGW(BaseUGW, GW):  # noqa: D101
-    __doc__ = BaseGW.__doc__.format(
-        description="Spin-unrestricted one-shot GW via self-energy moment constraints for "
-        + "molecules.",
-        extra_parameters="",
-    )
+class UGW(BaseUGW, GW):
+    """
+    Spin-unrestricted one-shot GW via self-energy moment constraints for
+    molecules.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.SCF
+        PySCF mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+
+    Notes
+    -----
+    This approach is described in [1]_.
+
+    References
+    ----------
+    .. [1] C. J. C. Scott, O. J. Backhouse, and G. H. Booth, 158, 12,
+        2023.
+    """
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-UG0W0"
+
+    def build_se_moments(self, nmom_max, integrals, **kwargs):
+        """Build the moments of the self-energy
+
+        Parameters
+        ----------
+        nmom_max : int
+            Maximum moment number to calculate.
+        integrals : UIntegrals
+            Integrals object.
+        **kwargs : dict, optional
+           Additional keyword arguments passed to polarizability class.
+
+        Returns
+        -------
+        se_moments_hole : tuple of numpy.ndarray
+            Moments of the hole self-energy for each spin channel. If
+            `self.diagonal_se`, non-diagonal elements are set to zero.
+        se_moments_part : tuple of numpy.ndarray
+            Moments of the particle self-energy for each spin channel.
+            If `self.diagonal_se`, non-diagonal elements are set to
+            zero.
+
+        See Also
+        --------
+        momentGW.uhf.rpa.dRPA
+        momentGW.uhf.tda.dTDA
+        """
+
+        if self.polarizability.lower() == "dtda":
+            tda = dTDA(self, nmom_max, integrals, **kwargs)
+            return tda.kernel()
+
+        elif self.polarizability.lower() == "drpa":
+            rpa = dRPA(self, nmom_max, integrals, **kwargs)
+            return rpa.kernel()
+
+        else:
+            raise NotImplementedError
 
     @logging.with_timer("Integral construction")
     @logging.with_status("Constructing integrals")
@@ -46,6 +129,7 @@ class UGW(BaseUGW, GW):  # noqa: D101
             Integrals object.
         """
 
+        # Get the integrals
         integrals = UIntegrals(
             self.with_df,
             self.mo_coeff,
@@ -54,44 +138,12 @@ class UGW(BaseUGW, GW):  # noqa: D101
             compression_tol=self.compression_tol,
             store_full=self.fock_loop,
         )
+
+        # Transform the integrals
         if transform:
             integrals.transform()
 
         return integrals
-
-    def build_se_moments(self, nmom_max, integrals, **kwargs):
-        """Build the moments of the self-energy.
-
-        Parameters
-        ----------
-        nmom_max : int
-            Maximum moment number to calculate.
-        integrals : UIntegrals
-            Integrals object.
-
-        See functions in `momentGW.uhf.rpa` for `kwargs` options.
-
-        Returns
-        -------
-        se_moments_hole : tuple of numpy.ndarray
-            Moments of the hole self-energy for each spin channel. If
-            `self.diagonal_se`, non-diagonal elements are set to zero.
-        se_moments_part : tuple of numpy.ndarray
-            Moments of the particle self-energy for each spin channel.
-            If `self.diagonal_se`, non-diagonal elements are set to
-            zero.
-        """
-
-        if self.polarizability.lower() == "dtda":
-            tda = dTDA(self, nmom_max, integrals, **kwargs)
-            return tda.kernel()
-
-        elif self.polarizability.lower() == "drpa":
-            rpa = dRPA(self, nmom_max, integrals, **kwargs)
-            return rpa.kernel()
-
-        else:
-            raise NotImplementedError
 
     def solve_dyson(self, se_moments_hole, se_moments_part, se_static, integrals=None):
         """
@@ -129,6 +181,7 @@ class UGW(BaseUGW, GW):  # noqa: D101
             Self-energy for each spin channel.
         """
 
+        # Solve the Dyson equation for the moments
         with logging.with_modifiers(status="Solving Dyson equation", timer="Dyson equation"):
             solver_occ = MBLSE(se_static[0], np.array(se_moments_hole[0]))
             solver_occ.kernel()
@@ -150,11 +203,15 @@ class UGW(BaseUGW, GW):  # noqa: D101
 
             se = (se_α, se_β)
 
+        # Initialise the solver
         solver = FockLoop(self, se=se, **self.fock_opts)
 
+        # Shift the self-energy poles relative to the Green's function
+        # to better conserve the particle number
         if self.optimise_chempot:
             se = solver.auxiliary_shift(se_static)
 
+        # Find the error in the moments
         error = (
             self.moment_error(se_moments_hole[0], se_moments_part[0], se[0]),
             self.moment_error(se_moments_hole[1], se_moments_part[1], se[1]),
@@ -167,10 +224,12 @@ class UGW(BaseUGW, GW):  # noqa: D101
                 f"particle = [{logging.rate(error[s][1], 1e-12, 1e-8)}]{error[s][1]:.3e}[/])"
             )
 
+        # Solve the Dyson equation for the self-energy
         gf, error = solver.solve_dyson(se_static)
         se[0].chempot = gf[0].chempot
         se[1].chempot = gf[1].chempot
 
+        # Self-consistently renormalise the density matrix
         if self.fock_loop:
             logging.write("")
             solver.gf = gf
@@ -178,6 +237,7 @@ class UGW(BaseUGW, GW):  # noqa: D101
             conv, gf, se = solver.kernel(integrals=integrals)
             _, error = solver.search_chempot(gf)
 
+        # Print the error in the number of electrons
         logging.write("")
         color = logging.rate(
             abs(error),
@@ -189,6 +249,40 @@ class UGW(BaseUGW, GW):  # noqa: D101
             logging.write(f"Chemical potential ({spin}):  {gf[s].chempot:.6f}")
 
         return tuple(gf), tuple(se)
+
+    def kernel(
+        self,
+        nmom_max,
+        moments=None,
+        integrals=None,
+    ):
+        """Driver for the method.
+
+        Parameters
+        ----------
+        nmom_max : int
+            Maximum moment number to calculate.
+        moments : tuple of numpy.ndarray, optional
+            Tuple of (hole, particle) moments, if passed then they will
+            be used instead of calculating them. Default value is
+            `None`.
+        integrals : UIntegrals, optional
+            Integrals object. If `None`, generate from scratch. Default
+            value is `None`.
+
+        Returns
+        -------
+        converged : bool
+            Whether the solver converged. For single-shot calculations,
+            this is always `True`.
+        gf : tuple of dyson.Lehmann
+            Green's function object for each spin channel.
+        se : tuple of dyson.Lehmann
+            Self-energy object for each spin channel.
+        qp_energy : NoneType
+            Quasiparticle energies. For one-shot GW, this is `None`.
+        """
+        return super().kernel(nmom_max, moments=moments, integrals=integrals)
 
     def make_rdm1(self, gf=None):
         """Get the first-order reduced density matrix.
@@ -234,11 +328,15 @@ class UGW(BaseUGW, GW):  # noqa: D101
             One-body energy.
         """
 
+        # Get the Green's function
         if gf is None:
             gf = self.gf
+
+        # Get the integrals
         if integrals is None:
             integrals = self.ao2mo()
 
+        # Form the Fock matrix
         with util.SilentSCF(self._scf):
             h1e = tuple(
                 util.einsum("pq,pi,qj->ij", self._scf.get_hcore(), c.conj(), c)
@@ -247,6 +345,7 @@ class UGW(BaseUGW, GW):  # noqa: D101
         rdm1 = self.make_rdm1(gf=gf)
         fock = integrals.get_fock(rdm1, h1e)
 
+        # Calculate the energy parts
         e_1b = energy.hartree_fock(rdm1[0], fock[0], h1e[0])
         e_1b += energy.hartree_fock(rdm1[1], fock[1], h1e[1])
 
@@ -273,19 +372,15 @@ class UGW(BaseUGW, GW):  # noqa: D101
         -------
         e_2b : float
             Two-body energy.
-
-        Notes
-        -----
-        With `g0=False`, this function scales as
-        :math:`\mathcal{O}(N^4)` with system size, whereas with
-        `g0=True`, it scales as :math:`\mathcal{O}(N^3)`.
         """
 
+        # Get the Green's function and self-energy
         if gf is None:
             gf = self.gf
         if se is None:
             se = self.se
 
+        # Calculate the Galitskii--Migdal energy
         if g0:
             e_2b_α = energy.galitskii_migdal_g0(self.mo_energy[0], self.mo_occ[0], se[0])
             e_2b_β = energy.galitskii_migdal_g0(self.mo_energy[1], self.mo_occ[1], se[1])
@@ -293,6 +388,7 @@ class UGW(BaseUGW, GW):  # noqa: D101
             e_2b_α = energy.galitskii_migdal(gf[0], se[0])
             e_2b_β = energy.galitskii_migdal(gf[1], se[1])
 
+        # Add the parts
         e_2b = (e_2b_α + e_2b_β) / 2
 
         return e_2b
@@ -312,18 +408,30 @@ class UGW(BaseUGW, GW):  # noqa: D101
             Mean-field Green's function for each spin channel.
         """
 
+        # Get the MO energies
         if mo_energy is None:
             mo_energy = self.mo_energy
 
+        # Build the Green's functions
         gf = [
             Lehmann(mo_energy[0], np.eye(self.nmo[0])),
             Lehmann(mo_energy[1], np.eye(self.nmo[1])),
         ]
-        gf[0].chempot = search_chempot(
-            gf[0].energies, gf[0].couplings, self.nmo[0], self.nocc[0], occupancy=1
-        )[0]
-        gf[1].chempot = search_chempot(
-            gf[1].energies, gf[1].couplings, self.nmo[1], self.nocc[1], occupancy=1
-        )[0]
+
+        # Find the chemical potentials
+        gf[0].chempot, _ = search_chempot(
+            gf[0].energies,
+            gf[0].couplings,
+            self.nmo[0],
+            self.nocc[0],
+            occupancy=1,
+        )
+        gf[1].chempot, _ = search_chempot(
+            gf[1].energies,
+            gf[1].couplings,
+            self.nmo[1],
+            self.nocc[1],
+            occupancy=1,
+        )
 
         return tuple(gf)

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -10,25 +10,29 @@ from momentGW.ints import Integrals
 
 
 class Integrals_α(Integrals):
-    """Overload the `__name__` to signify α part"""
-
-    def get_compression_metric(self):  # noqa: D102
-        return None
-
-    get_compression_metric.__doc__ = Integrals.get_compression_metric.__doc__
+    """Extends `Integrals` to represent the α channel."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__class__.__name__ = "Integrals (α)"
 
+    def get_compression_metric(self):
+        """Return the compression metric.
 
-class Integrals_β(Integrals):
-    """Overload the `__name__` to signify β part"""
+        Overrides `Integrals.get_compression_metric` to return `None`,
+        as the compression metric should be calculated for spinless
+        auxiliaries.
 
-    def get_compression_metric(self):  # noqa: D102
+        Returns
+        -------
+        rot : numpy.ndarray
+            Rotation matrix into the compressed auxiliary space.
+        """
         return None
 
-    get_compression_metric.__doc__ = Integrals.get_compression_metric.__doc__
+
+class Integrals_β(Integrals_α):
+    """Overload the `__name__` to signify β part"""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -37,7 +41,7 @@ class Integrals_β(Integrals):
 
 class UIntegrals(Integrals):
     """
-    Container for the integrals required for UGW methods.
+    Container for the density-fitted integrals required for UGW methods.
 
     Parameters
     ----------
@@ -108,16 +112,19 @@ class UIntegrals(Integrals):
             Rotation matrix into the compressed auxiliary space.
         """
 
+        # Get the compression sectors
         compression = self._parse_compression()
         if not compression:
             return None
 
+        # Initialise the inner product matrix
         prod = np.zeros((self.naux_full, self.naux_full))
 
         # Loop over required blocks
         for key in sorted(compression):
             for s, spin in enumerate(["α", "β"]):
                 with logging.with_status(f"{key} ({spin}) sector"):
+                    # Get the coefficients
                     ci, cj = [
                         {
                             "o": self.mo_coeff[s][:, self.mo_occ[s] > 0],
@@ -130,10 +137,12 @@ class UIntegrals(Integrals):
                     ni, nj = ci.shape[-1], cj.shape[-1]
                     coeffs = np.concatenate((ci, cj), axis=1)
 
+                    # Loop over the blocks
                     for p0, p1 in mpi_helper.prange(0, ni * nj, self.with_df.blockdim):
                         i0, j0 = divmod(p0, nj)
                         i1, j1 = divmod(p1, nj)
 
+                        # Build the (L|xy) array
                         Lxy = np.zeros((self.naux_full, p1 - p0))
                         b1 = 0
                         for block in self.with_df.loop():
@@ -152,11 +161,14 @@ class UIntegrals(Integrals):
                                 tmp = tmp.reshape(b1 - b0, -1)
                                 Lxy[b0:b1] = tmp[:, j0 : j0 + (p1 - p0)]
 
+                        # Update the inner product matrix
                         prod += np.dot(Lxy, Lxy.T)
 
+        # Reduce the inner product matrix
         prod = mpi_helper.allreduce(prod, root=0)
         prod *= 0.5
 
+        # Diagonalise the inner product matrix
         if mpi_helper.rank == 0:
             e, v = np.linalg.eigh(prod)
             mask = np.abs(e) > self.compression_tol
@@ -165,8 +177,11 @@ class UIntegrals(Integrals):
             rot = np.zeros((0,))
         del prod
 
+        # Broadcast the rotation matrix in case of hybrid parallelism
+        # introducing non-determinism
         rot = mpi_helper.bcast(rot, root=0)
 
+        # Print the compression status
         if rot.shape[-1] == self.naux_full:
             logging.write("No compression found for auxiliary space")
             rot = None
@@ -182,25 +197,27 @@ class UIntegrals(Integrals):
 
     def transform(self, do_Lpq=None, do_Lpx=True, do_Lia=True):
         """
-        Transform the integrals.
+        Transform the integrals in-place.
 
         Parameters
         ----------
         do_Lpq : bool, optional
-            Whether to compute the full (aux, MO, MO) array. Default
+            Whether to compute the full ``(aux, MO, MO)`` array. Default
             value is `True` if `store_full` is `True`, `False`
             otherwise.
         do_Lpx : bool, optional
-            Whether to compute the compressed (aux, MO, MO) array.
+            Whether to compute the compressed ``(aux, MO, MO)`` array.
             Default value is `True`.
         do_Lia : bool, optional
-            Whether to compute the compressed (aux, occ, vir) array.
+            Whether to compute the compressed ``(aux, occ, vir)`` array.
             Default value is `True`.
         """
 
+        # Get the compression metric
         if self._spins[0]._rot is None:
             self._spins[0]._rot = self._spins[1]._rot = self.get_compression_metric()
 
+        # Transform the integrals
         self._spins[0].transform(do_Lpq=do_Lpq, do_Lpx=do_Lpx, do_Lia=do_Lia)
         self._spins[1].transform(do_Lpq=do_Lpq, do_Lpx=do_Lpx, do_Lia=do_Lia)
 
@@ -212,14 +229,14 @@ class UIntegrals(Integrals):
         Parameters
         ----------
         mo_coeff_g : numpy.ndarray, optional
-            Coefficients corresponding to the Green's function. Default
-            value is `None`.
+            Coefficients corresponding to the Green's function for each
+            spin. Default value is `None`.
         mo_coeff_w : numpy.ndarray, optional
             Coefficients corresponding to the screened Coulomb
-            interaction. Default value is `None`.
+            interaction for each spin. Default value is `None`.
         mo_occ_w : numpy.ndarray, optional
             Occupations corresponding to the screened Coulomb
-            interaction. Default value is `None`.
+            interaction for each spin. Default value is `None`.
 
         Notes
         -----
@@ -229,13 +246,16 @@ class UIntegrals(Integrals):
         `mo_coeff_g` and `mo_coeff_w` must be provided.
         """
 
+        # Check the input
         if any((mo_coeff_w is not None, mo_occ_w is not None)):
             assert mo_coeff_w is not None and mo_occ_w is not None
 
+        # Update the Green's function coefficients
         if mo_coeff_g is not None:
             self._spins[0]._mo_coeff_g = mo_coeff_g[0]
             self._spins[1]._mo_coeff_g = mo_coeff_g[1]
 
+        # Update the screened Coulomb interaction coefficients
         do_all = False
         rot = None
         if mo_coeff_w is not None:
@@ -247,9 +267,11 @@ class UIntegrals(Integrals):
                 do_all = True
                 rot = self.get_compression_metric()
 
+        # Set the compression metric
         self._spins[0]._rot = rot
         self._spins[1]._rot = rot
 
+        # Transform the integrals
         self.transform(
             do_Lpq=self.store_full and do_all,
             do_Lpx=mo_coeff_g is not None or do_all,
@@ -273,17 +295,14 @@ class UIntegrals(Integrals):
             J matrix for each spin channel.
         """
 
+        # Calculate Coulomb term each pair of spins
         vj_αα = self._spins[0].get_j(dm[0], basis=basis, other=self._spins[0])
         vj_αβ = self._spins[0].get_j(dm[1], basis=basis, other=self._spins[1])
         vj_ββ = self._spins[1].get_j(dm[1], basis=basis, other=self._spins[1])
         vj_βα = self._spins[1].get_j(dm[0], basis=basis, other=self._spins[0])
 
-        vj = np.array(
-            [
-                vj_αα + vj_αβ,
-                vj_ββ + vj_βα,
-            ]
-        )
+        # Build the J matrix for each spin
+        vj = np.array([vj_αα + vj_αβ, vj_ββ + vj_βα])
 
         return vj
 
@@ -304,14 +323,28 @@ class UIntegrals(Integrals):
             K matrix for each spin channel.
         """
 
-        vk = np.array(
-            [
-                self._spins[0].get_k(dm[0], basis=basis),
-                self._spins[1].get_k(dm[1], basis=basis),
-            ]
-        )
+        # Calculate exchange term each spin
+        vk_αα = self._spins[0].get_k(dm[0], basis=basis)
+        vk_ββ = self._spins[1].get_k(dm[1], basis=basis)
+        vk = np.array([vk_αα, vk_ββ])
 
         return vk
+
+    def get_jk(self, dm, **kwargs):
+        """Build the J and K matrices.
+
+        Returns
+        -------
+        vj : numpy.ndarray
+            J matrix for each spin channel.
+        vk : numpy.ndarray
+            K matrix for each spin channel.
+
+        Notes
+        -----
+        See `get_j` and `get_k` for more information.
+        """
+        return super().get_jk(dm, **kwargs)
 
     def get_veff(self, dm, j=None, k=None, **kwargs):
         """Build the effective potential.
@@ -346,72 +379,92 @@ class UIntegrals(Integrals):
             vj, vk = j, self.get_k(dm, **kwargs)
         return vj - vk
 
+    def get_fock(self, dm, h1e, **kwargs):
+        """Build the Fock matrix.
+
+        Parameters
+        ----------
+        dm : numpy.ndarray
+            Density matrix for each spin channel.
+        h1e : numpy.ndarray
+            Core Hamiltonian matrix for each spin channel.
+        **kwargs : dict, optional
+            Additional keyword arguments for `get_jk`.
+
+        Returns
+        -------
+        fock : numpy.ndarray
+            Fock matrix for each spin channel.
+
+        Notes
+        -----
+        See `get_jk` for more information. The basis of `h1e` must be
+        the same as `dm`.
+        """
+        return super().get_fock(dm, **kwargs)
+
     @property
     def Lpq(self):
-        """Return the (aux, MO, MO) array."""
+        """Get the full uncompressed ``(aux, MO, MO)`` integrals."""
         return (self._spins[0].Lpq, self._spins[1].Lpq)
 
     @property
     def Lpx(self):
-        """Return the (aux, MO, MO) array."""
+        """Get the compressed ``(aux, MO, MO)`` integrals."""
         return (self._spins[0].Lpx, self._spins[1].Lpx)
 
     @property
     def Lia(self):
-        """Return the (aux, occ, vir) array."""
+        """Get the compressed ``(aux, occ, vir)`` integrals."""
         return (self._spins[0].Lia, self._spins[1].Lia)
 
     @property
     def mo_coeff_g(self):
-        """Return the MO coefficients for the Green's function."""
+        """Get the MO coefficients for the Green's function."""
         return (self._spins[0].mo_coeff_g, self._spins[1].mo_coeff_g)
 
     @property
     def mo_coeff_w(self):
-        """
-        Return the MO coefficients for the screened Coulomb interaction.
-        """
+        """Get the MO coefficients for the screened Coulomb interaction."""
         return (self._spins[0].mo_coeff_w, self._spins[1].mo_coeff_w)
 
     @property
     def mo_occ_w(self):
         """
-        Return the MO occupation numbers for the screened Coulomb
+        Get the MO occupation numbers for the screened Coulomb
         interaction.
         """
         return (self._spins[0].mo_occ_w, self._spins[1].mo_occ_w)
 
     @property
     def nmo(self):
-        """Return the number of MOs."""
+        """Get the number of MOs."""
         return (self._spins[0].nmo, self._spins[1].nmo)
 
     @property
     def nocc(self):
-        """Return the number of occupied MOs."""
+        """Get the number of occupied MOs."""
         return (self._spins[0].nocc, self._spins[1].nocc)
 
     @property
     def nvir(self):
-        """Return the number of virtual MOs."""
+        """Get the number of virtual MOs."""
         return (self._spins[0].nvir, self._spins[1].nvir)
 
     @property
     def nmo_g(self):
-        """Return the number of MOs for the Green's function."""
+        """Get the number of MOs for the Green's function."""
         return (self._spins[0].nmo_g, self._spins[1].nmo_g)
 
     @property
     def nmo_w(self):
-        """
-        Return the number of MOs for the screened Coulomb interaction.
-        """
+        """Get the number of MOs for the screened Coulomb interaction."""
         return (self._spins[0].nmo_w, self._spins[1].nmo_w)
 
     @property
     def nocc_w(self):
         """
-        Return the number of occupied MOs for the screened Coulomb
+        Get the number of occupied MOs for the screened Coulomb
         interaction.
         """
         return (self._spins[0].nocc_w, self._spins[1].nocc_w)
@@ -419,7 +472,7 @@ class UIntegrals(Integrals):
     @property
     def nvir_w(self):
         """
-        Return the number of virtual MOs for the screened Coulomb
+        Get the number of virtual MOs for the screened Coulomb
         interaction.
         """
         return (self._spins[0].nvir_w, self._spins[1].nvir_w)
@@ -427,7 +480,7 @@ class UIntegrals(Integrals):
     @property
     def naux(self):
         """
-        Return the number of auxiliary basis functions, after the
+        Get the number of auxiliary basis functions, after the
         compression.
         """
         assert self._spins[0].naux == self._spins[1].naux
@@ -436,7 +489,7 @@ class UIntegrals(Integrals):
     @property
     def naux_full(self):
         """
-        Return the number of auxiliary basis functions, before the
+        Get the number of auxiliary basis functions, before the
         compression.
         """
         return self.with_df.get_naoaux()
@@ -444,16 +497,14 @@ class UIntegrals(Integrals):
     @property
     def is_bare(self):
         """
-        Return a boolean flag indicating whether the integrals have
+        Get a boolean flag indicating whether the integrals have
         no self-consistencies.
         """
         return self._mo_coeff_g is None and self._mo_coeff_w is None
 
     @property
     def dtype(self):
-        """
-        Return the dtype of the integrals.
-        """
+        """Get the dtype of the integrals."""
         return np.result_type(self._spins[0].dtype, self._spins[1].dtype)
 
     def __getitem__(self, key):

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -12,27 +12,27 @@ from momentGW.ints import Integrals
 class Integrals_α(Integrals):
     """Overload the `__name__` to signify α part"""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__class__.__name__ = "Integrals (α)"
-
     def get_compression_metric(self):  # noqa: D102
         return None
 
     get_compression_metric.__doc__ = Integrals.get_compression_metric.__doc__
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__class__.__name__ = "Integrals (α)"
 
 
 class Integrals_β(Integrals):
     """Overload the `__name__` to signify β part"""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__class__.__name__ = "Integrals (β)"
-
     def get_compression_metric(self):  # noqa: D102
         return None
 
     get_compression_metric.__doc__ = Integrals.get_compression_metric.__doc__
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__class__.__name__ = "Integrals (β)"
 
 
 class UIntegrals(Integrals):
@@ -346,10 +346,6 @@ class UIntegrals(Integrals):
             vj, vk = j, self.get_k(dm, **kwargs)
         return vj - vk
 
-    def __getitem__(self, key):
-        """Get the integrals for one spin."""
-        return self._spins[key]
-
     @property
     def Lpq(self):
         """Return the (aux, MO, MO) array."""
@@ -459,3 +455,7 @@ class UIntegrals(Integrals):
         Return the dtype of the integrals.
         """
         return np.result_type(self._spins[0].dtype, self._spins[1].dtype)
+
+    def __getitem__(self, key):
+        """Get the integrals for one spin."""
+        return self._spins[key]

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -291,7 +291,7 @@ class UIntegrals(Integrals):
 
         Returns
         -------
-        vj : tuple of numpy.ndarray
+        vj : numpy.ndarray
             J matrix for each spin channel.
         """
 
@@ -365,7 +365,7 @@ class UIntegrals(Integrals):
         Returns
         -------
         veff : numpy.ndarray
-            Effective potential.
+            Effective potential for each spin channel.
 
         Notes
         -----

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -9,7 +9,7 @@ from momentGW import logging, mpi_helper
 from momentGW.ints import Integrals
 
 
-class Integrals_α(Integrals):
+class _Integrals_α(Integrals):
     """Extends `Integrals` to represent the α channel."""
 
     def __init__(self, *args, **kwargs):
@@ -31,7 +31,7 @@ class Integrals_α(Integrals):
         return None
 
 
-class Integrals_β(Integrals_α):
+class _Integrals_β(_Integrals_α):
     """Overload the `__name__` to signify β part"""
 
     def __init__(self, *args, **kwargs):
@@ -83,7 +83,7 @@ class UIntegrals(Integrals):
 
         # Attributes
         self._spins = {
-            0: Integrals_α(
+            0: _Integrals_α(
                 self.with_df,
                 self.mo_coeff[0],
                 self.mo_occ[0],
@@ -91,7 +91,7 @@ class UIntegrals(Integrals):
                 compression_tol=self.compression_tol,
                 store_full=self.store_full,
             ),
-            1: Integrals_β(
+            1: _Integrals_β(
                 self.with_df,
                 self.mo_coeff[1],
                 self.mo_occ[1],

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -401,7 +401,7 @@ class UIntegrals(Integrals):
         See `get_jk` for more information. The basis of `h1e` must be
         the same as `dm`.
         """
-        return super().get_fock(dm, **kwargs)
+        return super().get_fock(dm, h1e, **kwargs)
 
     @property
     def Lpq(self):

--- a/momentGW/uhf/qsgw.py
+++ b/momentGW/uhf/qsgw.py
@@ -10,8 +10,89 @@ from momentGW.qsgw import qsGW
 from momentGW.uhf import UGW, evUGW
 
 
-class qsUGW(UGW, qsGW):  # noqa: D101
-    __doc__ = qsGW.__doc__.replace("Spin-restricted", "Spin-unrestricted", 1)
+class qsUGW(UGW, qsGW):
+    """
+    Spin-unrestricted quasiparticle self-consistent GW via self-energy
+    moment constraints for molecules.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.SCF
+        PySCF mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    max_cycle : int, optional
+        Maximum number of iterations. Default value is `50`.
+    max_cycle_qp : int, optional
+        Maximum number of iterations in the quasiparticle equation
+        loop. Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    conv_tol_qp : float, optional
+        Convergence threshold in the change in the density matrix in
+        the quasiparticle equation loop. Default value is `1e-8`.
+    conv_logical : callable, optional
+        Function that takes an iterable of booleans as input indicating
+        whether the individual `conv_tol`, `conv_tol_moms`,
+        `conv_tol_qp` have been satisfied, respectively, and returns a
+        boolean indicating overall convergence. For example, the
+        function `all` requires both metrics to be met, and `any`
+        requires just one. Default value is `all`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space. Default value is `8`.
+    diis_space_qp : int, optional
+        Size of the DIIS extrapolation space in the quasiparticle
+        loop. Default value is `8`.
+    damping : float, optional
+        Damping parameter. Default value is `0.0`.
+    eta : float, optional
+        Small value to regularise the self-energy. Default value is
+        `1e-1`.
+    srg : float, optional
+        If non-zero, use the similarity renormalisation group approach
+        of Marie and Loos in place of the `eta` regularisation. For
+        value recommendations refer to their paper (arXiv:2303.05984).
+        Default value is `0.0`.
+    solver : BaseGW, optional
+        Solver to use to obtain the self-energy. Compatible with any
+        `BaseGW`-like class. Default value is `momentGW.gw.GW`.
+    solver_options : dict, optional
+        Keyword arguments to pass to the solver. Default value is an
+        empty `dict`.
+    """
 
     # --- Default qsUGW options
 
@@ -23,14 +104,13 @@ class qsUGW(UGW, qsGW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-qsUGW"
 
     @staticmethod
     def project_basis(matrix, ovlp, mo1, mo2):
-        """
-        Project a matrix from one basis to another.
+        """Project a matrix from one basis to another.
 
         Parameters
         ----------
@@ -54,8 +134,10 @@ class qsUGW(UGW, qsGW):  # noqa: D101
             channel.
         """
 
+        # Build the projection matrix
         proj = util.einsum("pq,spi,sqj->sij", ovlp, np.conj(mo1), mo2)
 
+        # Project the matrix
         if isinstance(matrix, np.ndarray):
             projected_matrix = util.einsum(
                 "s...pq,s...pi,s...qj->s...ij", matrix, np.conj(proj), proj
@@ -80,6 +162,8 @@ class qsUGW(UGW, qsGW):  # noqa: D101
         ----------
         se : tuple of dyson.Lehmann
             Self-energy to compute the moments of for each spin channel.
+        nmom_max : int
+            Maximum moment number to calculate.
 
         Returns
         -------
@@ -93,19 +177,19 @@ class qsUGW(UGW, qsGW):  # noqa: D101
         return th, tp
 
     def build_static_potential(self, mo_energy, se):
-        """
-        Build the static potential approximation to the self-energy.
+        """Build the static potential approximation to the self-energy.
 
         Parameters
         ----------
         mo_energy : numpy.ndarray
-            Molecular orbital energies.
-        se : dyson.Lehmann
-            Self-energy to approximate.
+            Molecular orbital energies for each spin channel.
+        se : tuple of dyson.Lehmann
+            Self-energy to approximate for each spin channel.
 
         Returns
         -------
         se_qp : numpy.ndarray
-            Static potential approximation to the self-energy.
+            Static potential approximation to the self-energy for each
+            spin channel.
         """
         return np.array([qsGW.build_static_potential(self, e, s) for e, s in zip(mo_energy, se)])

--- a/momentGW/uhf/qsgw.py
+++ b/momentGW/uhf/qsgw.py
@@ -19,6 +19,8 @@ class qsUGW(UGW, qsGW):  # noqa: D101
 
     _opts = util.list_union(UGW._opts, qsGW._opts)
 
+    check_convergence = evUGW.check_convergence
+
     @property
     def name(self):
         """Method name."""
@@ -107,5 +109,3 @@ class qsUGW(UGW, qsGW):  # noqa: D101
             Static potential approximation to the self-energy.
         """
         return np.array([qsGW.build_static_potential(self, e, s) for e, s in zip(mo_energy, se)])
-
-    check_convergence = evUGW.check_convergence

--- a/momentGW/uhf/rpa.py
+++ b/momentGW/uhf/rpa.py
@@ -72,7 +72,6 @@ class dRPA(dTDA, RdRPA):
         )
 
         # Perform the offset integral
-        # FIXME do these offset integrals need a sum over spin?
         offset = (
             self.eval_offset_integral(quad[0], d[0], Lia=self.integrals[0].Lia),
             self.eval_offset_integral(quad[1], d[1], Lia=self.integrals[1].Lia),
@@ -187,5 +186,10 @@ class dRPA(dTDA, RdRPA):
     @logging.with_timer("Density-density moments")
     @logging.with_status("Constructing density-density moments")
     def build_dd_moments_exact(self):
-        """Build the exact moments of the density-density response."""
+        """Build the exact moments of the density-density response.
+
+        Notes
+        -----
+        Placeholder for future implementation.
+        """
         raise NotImplementedError

--- a/momentGW/uhf/scgw.py
+++ b/momentGW/uhf/scgw.py
@@ -13,11 +13,11 @@ class scUGW(UGW, scGW):  # noqa: D101
 
     _opts = util.list_union(UGW._opts, scGW._opts)
 
+    check_convergence = evUGW.check_convergence
+    remove_unphysical_poles = evUGW.remove_unphysical_poles
+
     @property
     def name(self):
         """Method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-UG{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"
-
-    check_convergence = evUGW.check_convergence
-    remove_unphysical_poles = evUGW.remove_unphysical_poles

--- a/momentGW/uhf/scgw.py
+++ b/momentGW/uhf/scgw.py
@@ -8,8 +8,65 @@ from momentGW.scgw import scGW
 from momentGW.uhf import UGW, evUGW
 
 
-class scUGW(UGW, scGW):  # noqa: D101
-    __doc__ = scGW.__doc__.replace("Spin-restricted", "Spin-unrestricted", 1)
+class scUGW(UGW, scGW):
+    """
+    Spin-unrestricted self-consistent GW via self-energy moment
+    constraints for molecules.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.SCF
+        PySCF mean-field class.
+    diagonal_se : bool, optional
+        If `True`, use a diagonal approximation in the self-energy.
+        Default value is `False`.
+    polarizability : str, optional
+        Type of polarizability to use, can be one of `("drpa",
+        "drpa-exact", "dtda", "thc-dtda"). Default value is `"drpa"`.
+    npoints : int, optional
+        Number of numerical integration points. Default value is `48`.
+    optimise_chempot : bool, optional
+        If `True`, optimise the chemical potential by shifting the
+        position of the poles in the self-energy relative to those in
+        the Green's function. Default value is `False`.
+    fock_loop : bool, optional
+        If `True`, self-consistently renormalise the density matrix
+        according to the updated Green's function. Default value is
+        `False`.
+    fock_opts : dict, optional
+        Dictionary of options passed to the Fock loop. For more details
+        see `momentGW.fock`.
+    compression : str, optional
+        Blocks of the ERIs to use as a metric for compression. Can be
+        one or more of `("oo", "ov", "vv", "ia")` which can be passed as
+        a comma-separated string. `"oo"`, `"ov"` and `"vv"` refer to
+        compression on the initial ERIs, whereas `"ia"` refers to
+        compression on the ERIs entering RPA, which may change under a
+        self-consistent scheme. Default value is `"ia"`.
+    compression_tol : float, optional
+        Tolerance for the compression. Default value is `1e-10`.
+    thc_opts : dict, optional
+        Dictionary of options to be used for THC calculations. Current
+        implementation requires a filepath to import the THC integrals.
+    g0 : bool, optional
+        If `True`, do not self-consistently update the eigenvalues in
+        the Green's function. Default value is `False`.
+    w0 : bool, optional
+        If `True`, do not self-consistently update the eigenvalues in
+        the screened Coulomb interaction. Default value is `False`.
+    max_cycle : int, optional
+        Maximum number of iterations. Default value is `50`.
+    conv_tol : float, optional
+        Convergence threshold in the change in the HOMO and LUMO.
+        Default value is `1e-8`.
+    conv_tol_moms : float, optional
+        Convergence threshold in the change in the moments. Default
+        value is `1e-8`.
+    diis_space : int, optional
+        Size of the DIIS extrapolation space. Default value is `8`.
+    damping : float, optional
+        Damping parameter. Default value is `0.0`.
+    """
 
     _opts = util.list_union(UGW._opts, scGW._opts)
 
@@ -18,6 +75,6 @@ class scUGW(UGW, scGW):  # noqa: D101
 
     @property
     def name(self):
-        """Method name."""
+        """Get the method name."""
         polarizability = self.polarizability.upper().replace("DTDA", "dTDA").replace("DRPA", "dRPA")
         return f"{polarizability}-UG{'0' if self.g0 else ''}W{'0' if self.w0 else ''}"

--- a/momentGW/uhf/tda.py
+++ b/momentGW/uhf/tda.py
@@ -89,7 +89,7 @@ class dTDA(RdTDA):
         moments_vir : numpy.ndarray
             Moments of the virtual self-energy for each spin channel.
         """
-        return self.build_moments(exact=exact)
+        return super().kernel(exact=exact)
 
     @logging.with_timer("Moment convolution")
     @logging.with_status("Convoluting moments")

--- a/momentGW/uhf/tda.py
+++ b/momentGW/uhf/tda.py
@@ -10,8 +10,8 @@ from momentGW.tda import dTDA as RdTDA
 
 class dTDA(RdTDA):
     """
-    Compute the self-energy moments using dTDA and numerical
-    integration with unrestricted references.
+    Compute the self-energy moments using dTDA with unrestricted
+    references.
 
     Parameters
     ----------
@@ -45,6 +45,7 @@ class dTDA(RdTDA):
             channel.
         """
 
+        # Initialise the moments
         a0, a1 = self.mpi_slice(self.nov[0])
         b0, b1 = self.mpi_slice(self.nov[1])
         moments = np.zeros((self.nmom_max + 1, self.naux, (a1 - a0) + (b1 - b0)))
@@ -70,7 +71,63 @@ class dTDA(RdTDA):
 
         return moments
 
-    build_dd_moments_exact = build_dd_moments
+    def kernel(self, exact=False):
+        """
+        Run the polarizability calculation to compute moments of the
+        self-energy.
+
+        Parameters
+        ----------
+        exact : bool, optional
+            Has no effect and is only present for compatibility with
+            `dRPA`. Default value is `False`.
+
+        Returns
+        -------
+        moments_occ : numpy.ndarray
+            Moments of the occupied self-energy for each spin channel.
+        moments_vir : numpy.ndarray
+            Moments of the virtual self-energy for each spin channel.
+        """
+        return self.build_moments(exact=exact)
+
+    @logging.with_timer("Moment convolution")
+    @logging.with_status("Convoluting moments")
+    def convolve(self, eta, eta_orders=None, mo_energy_g=None, mo_occ_g=None):
+        """
+        Handle the convolution of the moments of the Green's function
+        and screened Coulomb interaction.
+
+        Parameters
+        ----------
+        eta : numpy.ndarray
+            Moments of the density-density response partly transformed
+            into moments of the screened Coulomb interaction, for each
+            spin channel.
+        mo_energy_g : numpy.ndarray, optional
+            Energies of the Green's function for each spin channel. If
+            `None`, use `self.mo_energy_g`. Default value is `None`.
+        eta_orders : list, optional
+            List of orders for the rotated density-density moments in
+            `eta`. If `None`, assume it spans all required orders.
+            Default value is `None`.
+        mo_occ_g : numpy.ndarray, optional
+            Occupancies of the Green's function for each spin channel.
+            If `None`, use `self.mo_occ_g`. Default value is `None`.
+
+        Returns
+        -------
+        moments_occ : numpy.ndarray
+            Moments of the occupied self-energy for each spin channel.
+        moments_vir : numpy.ndarray
+            Moments of the virtual self-energy for each spin channel.
+        """
+        return super().convolve(
+            eta,
+            eta_orders=eta_orders,
+            mo_energy_g=mo_energy_g,
+            mo_occ_g=mo_occ_g,
+        )
 
     @logging.with_timer("Self-energy moments")
     @logging.with_status("Constructing self-energy moments")
@@ -107,6 +164,7 @@ class dTDA(RdTDA):
             ]
             pq, p, q = "pq", "p", "q"
 
+        # Concatenate the integrals
         Lia = np.concatenate([self.integrals[0].Lia, self.integrals[1].Lia], axis=1)
 
         # Initialise output moments
@@ -123,11 +181,9 @@ class dTDA(RdTDA):
         for n in range(self.nmom_max + 1):
             eta_aux = np.dot(moments_dd[n], Lia.T)
             eta_aux = mpi_helper.allreduce(eta_aux)
-
             for x in range(a1 - a0):
                 Lp = self.integrals[0].Lpx[:, :, x]
                 eta[0][x] = util.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux)
-
             for x in range(b1 - b0):
                 Lp = self.integrals[1].Lpx[:, :, x]
                 eta[1][x] = util.einsum(f"P{p},Q{q},PQ->{pq}", Lp, Lp, eta_aux)
@@ -153,9 +209,37 @@ class dTDA(RdTDA):
 
         return tuple(moments_occ), tuple(moments_vir)
 
+    @logging.with_timer("Dynamic polarizability moments")
+    @logging.with_status("Constructing dynamic polarizability moments")
+    def build_dp_moments(self):
+        """
+        Build the moments of the dynamic polarizability for optical
+        spectra calculations.
+
+        Notes
+        -----
+        Placeholder for future implementation.
+        """
+        raise NotImplementedError
+
+    @logging.with_timer("Inverse density-density moment")
+    @logging.with_status("Constructing inverse density-density moment")
+    def build_dd_moment_inv(self):
+        r"""
+        Build the first inverse (`n=-1`) moment of the density-density
+        response.
+
+        Notes
+        -----
+        Placeholder for future implementation.
+        """
+        raise NotImplementedError
+
     @property
     def nov(self):
-        """Number of ov states in the screened Coulomb interaction."""
+        """
+        Get the number of ov states in the screened Coulomb interaction.
+        """
         return (
             np.sum(self.mo_occ_w[0] > 0) * np.sum(self.mo_occ_w[0] == 0),
             np.sum(self.mo_occ_w[1] > 0) * np.sum(self.mo_occ_w[1] == 0),

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -498,7 +498,7 @@ def einsum(*operands, **kwargs):
     ----------
     operands : list
         Any valid input to `numpy.einsum`.
-    out : ndarray, optional
+    out : numpy.ndarray, optional
         If provided, the calculation is done into this array.
     contract : callable, optional
         The function to use for contraction. Default value is
@@ -509,7 +509,7 @@ def einsum(*operands, **kwargs):
 
     Returns
     -------
-    output : ndarray
+    output : numpy.ndarray
         The calculation based on the Einstein summation convention.
 
     See Also

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -31,8 +31,6 @@ class Timer:
         self.t_prev, self.t_curr = self.t_curr, time.perf_counter()
         return self.t_curr - self.t_prev
 
-    __call__ = lap
-
     def total(self):
         """Return the total time since initialization.
 
@@ -78,6 +76,8 @@ class Timer:
             out.append("%3d ms" % milliseconds)
 
         return " ".join(out[-max(precision, len(out)) :])
+
+    __call__ = lap
 
 
 class DIIS(lib.diis.DIIS):

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -21,25 +21,52 @@ class Timer:
         self.t_curr = time.perf_counter()
 
     def lap(self):
-        """Return the time since the last call to `lap`."""
+        """Return the time since the last call to `lap`.
+
+        Returns
+        -------
+        lap : float
+            Lap time.
+        """
         self.t_prev, self.t_curr = self.t_curr, time.perf_counter()
         return self.t_curr - self.t_prev
 
     __call__ = lap
 
     def total(self):
-        """Return the total time since initialization."""
+        """Return the total time since initialization.
+
+        Returns
+        -------
+        total : float
+            Total time.
+        """
         return time.perf_counter() - self.t_init
 
     @staticmethod
     def format_time(seconds, precision=2):
-        """Return a formatted time."""
+        """Return a formatted time.
 
+        Parameters
+        ----------
+        seconds : float
+            Time in seconds.
+        precision : int, optional
+            Number of time units to display. Default is `2`.
+
+        Returns
+        -------
+        formatted : str
+            Formatted time.
+        """
+
+        # Get the time in hours, minutes, seconds, and milliseconds
         seconds, milliseconds = divmod(seconds, 1)
         milliseconds *= 1000
         minutes, seconds = divmod(seconds, 60)
         hours, minutes = divmod(minutes, 60)
 
+        # Format the time
         out = []
         if hours:
             out.append("%3d h" % hours)
@@ -57,14 +84,16 @@ class DIIS(lib.diis.DIIS):
     """
     Direct inversion of the iterative subspace (DIIS).
 
-    See `pyscf.lib.diis.DIIS` for more information.
-
     Notes
     -----
     For some reason, the default pyscf DIIS object can result in fully
     linearly dependent error vectors in high-moment self-consistent
     calculations. This class is a drop-in replacement with a fallback
     in this case.
+
+    See Also
+    --------
+    pyscf.lib.diis.DIIS : PySCF DIIS object which this class extends.
     """
 
     def update_with_scaling(self, x, axis, xerr=None):
@@ -92,6 +121,7 @@ class DIIS(lib.diis.DIIS):
         several orders of magnitude.
         """
 
+        # Find the scale of the matrices
         scale = np.max(np.abs(x), axis=axis, keepdims=True)
         scale[scale == 0] = 1
 
@@ -126,9 +156,11 @@ class DIIS(lib.diis.DIIS):
             Updated array.
         """
 
+        # Check if the object is complex
         if not np.iscomplexobj(x):
             return self.update(x, xerr=xerr)
 
+        # Get the shape
         shape = x.shape
         size = x.size
 
@@ -165,17 +197,25 @@ class DIIS(lib.diis.DIIS):
         -----
         This function improves the robustness of the DIIS procedure in
         the event of linear dependencies.
+
+        See Also
+        --------
+        pyscf.lib.diis.DIIS.extrapolate :
+            PySCF DIIS extrapolation which this function refactors.
         """
 
+        # Get the number of vectors
         if nd is None:
             nd = self.get_num_vec()
         if nd == 0:
             raise RuntimeError("No vector found in DIIS object.")
 
+        # Get the Hessian
         h = self._H[: nd + 1, : nd + 1]
         g = np.zeros(nd + 1, h.dtype)
         g[0] = 1
 
+        # Solve the linear system
         w, v = scipy.linalg.eigh(h)
         if np.any(abs(w) < 1e-14):
             idx = abs(w) > 1e-14
@@ -186,9 +226,11 @@ class DIIS(lib.diis.DIIS):
             except np.linalg.linalg.LinAlgError as e:
                 raise np.linalg.linalg.LinAlgError("DIIS matrix is singular.") from e
 
+        # Check for linear dependencies
         if np.all(abs(c) < 1e-14):
             raise np.linalg.linalg.LinAlgError("DIIS vectors are fully linearly dependent.")
 
+        # Extrapolate
         xnew = 0.0
         for i, ci in enumerate(c[1:]):
             xnew += self.get_vec(i) * ci
@@ -256,7 +298,6 @@ def list_union(*args):
     out : list
         Union of the lists.
     """
-
     cache = set()
     out = []
     for arg in args:
@@ -264,7 +305,6 @@ def list_union(*args):
             if x not in cache:
                 cache.add(x)
                 out.append(x)
-
     return out
 
 
@@ -292,14 +332,17 @@ def build_1h1p_energies(mo_energy, mo_occ):
         Array of 1h1p energies.
     """
 
+    # Check if the input is a tuple
     if not isinstance(mo_energy, tuple):
         mo_energy = (mo_energy, mo_energy)
     if not isinstance(mo_occ, tuple):
         mo_occ = (mo_occ, mo_occ)
 
+    # Get the occupied and virtual energies
     e_occ = mo_energy[0][mo_occ[0] > 0]
     e_vir = mo_energy[1][mo_occ[1] == 0]
 
+    # Construct the energy differences
     d = lib.direct_sum("a-i->ia", e_vir, e_occ)
 
     return d
@@ -468,6 +511,10 @@ def einsum(*operands, **kwargs):
     -------
     output : ndarray
         The calculation based on the Einstein summation convention.
+
+    See Also
+    --------
+    numpy.einsum : NumPy's `einsum` function.
     """
 
     # Parse the input

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -329,7 +329,7 @@ def build_1h1p_energies(mo_energy, mo_occ):
     Returns
     -------
     d : numpy.ndarray
-        Array of 1h1p energies.
+        1h1p energies.
     """
 
     # Check if the input is a tuple


### PR DESCRIPTION
This PR improves docstrings:

- Adds some stub methods instead of blind inheritance, so that we can alter the docstrings (i.e. if an RHF and UHF or molecular and PBC code are the same, we want to inherit, but we want to change the description of the arguments to include tuples over spin and/or k-points)
- Reorders class methods and introduces `ssort` as a formatter
- More detail and consistent formatting for all docstrings

I'm not happy with how `ssort` orders things, it topologically sorts based on dependencies of functions. This means that the sort is not the same when there is inheritance. It's not configurable and I can't find another package so I may just hand order the functions in our classes and not lint for it. I'd propose the order:

```
docstring
fields
meta dunder methods (`__new__`, `__init__`, ...)
name (property)
kernel
public methods (inc. static and class)
private methods
other properties
other dunder methods
```