### PR TITLE
Refactor solver options

### DIFF
--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -21,6 +21,7 @@ class Base:
         mo_energy=None,
         mo_coeff=None,
         mo_occ=None,
+        frozen=None,
         **kwargs,
     ):
         # Options
@@ -35,7 +36,7 @@ class Base:
         self._mo_energy = mo_energy
         self._mo_coeff = mo_coeff
         self._mo_occ = mo_occ
-        self.frozen = None
+        self.frozen = frozen
 
         # Logging
         init_logging()

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -272,7 +272,7 @@ class Base:
     def __getattr__(self, key):
         """
         Try to get an attribute from the `_opts` dictionary. If it is
-        not found, raise an AttributeError.
+        not found, raise an `AttributeError`.
 
         Parameters
         ----------
@@ -287,6 +287,21 @@ class Base:
         if key in self._opts:
             return self._opts[key]
         raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
+
+    def __setattr__(self, key, val):
+        """
+        Try to set an attribute from the `_opts` dictionary. If it is
+        not found, raise an `AttributeError`.
+
+        Parameters
+        ----------
+        key : str
+            Attribute key.
+        """
+        if key in self._opts:
+            self._opts[key] = val
+        else:
+            super().__setattr__(key, val)
 
 
 class BaseGW(Base):

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -72,8 +72,8 @@ class BSE(Base):
         Default value is `"singlet"`.
     """
 
-    _opts = OrderedDict(
-        **Base._opts,
+    _defaults = OrderedDict(
+        **Base._defaults,
         excitation="singlet",
         polarizability=None,
     )
@@ -488,8 +488,8 @@ class cpBSE(BSE):
         Default value is `"singlet"`.
     """
 
-    _opts = OrderedDict(
-        **BSE._opts,
+    _defaults = OrderedDict(
+        **BSE._defaults,
         scale=None,
         grid=None,
         eta=0.1,

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -3,6 +3,8 @@ Spin-restricted Bethe-Salpeter equation (BSE) via self-energy moment
 constraints for molecular systems.
 """
 
+from collections import OrderedDict
+
 import numpy as np
 from dyson import CPGF, MBLGF
 
@@ -70,12 +72,11 @@ class BSE(Base):
         Default value is `"singlet"`.
     """
 
-    # --- Default BSE options
-
-    excitation = "singlet"
-    polarizability = None
-
-    _opts = Base._opts + ["excitation", "polarizability"]
+    _opts = OrderedDict(
+        **Base._opts,
+        excitation="singlet",
+        polarizability=None,
+    )
 
     _kernel = kernel
 
@@ -487,13 +488,12 @@ class cpBSE(BSE):
         Default value is `"singlet"`.
     """
 
-    # --- Extra cpBSE options
-
-    scale = None
-    grid = None
-    eta = 0.1
-
-    _opts = BSE._opts + ["scale", "grid", "eta"]
+    _opts = OrderedDict(
+        **BSE._opts,
+        scale=None,
+        grid=None,
+        eta=0.1,
+    )
 
     def __init__(self, gw, **kwargs):
         super().__init__(gw, **kwargs)

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -188,8 +188,8 @@ class evGW(GW):
         which they are considered zero. Default value is `1e-11`.
     """
 
-    _opts = OrderedDict(
-        **GW._opts,
+    _defaults = OrderedDict(
+        **GW._defaults,
         g0=False,
         w0=False,
         max_cycle=50,

--- a/momentGW/evgw.py
+++ b/momentGW/evgw.py
@@ -3,6 +3,8 @@ Spin-restricted eigenvalue self-consistent GW via self-energy moment
 constraints for molecular systems.
 """
 
+from collections import OrderedDict
+
 import numpy as np
 
 from momentGW import logging, util
@@ -186,29 +188,18 @@ class evGW(GW):
         which they are considered zero. Default value is `1e-11`.
     """
 
-    # --- Extra evGW options
-
-    g0 = False
-    w0 = False
-    max_cycle = 50
-    conv_tol = 1e-8
-    conv_tol_moms = 1e-6
-    conv_logical = all
-    diis_space = 8
-    damping = 0.0
-    weight_tol = 1e-11
-
-    _opts = GW._opts + [
-        "g0",
-        "w0",
-        "max_cycle",
-        "conv_tol",
-        "conv_tol_moms",
-        "conv_logical",
-        "diis_space",
-        "damping",
-        "weight_tol",
-    ]
+    _opts = OrderedDict(
+        **GW._opts,
+        g0=False,
+        w0=False,
+        max_cycle=50,
+        conv_tol=1e-8,
+        conv_tol_moms=1e-6,
+        conv_logical=all,
+        diis_space=8,
+        damping=0.0,
+        weight_tol=1e-11,
+    )
 
     _kernel = kernel
 

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -2,6 +2,8 @@
 Fock matrix self-consistent loop.
 """
 
+from collections import OrderedDict
+
 import numpy as np
 import scipy
 from dyson import Lehmann
@@ -146,16 +148,14 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
 class BaseFockLoop:
     """Base class for Fock loops."""
 
-    _opts = []
-
-    # --- Default Fock loop options
-
-    fock_diis_space = 10
-    fock_diis_min_space = 1
-    conv_tol_nelec = 1e-6
-    conv_tol_rdm1 = 1e-8
-    max_cycle_inner = 100
-    max_cycle_outer = 20
+    _opts = OrderedDict(
+        fock_diis_space=10,
+        fock_diis_min_space=1,
+        conv_tol_nelec=1e-6,
+        conv_tol_rdm1=1e-8,
+        max_cycle_inner=100,
+        max_cycle_outer=20,
+    )
 
     def __init__(self, gw, gf=None, se=None, **kwargs):
         # Parameters
@@ -395,6 +395,25 @@ class BaseFockLoop:
     def nocc(self):
         """Get the number of occupied MOs."""
         return self.gw.nocc
+
+    def __getattr__(self, key):
+        """
+        Try to get an attribute from the `_opts` dictionary. If it is
+        not found, raise an AttributeError.
+
+        Parameters
+        ----------
+        key : str
+            Attribute key.
+
+        Returns
+        -------
+        value : any
+            Attribute value.
+        """
+        if key in self._opts:
+            return self._opts[key]
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
 
 
 class FockLoop(BaseFockLoop):

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -148,7 +148,7 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
 class BaseFockLoop:
     """Base class for Fock loops."""
 
-    _opts = OrderedDict(
+    _defaults = OrderedDict(
         fock_diis_space=10,
         fock_diis_min_space=1,
         conv_tol_nelec=1e-6,
@@ -162,10 +162,11 @@ class BaseFockLoop:
         self.gw = gw
 
         # Options
+        self._opts = self._defaults.copy()
         for key, val in kwargs.items():
-            if not hasattr(self, key):
+            if key not in self._opts:
                 raise AttributeError(f"{key} is not a valid option for {self.name}")
-            setattr(self, key, val)
+            self._opts[key] = val
 
         # Attributes
         self._h1e = None
@@ -399,7 +400,7 @@ class BaseFockLoop:
     def __getattr__(self, key):
         """
         Try to get an attribute from the `_opts` dictionary. If it is
-        not found, raise an AttributeError.
+        not found, raise an `AttributeError`.
 
         Parameters
         ----------
@@ -411,9 +412,24 @@ class BaseFockLoop:
         value : any
             Attribute value.
         """
-        if key in self._opts:
+        if key in self._defaults:
             return self._opts[key]
-        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
+        raise AttributeError
+
+    def __setattr__(self, key, val):
+        """
+        Try to set an attribute from the `_opts` dictionary. If it is
+        not found, raise an `AttributeError`.
+
+        Parameters
+        ----------
+        key : str
+            Attribute key.
+        """
+        if key in self._defaults:
+            self._opts[key] = val
+        else:
+            super().__setattr__(key, val)
 
 
 class FockLoop(BaseFockLoop):

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -3,6 +3,7 @@ Spin-restricted Fock matrix self-consistent GW via self-energy moment
 constraints for molecular systems.
 """
 
+import copy
 from collections import OrderedDict
 
 import numpy as np
@@ -69,8 +70,9 @@ def kernel(
 
     # Get the solver
     solver_options = {} if not gw.solver_options else gw.solver_options.copy()
-    for key in gw.solver._opts:
-        solver_options[key] = solver_options.get(key, getattr(gw, key, getattr(gw.solver, key)))
+    for key in gw.solver._defaults:
+        if key not in solver_options:
+            solver_options[key] = copy.deepcopy(gw._opts.get(key, gw.solver._defaults[key]))
     with logging.with_silent():
         subgw = gw.solver(gw._scf, **solver_options)
         subgw.frozen = gw.frozen
@@ -194,8 +196,8 @@ class fsGW(GW):
         empty `dict`.
     """
 
-    _opts = OrderedDict(
-        **GW._opts,
+    _defaults = OrderedDict(
+        **GW._defaults,
         max_cycle=50,
         conv_tol=1e-8,
         conv_tol_moms=1e-8,
@@ -205,8 +207,8 @@ class fsGW(GW):
         solver=GW,
         solver_options={},
     )
-    _opts["fock_loop"] = True
-    _opts["optimise_chempot"] = True
+    _defaults["fock_loop"] = True
+    _defaults["optimise_chempot"] = True
 
     _kernel = kernel
 

--- a/momentGW/fsgw.py
+++ b/momentGW/fsgw.py
@@ -3,6 +3,8 @@ Spin-restricted Fock matrix self-consistent GW via self-energy moment
 constraints for molecular systems.
 """
 
+from collections import OrderedDict
+
 import numpy as np
 
 from momentGW import logging, mpi_helper, util
@@ -192,32 +194,19 @@ class fsGW(GW):
         empty `dict`.
     """
 
-    # --- Default fsGW options
-
-    fock_loop = True
-    optimise_chempot = True
-
-    # --- Extra fsGW options
-
-    max_cycle = 50
-    conv_tol = 1e-8
-    conv_tol_moms = 1e-8
-    conv_logical = all
-    diis_space = 8
-    damping = 0.0
-    solver = GW
-    solver_options = {}
-
-    _opts = GW._opts + [
-        "max_cycle",
-        "conv_tol",
-        "conv_tol_moms",
-        "conv_logical",
-        "diis_space",
-        "damping",
-        "solver",
-        "solver_options",
-    ]
+    _opts = OrderedDict(
+        **GW._opts,
+        max_cycle=50,
+        conv_tol=1e-8,
+        conv_tol_moms=1e-8,
+        conv_logical=all,
+        diis_space=8,
+        damping=0.0,
+        solver=GW,
+        solver_options={},
+    )
+    _opts["fock_loop"] = True
+    _opts["optimise_chempot"] = True
 
     _kernel = kernel
 

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -3,6 +3,8 @@ Base class for moment-constrained GW solvers with periodic boundary
 conditions.
 """
 
+from collections import OrderedDict
+
 import numpy as np
 from pyscf.pbc.mp.kmp2 import get_nmo, get_nocc
 
@@ -55,17 +57,11 @@ class BaseKGW(BaseGW):
         `False`.
     """
 
-    # --- Default KGW options
-
-    compression = None
-
-    # --- Extra PBC options
-
-    fc = False
-
-    _opts = BaseGW._opts + [
-        "fc",
-    ]
+    _opts = OrderedDict(
+        **BaseGW._opts,
+        fc=False,
+    )
+    _opts["compression"] = None
 
     get_nmo = get_nmo
     get_nocc = get_nocc

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -57,11 +57,11 @@ class BaseKGW(BaseGW):
         `False`.
     """
 
-    _opts = OrderedDict(
-        **BaseGW._opts,
+    _defaults = OrderedDict(
+        **BaseGW._defaults,
         fc=False,
     )
-    _opts["compression"] = None
+    _defaults["compression"] = None
 
     get_nmo = get_nmo
     get_nocc = get_nocc

--- a/momentGW/pbc/evgw.py
+++ b/momentGW/pbc/evgw.py
@@ -83,7 +83,7 @@ class evKGW(KGW, evGW):
         which they are considered zero. Default value is `1e-11`.
     """
 
-    _opts = util.list_union(KGW._opts, evGW._opts)
+    _opts = util.dict_union(KGW._opts, evGW._opts)
 
     @property
     def name(self):

--- a/momentGW/pbc/evgw.py
+++ b/momentGW/pbc/evgw.py
@@ -83,7 +83,7 @@ class evKGW(KGW, evGW):
         which they are considered zero. Default value is `1e-11`.
     """
 
-    _opts = util.dict_union(KGW._opts, evGW._opts)
+    _defaults = util.dict_union(KGW._defaults, evGW._defaults)
 
     @property
     def name(self):

--- a/momentGW/pbc/fsgw.py
+++ b/momentGW/pbc/fsgw.py
@@ -80,6 +80,8 @@ class fsKGW(KGW, fsGW):
     """
 
     _defaults = util.dict_union(KGW._defaults, fsGW._defaults)
+    _defaults["fock_loop"] = True
+    _defaults["optimise_chempot"] = True
     _defaults["solver"] = KGW
 
     project_basis = staticmethod(qsKGW.project_basis)

--- a/momentGW/pbc/fsgw.py
+++ b/momentGW/pbc/fsgw.py
@@ -79,8 +79,8 @@ class fsKGW(KGW, fsGW):
         empty `dict`.
     """
 
-    _opts = util.dict_union(KGW._opts, fsGW._opts)
-    _opts["solver"] = KGW
+    _defaults = util.dict_union(KGW._defaults, fsGW._defaults)
+    _defaults["solver"] = KGW
 
     project_basis = staticmethod(qsKGW.project_basis)
     self_energy_to_moments = staticmethod(qsKGW.self_energy_to_moments)

--- a/momentGW/pbc/fsgw.py
+++ b/momentGW/pbc/fsgw.py
@@ -79,11 +79,8 @@ class fsKGW(KGW, fsGW):
         empty `dict`.
     """
 
-    # --- Default fsKGW options
-
-    solver = KGW
-
-    _opts = util.list_union(KGW._opts, fsGW._opts)
+    _opts = util.dict_union(KGW._opts, fsGW._opts)
+    _opts["solver"] = KGW
 
     project_basis = staticmethod(qsKGW.project_basis)
     self_energy_to_moments = staticmethod(qsKGW.self_energy_to_moments)

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -61,7 +61,7 @@ class KGW(BaseKGW, GW):
         `False`.
     """
 
-    _opts = util.list_union(BaseKGW._opts, GW._opts)
+    _opts = util.dict_union(BaseKGW._opts, GW._opts)
 
     @property
     def name(self):

--- a/momentGW/pbc/gw.py
+++ b/momentGW/pbc/gw.py
@@ -61,7 +61,7 @@ class KGW(BaseKGW, GW):
         `False`.
     """
 
-    _opts = util.dict_union(BaseKGW._opts, GW._opts)
+    _defaults = util.dict_union(BaseKGW._defaults, GW._defaults)
 
     @property
     def name(self):

--- a/momentGW/pbc/qsgw.py
+++ b/momentGW/pbc/qsgw.py
@@ -98,11 +98,8 @@ class qsKGW(KGW, qsGW):
         empty `dict`.
     """
 
-    # --- Default qsKGW options
-
-    solver = KGW
-
-    _opts = util.list_union(KGW._opts, qsGW._opts)
+    _opts = util.dict_union(KGW._opts, qsGW._opts)
+    _opts["solver"] = KGW
 
     check_convergence = evKGW.check_convergence
 

--- a/momentGW/pbc/qsgw.py
+++ b/momentGW/pbc/qsgw.py
@@ -98,8 +98,8 @@ class qsKGW(KGW, qsGW):
         empty `dict`.
     """
 
-    _opts = util.dict_union(KGW._opts, qsGW._opts)
-    _opts["solver"] = KGW
+    _defaults = util.dict_union(KGW._defaults, qsGW._defaults)
+    _defaults["solver"] = KGW
 
     check_convergence = evKGW.check_convergence
 

--- a/momentGW/pbc/scgw.py
+++ b/momentGW/pbc/scgw.py
@@ -72,7 +72,7 @@ class scKGW(KGW, scGW):
         Damping parameter. Default value is `0.0`.
     """
 
-    _opts = util.dict_union(KGW._opts, scGW._opts)
+    _defaults = util.dict_union(KGW._defaults, scGW._defaults)
 
     check_convergence = evKGW.check_convergence
     remove_unphysical_poles = evKGW.remove_unphysical_poles

--- a/momentGW/pbc/scgw.py
+++ b/momentGW/pbc/scgw.py
@@ -72,7 +72,7 @@ class scKGW(KGW, scGW):
         Damping parameter. Default value is `0.0`.
     """
 
-    _opts = util.list_union(KGW._opts, scGW._opts)
+    _opts = util.dict_union(KGW._opts, scGW._opts)
 
     check_convergence = evKGW.check_convergence
     remove_unphysical_poles = evKGW.remove_unphysical_poles

--- a/momentGW/pbc/uhf/evgw.py
+++ b/momentGW/pbc/uhf/evgw.py
@@ -84,7 +84,7 @@ class evKUGW(KUGW, evKGW, evUGW):
         which they are considered zero. Default value is `1e-11`.
     """
 
-    _opts = util.list_union(evKGW._opts, evKGW._opts, evUGW._opts)
+    _opts = util.dict_union(evKGW._opts, evKGW._opts, evUGW._opts)
 
     @property
     def name(self):

--- a/momentGW/pbc/uhf/evgw.py
+++ b/momentGW/pbc/uhf/evgw.py
@@ -84,7 +84,7 @@ class evKUGW(KUGW, evKGW, evUGW):
         which they are considered zero. Default value is `1e-11`.
     """
 
-    _opts = util.dict_union(evKGW._opts, evKGW._opts, evUGW._opts)
+    _defaults = util.dict_union(evKGW._defaults, evKGW._defaults, evUGW._defaults)
 
     @property
     def name(self):

--- a/momentGW/pbc/uhf/fsgw.py
+++ b/momentGW/pbc/uhf/fsgw.py
@@ -80,11 +80,8 @@ class fsKUGW(KUGW, fsKGW, fsUGW):
         empty `dict`.
     """
 
-    # --- Default fsKUGW options
-
-    solver = KUGW
-
-    _opts = util.list_union(KUGW._opts, fsKGW._opts, fsUGW._opts)
+    _opts = util.dict_union(KUGW._opts, fsKGW._opts, fsUGW._opts)
+    _opts["solver"] = KUGW
 
     project_basis = staticmethod(qsKUGW.project_basis)
     self_energy_to_moments = staticmethod(qsKUGW.self_energy_to_moments)

--- a/momentGW/pbc/uhf/fsgw.py
+++ b/momentGW/pbc/uhf/fsgw.py
@@ -80,8 +80,8 @@ class fsKUGW(KUGW, fsKGW, fsUGW):
         empty `dict`.
     """
 
-    _opts = util.dict_union(KUGW._opts, fsKGW._opts, fsUGW._opts)
-    _opts["solver"] = KUGW
+    _defaults = util.dict_union(KUGW._defaults, fsKGW._defaults, fsUGW._defaults)
+    _defaults["solver"] = KUGW
 
     project_basis = staticmethod(qsKUGW.project_basis)
     self_energy_to_moments = staticmethod(qsKUGW.self_energy_to_moments)

--- a/momentGW/pbc/uhf/fsgw.py
+++ b/momentGW/pbc/uhf/fsgw.py
@@ -81,6 +81,8 @@ class fsKUGW(KUGW, fsKGW, fsUGW):
     """
 
     _defaults = util.dict_union(KUGW._defaults, fsKGW._defaults, fsUGW._defaults)
+    _defaults["fock_loop"] = True
+    _defaults["optimise_chempot"] = True
     _defaults["solver"] = KUGW
 
     project_basis = staticmethod(qsKUGW.project_basis)

--- a/momentGW/pbc/uhf/gw.py
+++ b/momentGW/pbc/uhf/gw.py
@@ -61,7 +61,7 @@ class KUGW(BaseKUGW, KGW, UGW):
         `False`.
     """
 
-    _opts = util.list_union(BaseKUGW._opts, KGW._opts, UGW._opts)
+    _opts = util.dict_union(BaseKUGW._opts, KGW._opts, UGW._opts)
 
     @property
     def name(self):

--- a/momentGW/pbc/uhf/gw.py
+++ b/momentGW/pbc/uhf/gw.py
@@ -61,7 +61,7 @@ class KUGW(BaseKUGW, KGW, UGW):
         `False`.
     """
 
-    _opts = util.dict_union(BaseKUGW._opts, KGW._opts, UGW._opts)
+    _defaults = util.dict_union(BaseKUGW._defaults, KGW._defaults, UGW._defaults)
 
     @property
     def name(self):

--- a/momentGW/pbc/uhf/qsgw.py
+++ b/momentGW/pbc/uhf/qsgw.py
@@ -99,8 +99,8 @@ class qsKUGW(KUGW, qsKGW, qsUGW):
         empty `dict`.
     """
 
-    _opts = util.dict_union(KUGW._opts, qsKGW._opts, qsUGW._opts)
-    _opts["solver"] = KUGW
+    _defaults = util.dict_union(KUGW._defaults, qsKGW._defaults, qsUGW._defaults)
+    _defaults["solver"] = KUGW
 
     check_convergence = evKUGW.check_convergence
 

--- a/momentGW/pbc/uhf/qsgw.py
+++ b/momentGW/pbc/uhf/qsgw.py
@@ -99,11 +99,8 @@ class qsKUGW(KUGW, qsKGW, qsUGW):
         empty `dict`.
     """
 
-    # --- Default qsKUGW options
-
-    solver = KUGW
-
-    _opts = util.list_union(KUGW._opts, qsKGW._opts, qsUGW._opts)
+    _opts = util.dict_union(KUGW._opts, qsKGW._opts, qsUGW._opts)
+    _opts["solver"] = KUGW
 
     check_convergence = evKUGW.check_convergence
 

--- a/momentGW/pbc/uhf/scgw.py
+++ b/momentGW/pbc/uhf/scgw.py
@@ -73,7 +73,7 @@ class scKUGW(KUGW, scKGW, scUGW):
         Damping parameter. Default value is `0.0`.
     """
 
-    _opts = util.list_union(scKGW._opts, scKGW._opts, scUGW._opts)
+    _opts = util.dict_union(scKGW._opts, scKGW._opts, scUGW._opts)
 
     check_convergence = evKUGW.check_convergence
     remove_unphysical_poles = evKUGW.remove_unphysical_poles

--- a/momentGW/pbc/uhf/scgw.py
+++ b/momentGW/pbc/uhf/scgw.py
@@ -73,7 +73,7 @@ class scKUGW(KUGW, scKGW, scUGW):
         Damping parameter. Default value is `0.0`.
     """
 
-    _opts = util.dict_union(scKGW._opts, scKGW._opts, scUGW._opts)
+    _defaults = util.dict_union(scKGW._defaults, scKGW._defaults, scUGW._defaults)
 
     check_convergence = evKUGW.check_convergence
     remove_unphysical_poles = evKUGW.remove_unphysical_poles

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -3,6 +3,7 @@ Spin-restricted quasiparticle self-consistent GW via self-energy moment
 constraints for molecular systems.
 """
 
+import copy
 from collections import OrderedDict
 
 import numpy as np
@@ -78,8 +79,9 @@ def kernel(
 
     # Get the solver
     solver_options = {} if not gw.solver_options else gw.solver_options.copy()
-    for key in gw.solver._opts:
-        solver_options[key] = solver_options.get(key, getattr(gw, key, getattr(gw.solver, key)))
+    for key in gw.solver._defaults:
+        if key not in solver_options:
+            solver_options[key] = copy.deepcopy(gw._opts.get(key, gw.solver._defaults[key]))
     with logging.with_silent():
         subgw = gw.solver(gw._scf, **solver_options)
         subgw.frozen = gw.frozen
@@ -254,8 +256,8 @@ class qsGW(GW):
         empty `dict`.
     """
 
-    _opts = OrderedDict(
-        **GW._opts,
+    _defaults = OrderedDict(
+        **GW._defaults,
         max_cycle=50,
         max_cycle_qp=50,
         conv_tol=1e-8,

--- a/momentGW/qsgw.py
+++ b/momentGW/qsgw.py
@@ -3,6 +3,8 @@ Spin-restricted quasiparticle self-consistent GW via self-energy moment
 constraints for molecular systems.
 """
 
+from collections import OrderedDict
+
 import numpy as np
 from pyscf import lib
 
@@ -252,37 +254,22 @@ class qsGW(GW):
         empty `dict`.
     """
 
-    # --- Extra qsGW options
-
-    max_cycle = 50
-    max_cycle_qp = 50
-    conv_tol = 1e-8
-    conv_tol_moms = 1e-6
-    conv_tol_qp = 1e-8
-    conv_logical = all
-    diis_space = 8
-    diis_space_qp = 8
-    damping = 0.0
-    eta = 1e-1
-    srg = 0.0
-    solver = GW
-    solver_options = None
-
-    _opts = GW._opts + [
-        "max_cycle",
-        "max_cycle_qp",
-        "conv_tol",
-        "conv_tol_moms",
-        "conv_tol_qp",
-        "conv_logical",
-        "diis_space",
-        "diis_space_qp",
-        "damping",
-        "eta",
-        "srg",
-        "solver",
-        "solver_options",
-    ]
+    _opts = OrderedDict(
+        **GW._opts,
+        max_cycle=50,
+        max_cycle_qp=50,
+        conv_tol=1e-8,
+        conv_tol_moms=1e-6,
+        conv_tol_qp=1e-8,
+        conv_logical=all,
+        diis_space=8,
+        diis_space_qp=8,
+        damping=0.0,
+        eta=1e-1,
+        srg=0.0,
+        solver=GW,
+        solver_options={},
+    )
 
     _kernel = kernel
 

--- a/momentGW/uhf/evgw.py
+++ b/momentGW/uhf/evgw.py
@@ -80,7 +80,7 @@ class evUGW(UGW, evGW):
         which they are considered zero. Default value is `1e-11`.
     """
 
-    _opts = util.dict_union(UGW._opts, evGW._opts)
+    _defaults = util.dict_union(UGW._defaults, evGW._defaults)
 
     @property
     def name(self):

--- a/momentGW/uhf/evgw.py
+++ b/momentGW/uhf/evgw.py
@@ -80,7 +80,7 @@ class evUGW(UGW, evGW):
         which they are considered zero. Default value is `1e-11`.
     """
 
-    _opts = util.list_union(UGW._opts, evGW._opts)
+    _opts = util.dict_union(UGW._opts, evGW._opts)
 
     @property
     def name(self):

--- a/momentGW/uhf/fsgw.py
+++ b/momentGW/uhf/fsgw.py
@@ -76,11 +76,8 @@ class fsUGW(UGW, fsGW):
         empty `dict`.
     """
 
-    # --- Default fsUGW options
-
-    solver = UGW
-
-    _opts = util.list_union(UGW._opts, fsGW._opts)
+    _opts = util.dict_union(UGW._opts, fsGW._opts)
+    _opts["solver"] = UGW
 
     project_basis = staticmethod(qsUGW.project_basis)
     self_energy_to_moments = staticmethod(qsUGW.self_energy_to_moments)

--- a/momentGW/uhf/fsgw.py
+++ b/momentGW/uhf/fsgw.py
@@ -76,8 +76,8 @@ class fsUGW(UGW, fsGW):
         empty `dict`.
     """
 
-    _opts = util.dict_union(UGW._opts, fsGW._opts)
-    _opts["solver"] = UGW
+    _defaults = util.dict_union(UGW._defaults, fsGW._defaults)
+    _defaults["solver"] = UGW
 
     project_basis = staticmethod(qsUGW.project_basis)
     self_energy_to_moments = staticmethod(qsUGW.self_energy_to_moments)

--- a/momentGW/uhf/fsgw.py
+++ b/momentGW/uhf/fsgw.py
@@ -77,6 +77,8 @@ class fsUGW(UGW, fsGW):
     """
 
     _defaults = util.dict_union(UGW._defaults, fsGW._defaults)
+    _defaults["fock_loop"] = True
+    _defaults["optimise_chempot"] = True
     _defaults["solver"] = UGW
 
     project_basis = staticmethod(qsUGW.project_basis)

--- a/momentGW/uhf/qsgw.py
+++ b/momentGW/uhf/qsgw.py
@@ -94,11 +94,8 @@ class qsUGW(UGW, qsGW):
         empty `dict`.
     """
 
-    # --- Default qsUGW options
-
-    solver = UGW
-
-    _opts = util.list_union(UGW._opts, qsGW._opts)
+    _opts = util.dict_union(UGW._opts, qsGW._opts)
+    _opts["solver"] = UGW
 
     check_convergence = evUGW.check_convergence
 

--- a/momentGW/uhf/qsgw.py
+++ b/momentGW/uhf/qsgw.py
@@ -94,8 +94,8 @@ class qsUGW(UGW, qsGW):
         empty `dict`.
     """
 
-    _opts = util.dict_union(UGW._opts, qsGW._opts)
-    _opts["solver"] = UGW
+    _defaults = util.dict_union(UGW._defaults, qsGW._defaults)
+    _defaults["solver"] = UGW
 
     check_convergence = evUGW.check_convergence
 

--- a/momentGW/uhf/scgw.py
+++ b/momentGW/uhf/scgw.py
@@ -68,7 +68,7 @@ class scUGW(UGW, scGW):
         Damping parameter. Default value is `0.0`.
     """
 
-    _opts = util.dict_union(UGW._opts, scGW._opts)
+    _defaults = util.dict_union(UGW._defaults, scGW._defaults)
 
     check_convergence = evUGW.check_convergence
     remove_unphysical_poles = evUGW.remove_unphysical_poles

--- a/momentGW/uhf/scgw.py
+++ b/momentGW/uhf/scgw.py
@@ -68,7 +68,7 @@ class scUGW(UGW, scGW):
         Damping parameter. Default value is `0.0`.
     """
 
-    _opts = util.list_union(UGW._opts, scGW._opts)
+    _opts = util.dict_union(UGW._opts, scGW._opts)
 
     check_convergence = evUGW.check_convergence
     remove_unphysical_poles = evUGW.remove_unphysical_poles

--- a/momentGW/util.py
+++ b/momentGW/util.py
@@ -266,6 +266,31 @@ def list_union(*args):
     return out
 
 
+def dict_union(*args):
+    """
+    Find the union of a list of dictionaries, preserving the order
+    of the first occurrence of each key.
+
+    Parameters
+    ----------
+    args : list of dict
+        Dictionaries to find the union of.
+
+    Returns
+    -------
+    out : dict
+        Union of the dictionaries.
+    """
+    cache = set()
+    out = type(args[0])() if len(args) else {}
+    for arg in args:
+        for x in arg:
+            if x not in cache:
+                cache.add(x)
+                out[x] = arg[x]
+    return out
+
+
 def build_1h1p_energies(mo_energy, mo_occ):
     r"""
     Construct an array of 1h1p energies where elements are


### PR DESCRIPTION
Refactors the solver options internals, now each solver has

- `_defaults`: determined at class declaration, contains the default options for the solver
- `_opts`: set at object initialisation, copied from `_defaults` and updated accordingly

`__getattr__` and `__setattr__` are implemented on the `Base` class so that nothing API-related changes. This slightly cleaner but also facilitates `sphinx` documentation i've been messing with a bit better.