### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: local
+  hooks:
+  - id: ssort
+  - id: isort
+  - id: black
+  - id: flake8

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,23 @@
+- id: ssort
+  name: Sort declarations (ssort)
+  entry: ssort
+  language: system
+  files: \.(py)$
+
+- id: isort
+  name: Sort imports (isort)
+  entry: isort
+  language: system
+  files: \.(py)$
+
+- id: black
+  name: Black
+  entry: black
+  language: system
+  files: \.(py)$
+
+- id: flake8
+  name: Flake8
+  entry: flake8
+  language: system
+  files: momentGW/

--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ The data presented in the publications can be found in the `benchmark` directory
 
 Contributions are welcome, and can be made by submitting a pull request to the `master` branch.
 The code uses [NumPy-style docstrings](https://numpydoc.readthedocs.io/en/latest/format.html) and is formatted using [`black`](https://black.readthedocs.io/en/stable/), [`isort`](https://pycqa.github.io/isort/), [`ssort`](https://github.com/bwhmather/ssort), and [`flake8`](https://flake8.pycqa.org/en/latest/).
+The package includes pre-commit hooks to apply these formatting rules.
+To install the necessary packages for development, install the package with the `dev` extra:
+```bash
+python -m pip install .[dev] --user
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "pytest>=6.2.4",
     "pytest-cov>=4.0.0",
     "pytest-env>=1.1.0",
+    "pre-commit>=2.15.0",
 ]
 mpi = [
     "mpi4py>=3.1.0",


### PR DESCRIPTION
Adds pre-commit hooks to execute the formatting and linting stack before the commit. For `ssort`, `isort`, and `black`, this will change the committed code. I believe for `flake8` this will just prevent a commit in the case of errors.

Note that you'll need to run
```
pip install pre-commit
pre-commit install
```
to get them working.