### PR TITLE
Add hooks for converting the mean-field

### DIFF
--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -12,6 +12,10 @@ class Base:
 
     _opts = []
 
+    def _convert_mf(self, mf):
+        """Abstract method for converting the mean-field object."""
+        raise NotImplementedError
+
     def __init__(
         self,
         mf,
@@ -21,7 +25,7 @@ class Base:
         **kwargs,
     ):
         # Parameters
-        self._scf = mf
+        self._scf = self._convert_mf(mf)
         self._mo_energy = mo_energy
         self._mo_coeff = mo_coeff
         self._mo_occ = mo_occ
@@ -512,6 +516,25 @@ class BaseGW(Base):
         panel = logging.Panel(table, title="Summary", padding=(1, 2), expand=False)
 
         return panel
+
+    def _convert_mf(self, mf):
+        """Convert the mean-field object to the correct spin.
+
+        Parameters
+        ----------
+        mf : pyscf.scf.SCF
+            PySCF mean-field class.
+
+        Returns
+        -------
+        mf : pyscf.scf.SCF
+            PySCF mean-field class in the correct spin.
+        """
+        if hasattr(mf, "xc"):
+            mf = mf.to_rks()
+        else:
+            mf = mf.to_rhf()
+        return mf
 
     @logging.with_timer("Kernel")
     def kernel(

--- a/momentGW/bse.py
+++ b/momentGW/bse.py
@@ -398,6 +398,25 @@ class BSE(Base):
 
         return panel
 
+    def _convert_mf(self, mf):
+        """Convert the mean-field object to the correct spin.
+
+        Parameters
+        ----------
+        mf : pyscf.scf.SCF
+            PySCF mean-field class.
+
+        Returns
+        -------
+        mf : pyscf.scf.SCF
+            PySCF mean-field class in the correct spin.
+        """
+        if hasattr(mf, "xc"):
+            mf = mf.to_rks()
+        else:
+            mf = mf.to_rhf()
+        return mf
+
     @logging.with_timer("Kernel")
     def kernel(
         self,

--- a/momentGW/uhf/base.py
+++ b/momentGW/uhf/base.py
@@ -145,6 +145,25 @@ class BaseUGW(BaseGW):
 
         return table
 
+    def _convert_mf(self, mf):
+        """Convert the mean-field object to the correct spin.
+
+        Parameters
+        ----------
+        mf : pyscf.scf.SCF
+            PySCF mean-field class.
+
+        Returns
+        -------
+        mf : pyscf.scf.SCF
+            PySCF mean-field class in the correct spin.
+        """
+        if hasattr(mf, "xc"):
+            mf = mf.to_uks()
+        else:
+            mf = mf.to_uhf()
+        return mf
+
     @staticmethod
     def _gf_to_occ(gf):
         """


### PR DESCRIPTION
Adds a `_convert_mf` method that is called as
```
self._scf = self._convert_mf(mf)
```
when initialising the solvers.  This allows one to i.e. call `UGW(mf)` where `mf` is restricted, and the solver will first convert it to unrestricted.