### PR TITLE
Add support for GF2

### DIFF
--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -59,6 +59,7 @@ from momentGW.logging import init_logging, console, dump_times
 
 from momentGW.tda import dTDA
 from momentGW.rpa import dRPA
+from momentGW.gf2 import GF2
 
 from momentGW.gw import GW
 from momentGW.bse import BSE, cpBSE

--- a/momentGW/__init__.py
+++ b/momentGW/__init__.py
@@ -59,7 +59,6 @@ from momentGW.logging import init_logging, console, dump_times
 
 from momentGW.tda import dTDA
 from momentGW.rpa import dRPA
-from momentGW.gf2 import GF2
 
 from momentGW.gw import GW
 from momentGW.bse import BSE, cpBSE
@@ -67,6 +66,7 @@ from momentGW.evgw import evGW
 from momentGW.qsgw import qsGW
 from momentGW.fsgw import fsGW
 from momentGW.scgw import scGW
+from momentGW.gf2 import G0F2, evGF2, qsGF2, fsGF2, GF2
 
 from momentGW.pbc.gw import KGW
 from momentGW.pbc.evgw import evKGW

--- a/momentGW/gf2.py
+++ b/momentGW/gf2.py
@@ -1,0 +1,129 @@
+"""
+Construct GF2 self-energy moments.
+"""
+
+import numpy as np
+
+from momentGW import logging, mpi_helper, util
+
+
+class GF2:
+    """
+    Compute the GF2 self-energy moments.
+
+    This follows the same structure as the dTDA and dRPA classes,
+    allowing conversion of the GW solvers to GF2 solvers.
+
+    Parameters
+    ----------
+    gw : BaseGW
+        GW object.
+    nmom_max : int
+        Maximum moment number to calculate.
+    integrals : Integrals
+        Density-fitted integrals.
+    mo_energy : dict, optional
+        Molecular orbital energies. Keys are "g" and "w" for the Green's
+        function and screened Coulomb interaction, respectively.
+        If `None`, use `gw.mo_energy` for both. Default value is `None`.
+    mo_occ : dict, optional
+        Molecular orbital occupancies. Keys are "g" and "w" for the
+        Green's function and screened Coulomb interaction, respectively.
+        If `None`, use `gw.mo_occ` for both. Default value is `None`.
+    """
+
+    def __init__(self, *args, non_dyson=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.non_dyson = non_dyson
+
+        # Check the MO energies and occupancies
+        if not (
+            np.allclose(self.mo_energy["g"], self.mo_energy["w"])
+            and np.allclose(self.mo_occ["g"], self.mo_occ["w"])
+        ):
+            raise ValueError(
+                "MO energies for Green's function and screened Coulomb "
+                f"interaction must be the same for {self.__class__.__name__}."
+            )
+
+    def kernel(self):
+        """
+        Run the polarizability calculation to compute moments of the
+        self-energy.
+
+        Returns
+        -------
+        moments_occ : numpy.ndarray
+            Moments of the occupied self-energy.
+        moments_vir : numpy.ndarray
+            Moments of the virtual self-energy.
+        """
+        return self.build_se_moments()
+
+    @logging.with_timer("Self-energy moments")
+    @logging.with_status("Constructing self-energy moments")
+    def build_se_moments(self):
+        """Build the moments of the self-energy.
+
+        Returns
+        -------
+        moments_occ : numpy.ndarray
+            Moments of the occupied self-energy.
+        moments_vir : numpy.ndarray
+            Moments of the virtual self-energy.
+        """
+
+        # Setup dependent on diagonal SE
+        if self.gw.diagonal_se:
+            pq = p = q = "p"
+            fproc = lambda x: np.diag(x)
+        else:
+            pq, p, q = "pq", "p", "q"
+            fproc = lambda x: x
+
+        # Get the physical space mask
+        if self.non_dyson:
+            po = slice(None, np.sum(self.mo_occ_g > 0))
+            pv = slice(np.sum(self.mo_occ_g > 0), None)
+        else:
+            po = slice(None)
+            pv = slice(None)
+
+        # Initialise output moments
+        moments_occ = np.zeros((self.nmom_max + 1, self.nmo, self.nmo))
+        moments_vir = np.zeros((self.nmom_max + 1, self.nmo, self.nmo))
+
+        # Get the energies
+        e_i = self.mo_energy_g[self.mo_occ_g > 0]
+        e_a = self.mo_energy_g[self.mo_occ_g == 0]
+
+        # Get the occupied moments
+        for i in range(*self.mpi_slice(e_i.size)):
+            pija = util.einsum("Pp,Pja->pja", self.integrals.Lpx[po, :, i], self.integrals.Lia)
+            pjia = util.einsum("Ppj,Pa->pja", self.integrals.Lpx[po], self.integrals.Lia[:, i])
+            pjia = 2 * pija - pjia
+            e_ija = e_i[i] + util.direct_sum("j,a->ja", e_i, -e_a)
+
+            # Loop over orders
+            for n in range(self.nmom_max + 1):
+                moments_occ[n, po, po] += fproc(util.einsum(f"{p}ja,{q}ja->{pq}", pija, pjia))
+                if n != self.nmom_max:
+                    pija = util.einsum("pja,ja->pja", pija, e_ija)
+
+        # Get the virtual moments
+        for a in range(*self.mpi_slice(e_a.size)):
+            pabi = util.einsum("Pp,Pbi->pbi", self.integrals.Lpx[pv, :, a], self.integrals.Lia)
+            pbai = util.einsum("Ppb,Pi->pbi", self.integrals.Lpx[pv], self.integrals.Lia[:, a])
+            pbai = 2 * pabi - pbai
+            e_abi = e_a[a] - util.direct_sum("b,i->bi", e_a, -e_i)
+
+            # Loop over orders
+            for n in range(self.nmom_max + 1):
+                moments_vir[n, pv, pv] += fproc(util.einsum(f"{p}bi,{q}bi->{pq}", pabi, pbai))
+                if n != self.nmom_max:
+                    pabi = util.einsum("pbi,bi->pbi", pabi, e_abi)
+
+        moments_occ = mpi_helper.allreduce(moments_occ)
+        moments_vir = mpi_helper.allreduce(moments_vir)
+
+        return moments_occ, moments_vir

--- a/momentGW/gf2.py
+++ b/momentGW/gf2.py
@@ -134,8 +134,8 @@ class GF2:
 
         # Get the occupied moments
         for i in range(*self.mpi_slice(e_i.size)):
-            pija = util.einsum("Pp,Pja->pja", self.integrals.Lpx[po, :, i], Lia)
-            pjia = util.einsum("Ppj,Pa->pja", self.integrals.Lpx[po, :, : e_i.size], Lia[:, i])
+            pija = util.einsum("Pp,Pja->pja", self.integrals.Lpx[:, po, i], Lia)
+            pjia = util.einsum("Ppj,Pa->pja", self.integrals.Lpx[:, po, : e_i.size], Lia[:, i])
             pjia = 2 * pija - pjia
             e_ija = e_i[i] + e_i[:, None] - e_a[None, :]
 
@@ -147,8 +147,8 @@ class GF2:
 
         # Get the virtual moments
         for a in range(*self.mpi_slice(e_a.size)):
-            pabi = util.einsum("Pp,Pbi->pbi", self.integrals.Lpx[pv, :, e_i.size + a], Lai)
-            pbai = util.einsum("Ppb,Pi->pbi", self.integrals.Lpx[pv, :, e_i.size :], Lai[:, a])
+            pabi = util.einsum("Pp,Pbi->pbi", self.integrals.Lpx[:, pv, e_i.size + a], Lai)
+            pbai = util.einsum("Ppb,Pi->pbi", self.integrals.Lpx[:, pv, e_i.size :], Lai[:, a])
             pbai = 2 * pabi - pbai
             e_abi = e_a[a] + e_a[:, None] - e_i[None, :]
 

--- a/momentGW/gf2.py
+++ b/momentGW/gf2.py
@@ -32,19 +32,50 @@ class GF2:
         If `None`, use `gw.mo_occ` for both. Default value is `None`.
     """
 
-    def __init__(self, *args, non_dyson=True, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        gw,
+        nmom_max,
+        integrals,
+        mo_energy=None,
+        mo_occ=None,
+        non_dyson=False,
+    ):
+        self.gw = gw
+        self.nmom_max = nmom_max
+        self.integrals = integrals
         self.non_dyson = non_dyson
+
+        # Get the MO energies for G and W
+        if mo_energy is not None:
+            self.mo_energy_g = mo_energy["g"]
+            self.mo_energy_w = mo_energy["w"]
+        else:
+            self.mo_energy_g = self.mo_energy_w = gw.mo_energy
+
+        # Get the MO occupancies for G and W
+        if mo_occ is not None:
+            self.mo_occ_g = mo_occ["g"]
+            self.mo_occ_w = mo_occ["w"]
+        else:
+            self.mo_occ_g = self.mo_occ_w = gw.mo_occ
 
         # Check the MO energies and occupancies
         if not (
-            np.allclose(self.mo_energy["g"], self.mo_energy["w"])
-            and np.allclose(self.mo_occ["g"], self.mo_occ["w"])
+            np.allclose(self.mo_energy_g, self.mo_energy_w)
+            and np.allclose(self.mo_occ_g, self.mo_occ_w)
         ):
             raise ValueError(
                 "MO energies for Green's function and screened Coulomb "
                 f"interaction must be the same for {self.__class__.__name__}."
             )
+
+        # Options and thresholds
+        self.report_quadrature_error = True
+        if self.gw.compression and "ia" in self.gw.compression.split(","):
+            self.compression_tol = gw.compression_tol
+        else:
+            self.compression_tol = None
 
     def kernel(self):
         """
@@ -97,12 +128,16 @@ class GF2:
         e_i = self.mo_energy_g[self.mo_occ_g > 0]
         e_a = self.mo_energy_g[self.mo_occ_g == 0]
 
+        # Get the integrals
+        Lia = self.integrals.Lia.reshape(-1, e_i.size, e_a.size)
+        Lai = Lia.swapaxes(1, 2)
+
         # Get the occupied moments
         for i in range(*self.mpi_slice(e_i.size)):
-            pija = util.einsum("Pp,Pja->pja", self.integrals.Lpx[po, :, i], self.integrals.Lia)
-            pjia = util.einsum("Ppj,Pa->pja", self.integrals.Lpx[po], self.integrals.Lia[:, i])
+            pija = util.einsum("Pp,Pja->pja", self.integrals.Lpx[po, :, i], Lia)
+            pjia = util.einsum("Ppj,Pa->pja", self.integrals.Lpx[po, :, : e_i.size], Lia[:, i])
             pjia = 2 * pija - pjia
-            e_ija = e_i[i] + util.direct_sum("j,a->ja", e_i, -e_a)
+            e_ija = e_i[i] + e_i[:, None] - e_a[None, :]
 
             # Loop over orders
             for n in range(self.nmom_max + 1):
@@ -112,10 +147,10 @@ class GF2:
 
         # Get the virtual moments
         for a in range(*self.mpi_slice(e_a.size)):
-            pabi = util.einsum("Pp,Pbi->pbi", self.integrals.Lpx[pv, :, a], self.integrals.Lia)
-            pbai = util.einsum("Ppb,Pi->pbi", self.integrals.Lpx[pv], self.integrals.Lia[:, a])
+            pabi = util.einsum("Pp,Pbi->pbi", self.integrals.Lpx[pv, :, e_i.size + a], Lai)
+            pbai = util.einsum("Ppb,Pi->pbi", self.integrals.Lpx[pv, :, e_i.size :], Lai[:, a])
             pbai = 2 * pabi - pbai
-            e_abi = e_a[a] - util.direct_sum("b,i->bi", e_a, -e_i)
+            e_abi = e_a[a] + e_a[:, None] - e_i[None, :]
 
             # Loop over orders
             for n in range(self.nmom_max + 1):
@@ -127,3 +162,50 @@ class GF2:
         moments_vir = mpi_helper.allreduce(moments_vir)
 
         return moments_occ, moments_vir
+
+    @property
+    def nmo(self):
+        """Number of MOs."""  # TODO: do we want fuller documentation?
+        return self.gw.nmo
+
+    @property
+    def naux(self):
+        """Number of auxiliaries."""
+        return self.integrals.naux
+
+    def mpi_slice(self, n):
+        """
+        Return the start and end index for the current process for total
+        size `n`.
+
+        Parameters
+        ----------
+        n : int
+            Total size.
+
+        Returns
+        -------
+        p0 : int
+            Start index for current process.
+        p1 : int
+            End index for current process.
+        """
+        return list(mpi_helper.prange(0, n, n))[0]
+
+    def mpi_size(self, n):
+        """
+        Return the number of states in the current process for total size
+        `n`.
+
+        Parameters
+        ----------
+        n : int
+            Total size.
+
+        Returns
+        -------
+        size : int
+            Number of states in current process.
+        """
+        p0, p1 = self.mpi_slice(n)
+        return p1 - p0

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -12,6 +12,7 @@ from momentGW.fock import FockLoop, search_chempot
 from momentGW.ints import Integrals
 from momentGW.rpa import dRPA
 from momentGW.tda import dTDA
+from momentGW.gf2 import GF2
 
 
 def kernel(
@@ -166,6 +167,10 @@ class GW(BaseGW):  # noqa: D101
         elif self.polarizability.lower() == "thc-dtda":
             tda = thc.dTDA(self, nmom_max, integrals, **kwargs)
             return tda.kernel()
+
+        elif self.polarizability.lower() == "gf2":
+            gf2 = GF2(self, nmom_max, integrals, **kwargs)
+            return gf2.kernel()
 
         else:
             raise NotImplementedError

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -169,7 +169,11 @@ class GW(BaseGW):  # noqa: D101
             return tda.kernel()
 
         elif self.polarizability.lower() == "gf2":
-            gf2 = GF2(self, nmom_max, integrals, **kwargs)
+            gf2 = GF2(self, nmom_max, integrals, non_dyson=False, **kwargs)
+            return gf2.kernel()
+
+        elif self.polarizability.lower() == "nd-gf2":
+            gf2 = GF2(self, nmom_max, integrals, non_dyson=True, **kwargs)
             return gf2.kernel()
 
         else:

--- a/momentGW/gw.py
+++ b/momentGW/gw.py
@@ -12,7 +12,6 @@ from momentGW.fock import FockLoop, search_chempot
 from momentGW.ints import Integrals
 from momentGW.rpa import dRPA
 from momentGW.tda import dTDA
-from momentGW.gf2 import GF2
 
 
 def kernel(
@@ -167,14 +166,6 @@ class GW(BaseGW):  # noqa: D101
         elif self.polarizability.lower() == "thc-dtda":
             tda = thc.dTDA(self, nmom_max, integrals, **kwargs)
             return tda.kernel()
-
-        elif self.polarizability.lower() == "gf2":
-            gf2 = GF2(self, nmom_max, integrals, non_dyson=False, **kwargs)
-            return gf2.kernel()
-
-        elif self.polarizability.lower() == "nd-gf2":
-            gf2 = GF2(self, nmom_max, integrals, non_dyson=True, **kwargs)
-            return gf2.kernel()
 
         else:
             raise NotImplementedError


### PR DESCRIPTION
Adds support for GF2:

- Classes for calculating self-energy moments (`dTDA`, `dRPA`) now inherit from `BaseSE`
- Adds `_GF2` classes that inherit from `BaseSE` and calculate self-energy moments at the level of second-order perturbation theory (no screening, with exchange)
- Adds stub methods inheriting GW classes for GF2, G0F2, evGF2, qsGF2, fsGF2

To-do:

- [x] RHF
- [ ] UHF
- [ ] RHF PBC
- [ ] UHF PBC
- [ ] Tests
- [ ] Examples