### PR TITLE
Improve `_gf_to_mo_energy`

### DIFF
--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -637,21 +637,40 @@ class BaseGW(Base):
             Updated MO energies.
         """
 
+        # Initialise arrays
         check = set()
+        best_weights = np.zeros((gf.nphys,))
+        best_assignments = np.zeros((gf.nphys,), dtype=int)
         mo_energy = np.zeros((gf.nphys,))
 
-        for i in range(gf.nphys):
-            weights = gf.couplings[i] ** 2
-            arg = None
-            while arg is None or arg in check:
-                arg = np.argmax(weights)
-                weights[arg] = 0
-            mo_energy[i] = gf.energies[arg]
-            check.add(arg)
+        todo = set(range(gf.nphys))
+        while todo:
+            # Get the next index
+            i = todo.pop()
 
-        if len(check) != gf.nphys:
-            # TODO improve this warning
-            logging.warn("[bad]Inconsistent quasiparticle weights![/]")
+            # Get the weights on the ith orbital for each pole
+            weights = gf.couplings[i] * gf.couplings[i].conj()
+
+            while True:
+                # Get the pole with the largest weight
+                arg = np.argmax(weights)
+
+                # If the pole is already assigned, check if the current
+                # assignment is better. If it is, add the assigned state
+                # back to the todo list, otherwise get the next best
+                if arg in check:
+                    if weights[arg] > best_weights[i]:
+                        todo.add(best_assignments[i])
+                    else:
+                        weights[arg] = 0
+                        continue
+                break
+
+            # Assign the pole to the orbital
+            check.add(arg)
+            best_weights[i] = weights[arg]
+            best_assignments[i] = arg
+            mo_energy[i] = gf.energies[arg]
 
         return mo_energy
 

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -641,7 +641,11 @@ class BaseGW(Base):
         mo_energy = np.zeros((gf.nphys,))
 
         for i in range(gf.nphys):
-            arg = np.argmax(gf.couplings[i] ** 2)
+            weights = gf.couplings[i] ** 2
+            arg = None
+            while arg is None or arg in check:
+                arg = np.argmax(weights)
+                weights[arg] = 0
             mo_energy[i] = gf.energies[arg]
             check.add(arg)
 

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -239,21 +239,7 @@ class BaseKGW(BaseGW):
         mo_energy : numpy.ndarray
             Updated MO energies at each k-point.
         """
-
-        mo_energy = np.zeros_like(self.mo_energy)
-
-        for k in self.kpts.loop(1):
-            check = set()
-            for i in range(self.nmo):
-                weights = np.real(gf[k].couplings[i] * gf[k].couplings[i].conj())
-                arg = None
-                while arg is None or arg in check:
-                    arg = np.argmax(weights)
-                    weights[arg] = 0
-                mo_energy[k][i] = gf[k].energies[arg]
-                check.add(arg)
-
-        return mo_energy
+        return np.array([BaseGW._gf_to_mo_energy(self, g) for g in gf])
 
     @property
     def kpts(self):

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -245,13 +245,13 @@ class BaseKGW(BaseGW):
         for k in self.kpts.loop(1):
             check = set()
             for i in range(self.nmo):
-                arg = np.argmax(gf[k].couplings[i] * gf[k].couplings[i].conj())
+                weights = np.real(gf[k].couplings[i] * gf[k].couplings[i].conj())
+                arg = None
+                while arg is None or arg in check:
+                    arg = np.argmax(weights)
+                    weights[arg] = 0
                 mo_energy[k][i] = gf[k].energies[arg]
                 check.add(arg)
-
-            if len(check) != self.nmo:
-                # TODO improve this warning
-                logging.warn(f"[bad]Inconsistent quasiparticle weights at k-point {k}![/]")
 
         return mo_energy
 

--- a/momentGW/pbc/uhf/base.py
+++ b/momentGW/pbc/uhf/base.py
@@ -240,22 +240,7 @@ class BaseKUGW(BaseKGW, BaseUGW):
         mo_energy : numpy.ndarray
             Updated MO energies at each k-point for each spin channel.
         """
-
-        mo_energy = np.zeros_like(self.mo_energy)
-
-        for s, spin in enumerate(["α", "β"]):
-            for k in self.kpts.loop(1):
-                check = set()
-                for i in range(self.nmo[s]):
-                    weights = np.real(gf[s][k].couplings[i] * gf[s][k].couplings[i].conj())
-                    arg = None
-                    while arg is None or arg in check:
-                        arg = np.argmax(weights)
-                        weights[arg] = 0
-                    mo_energy[s][k][i] = gf[s][k].energies[arg]
-                    check.add(arg)
-
-        return mo_energy
+        return np.array([[BaseGW._gf_to_mo_energy(self, g) for g in gs] for gs in gf])
 
     @property
     def nmo(self):

--- a/momentGW/pbc/uhf/base.py
+++ b/momentGW/pbc/uhf/base.py
@@ -247,15 +247,13 @@ class BaseKUGW(BaseKGW, BaseUGW):
             for k in self.kpts.loop(1):
                 check = set()
                 for i in range(self.nmo[s]):
-                    arg = np.argmax(gf[s][k].couplings[i] * gf[s][k].couplings[i].conj())
+                    weights = np.real(gf[s][k].couplings[i] * gf[s][k].couplings[i].conj())
+                    arg = None
+                    while arg is None or arg in check:
+                        arg = np.argmax(weights)
+                        weights[arg] = 0
                     mo_energy[s][k][i] = gf[s][k].energies[arg]
                     check.add(arg)
-
-                if len(check) != self.nmo[s]:
-                    # TODO improve this warning
-                    logging.warn(
-                        f"[bad]Inconsistent quasiparticle weights for {spin} at k-point {k}![/]"
-                    )
 
         return mo_energy
 

--- a/momentGW/uhf/base.py
+++ b/momentGW/uhf/base.py
@@ -220,18 +220,4 @@ class BaseUGW(BaseGW):
         mo_energy : numpy.ndarray
             Updated MO energies for each spin channel.
         """
-
-        mo_energy = np.zeros_like(self.mo_energy)
-
-        for s, spin in enumerate(["α", "β"]):
-            check = set()
-            for i in range(self.nmo[s]):
-                weights = gf[s].couplings[i] * gf[s].couplings[i].conj()
-                arg = None
-                while arg is None or arg in check:
-                    arg = np.argmax(weights)
-                    weights[arg] = 0
-                mo_energy[s][i] = gf[s].energies[arg]
-                check.add(arg)
-
-        return mo_energy
+        return np.array([BaseGW._gf_to_mo_energy(self, g) for g in gf])

--- a/momentGW/uhf/base.py
+++ b/momentGW/uhf/base.py
@@ -226,12 +226,12 @@ class BaseUGW(BaseGW):
         for s, spin in enumerate(["α", "β"]):
             check = set()
             for i in range(self.nmo[s]):
-                arg = np.argmax(gf[s].couplings[i] * gf[s].couplings[i].conj())
+                weights = gf[s].couplings[i] * gf[s].couplings[i].conj()
+                arg = None
+                while arg is None or arg in check:
+                    arg = np.argmax(weights)
+                    weights[arg] = 0
                 mo_energy[s][i] = gf[s].energies[arg]
                 check.add(arg)
-
-            if len(check) != self.nmo[s]:
-                # TODO improve this warning
-                logging.warn(f"[bad]Inconsistent quasiparticle weights for {spin}![/]")
 
         return mo_energy


### PR DESCRIPTION
This PR improves the `_gf_to_mo_energy` functions. Originally these functions found the poles which best overlap with the MOs and used them as new MO energies, which allowed poles to be used multiple times for the same MO, introducing an artificial degeneracy in the new MO energies. This only happened for considerably non-Koopmans'-like states, and triggered the ambiguous `Inconsistent quasiparticle weights` warning.

The new implementation uses some heuristic to make unique assignments on each MO. This removes the aforementioned warning which is now impossible.

This PR also improves the inheritance for these functions such that there is a single implementation of the new algorithm in `BaseGW`.