### PR TITLE
Fix scaled DIIS

### DIFF
--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -88,8 +88,7 @@ def kernel(
             try:
                 x, xerr = gw._prepare_diis_input(th, th_prev, tp, tp_prev)
                 th, tp = diis.update(x, xerr=xerr)
-            except Exception as e:
-                raise e
+            except:
                 logging.warn(f"DIIS step [red]failed[/] at iteration {cycle}")
 
             # Damp the moments
@@ -331,9 +330,9 @@ class evGW(GW):
         xerr = x - xprev if xprev is not None else None
 
         # Scale the error array
-        scale = np.max(np.abs(x), axis=-3, keepdims=True)
-        scale[scale < 1.0] = 1.0
         if xerr is not None:
+            scale = np.max(np.abs(x), axis=(-1, -2), keepdims=True)
+            scale[scale == 0] = 1.0
             xerr /= scale
 
         return x, xerr

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -86,9 +86,10 @@ def kernel(
 
             # Extrapolate the moments
             try:
-                x, xerr = self._prepare_diis_input(th, th_prev, tp, tp_prev)
+                x, xerr = gw._prepare_diis_input(th, th_prev, tp, tp_prev)
                 th, tp = diis.update(x, xerr=xerr)
-            except Exception:
+            except Exception as e:
+                raise e
                 logging.warn(f"DIIS step [red]failed[/] at iteration {cycle}")
 
             # Damp the moments
@@ -331,7 +332,8 @@ class evGW(GW):
 
         # Scale the error array
         scale = np.max(np.abs(x), axis=-3, keepdims=True)
-        scale[scale < 1e-8] = 1.0
-        xerr /= scale
+        scale[scale < 1.0] = 1.0
+        if xerr is not None:
+            xerr /= scale
 
         return x, xerr

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -88,7 +88,7 @@ def kernel(
             try:
                 x, xerr = gw._prepare_diis_input(th, th_prev, tp, tp_prev)
                 th, tp = diis.update(x, xerr=xerr)
-            except:
+            except Exception:
                 logging.warn(f"DIIS step [red]failed[/] at iteration {cycle}")
 
             # Damp the moments

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -86,7 +86,8 @@ def kernel(
 
             # Extrapolate the moments
             try:
-                th, tp = diis.update_with_scaling(np.array((th, tp)), (-2, -1))
+                x, xerr = self._prepare_diis_input(th, th_prev, tp, tp_prev)
+                th, tp = diis.update(x, xerr=xerr)
             except Exception:
                 logging.warn(f"DIIS step [red]failed[/] at iteration {cycle}")
 
@@ -297,3 +298,40 @@ class evGW(GW):
             Green's function, with potentially fewer poles.
         """
         return gf.physical(weight=self.weight_tol)
+
+    def _prepare_diis_input(self, th, th_prev, tp, tp_prev):
+        """Prepare the input arrays for the DIIS extrapolation.
+
+        Parameters
+        ----------
+        th : numpy.ndarray
+            Moments of the occupied self-energy.
+        th_prev : numpy.ndarray
+            Moments of the occupied self-energy from the previous
+            iteration.
+        tp : numpy.ndarray
+            Moments of the virtual self-energy.
+        tp_prev : numpy.ndarray
+            Moments of the virtual self-energy from the previous iteration.
+
+        Returns
+        -------
+        x : numpy.ndarray
+            Array to extrapolate using DIIS.
+        xerr : numpy.ndarray
+            Array of errors for the DIIS extrapolation.
+        """
+
+        # Get the array to extrapolate
+        x = np.array((th, tp))
+
+        # Get the error array
+        xprev = np.array((th_prev, tp_prev)) if th_prev is not None else None
+        xerr = x - xprev if xprev is not None else None
+
+        # Scale the error array
+        scale = np.max(np.abs(x), axis=-3, keepdims=True)
+        scale[scale < 1e-8] = 1.0
+        xerr /= scale
+
+        return x, xerr

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -3,8 +3,6 @@ Spin-restricted self-consistent GW via self-energy moment constraitns
 for molecular systems.
 """
 
-import numpy as np
-
 from momentGW import logging, util
 from momentGW.evgw import evGW
 
@@ -99,7 +97,7 @@ def kernel(
 
             # Extrapolate the moments
             try:
-                x, xerr = self._prepare_diis_input(th, th_prev, tp, tp_prev)
+                x, xerr = gw._prepare_diis_input(th, th_prev, tp, tp_prev)
                 th, tp = diis.update(x, xerr=xerr)
             except Exception:
                 logging.warn(f"DIIS step [red]failed[/] at iteration {cycle}")

--- a/momentGW/scgw.py
+++ b/momentGW/scgw.py
@@ -99,7 +99,8 @@ def kernel(
 
             # Extrapolate the moments
             try:
-                th, tp = diis.update_with_scaling(np.array((th, tp)), (-2, -1))
+                x, xerr = self._prepare_diis_input(th, th_prev, tp, tp_prev)
+                th, tp = diis.update(x, xerr=xerr)
             except Exception:
                 logging.warn(f"DIIS step [red]failed[/] at iteration {cycle}")
 

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -96,48 +96,6 @@ class DIIS(lib.diis.DIIS):
     pyscf.lib.diis.DIIS : PySCF DIIS object which this class extends.
     """
 
-    def update_with_scaling(self, x, axis, xerr=None):
-        """
-        Scales the arrays, according to the maximum absolute value along
-        given axis, executes DIIS, and then rescales the output.
-
-        Parameters
-        ----------
-        x : numpy.ndarray
-            Array to update with DIIS.
-        axis : int or tuple
-            Axis or axes along which to scale.
-        xerr : numpy.ndarray, optional
-            Error metric for the array. Default is `None`.
-
-        Returns
-        -------
-        x : numpy.ndarray
-            Updated array.
-
-        Notes
-        -----
-        This function is useful for extrapolations on moments which span
-        several orders of magnitude.
-        """
-
-        # Find the scale of the matrices
-        scale = np.max(np.abs(x), axis=axis, keepdims=True)
-        scale[scale == 0] = 1
-
-        # Scale
-        x = x / scale
-        if xerr:
-            xerr = xerr / scale
-
-        # Execute DIIS
-        x = self.update(x, xerr=xerr)
-
-        # Rescale
-        x = x * scale
-
-        return x
-
     def update_with_complex_unravel(self, x, xerr=None):
         """
         Execute DIIS where the error vectors are unravelled to

--- a/tests/test_evgw.py
+++ b/tests/test_evgw.py
@@ -90,7 +90,7 @@ class Test_evGW(unittest.TestCase):
         self._test_regression("hf", dict(g0=True, damping=0.5), 1, ip, ea, "g0w")
 
     def test_regression_pbe_fock_loop(self):
-        ip = -0.281393565321
+        ip = -0.281393616901
         ea = 0.007257181880
         self._test_regression("pbe", dict(), 1, ip, ea, "pbe")
 

--- a/tests/test_gw.py
+++ b/tests/test_gw.py
@@ -41,7 +41,23 @@ class Test_GW(unittest.TestCase):
     def tearDownClass(cls):
         del cls.mol, cls.mf, cls.gw_exact
 
-    def test_vs_pyscf(self):
+    def test_vs_pyscf_vhf_df(self):
+        gw = GW(self.mf)
+        gw.diagonal_se = True
+        conv, gf, se, _ = gw.kernel(nmom_max=7)
+        gf = gf.physical(weight=1e-8)
+        self.assertAlmostEqual(
+            gf.occupied().energies.max(),
+            self.gw_exact.mo_energy[self.gw_exact.mo_occ > 0].max(),
+            2,
+        )
+        self.assertAlmostEqual(
+            gf.virtual().energies.min(),
+            self.gw_exact.mo_energy[self.gw_exact.mo_occ == 0].min(),
+            2,
+        )
+
+    def test_vs_pyscf_no_vhf_df(self):
         gw = GW(self.mf)
         gw.diagonal_se = True
         conv, gf, se, _ = gw.kernel(nmom_max=7)
@@ -212,11 +228,6 @@ class Test_GW(unittest.TestCase):
         ip = -0.273126988182
         ea = 0.005294015947
         self._test_regression("hf", dict(polarizability="dtda"), 7, ip, ea, "tda")
-
-    def test_regression_frozen(self):
-        ip = -0.271377851106
-        ea = 0.006362994649
-        self._test_regression("hf", dict(frozen=[0, 9, 10]), 3, ip, ea, "frozen")
 
 
 if __name__ == "__main__":

--- a/tests/test_scugw.py
+++ b/tests/test_scugw.py
@@ -296,7 +296,7 @@ class Test_scUGW_no_beta(unittest.TestCase):
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.1998469228)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.1998418470)
         self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5138875709)
 
 

--- a/tests/test_ugw.py
+++ b/tests/test_ugw.py
@@ -148,43 +148,6 @@ class Test_UGW_vs_RGW(unittest.TestCase):
         np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[0])
         np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[1])
 
-    def test_dtda_frozen(self):
-        rgw = GW(self.mf)
-        rgw.polarizability = "dtda"
-        rgw.frozen = [0]
-        rgw.kernel(5)
-
-        uhf = self.mf.to_uks()
-        uhf.with_df = self.mf.with_df
-
-        ugw = UGW(uhf)
-        ugw.frozen = [0]
-        ugw.kernel(5)
-
-        self.assertTrue(rgw.converged)
-        self.assertTrue(ugw.converged)
-
-        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[0])
-        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[1])
-
-    def test_drpa_frozen(self):
-        rgw = GW(self.mf)
-        rgw.frozen = [0]
-        rgw.kernel(5)
-
-        uhf = self.mf.to_uks()
-        uhf.with_df = self.mf.with_df
-
-        ugw = UGW(uhf)
-        ugw.frozen = [0]
-        ugw.kernel(5)
-
-        self.assertTrue(rgw.converged)
-        self.assertTrue(ugw.converged)
-
-        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[0])
-        np.testing.assert_allclose(rgw.qp_energy, ugw.qp_energy[1])
-
 
 class Test_UGW(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
We have been applying DIIS to moments by scaling the moments to account for the fact that they are on wildly different numerical ranges. I was originally doing something like:
```
moments = ...
moments_scaled = scale(moments)
moments_error = get_error(moments_scaled)
moments_scaled = diis(moments_scaled, moments_error)
moments = unscale(moments_scaled)
```
however this is also very numerically unstable. I've changed this to something like:
```
moments = ...
moments_error = get_error(moments)
moments_error_scaled = scale(moments_error)
moments = diis(moments, moments_error_scaled)
```
such that the DIIS coefficients are calculated using the scaled errors, but the moments that are therein linearly combined are never scaled/unscaled, avoiding the loss of precision.