### PR TITLE
Property caching

### DIFF
--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -224,7 +224,9 @@ class Base:
         """Set the frozen orbitals."""
         if value is not None:
             self._frozen = np.asarray(value)
-        del self.nmo, self.nocc, self.active
+        for attr in ("nmo", "nocc", "active"):
+            if hasattr(self, attr):
+                delattr(self, attr)
 
     @property
     def mo_energy(self):
@@ -245,7 +247,9 @@ class Base:
         """Set the molecular orbital energies."""
         if value is not None:
             self._mo_energy = mpi_helper.bcast(np.asarray(value))
-        del self.nmo, self.nocc, self.active
+        for attr in ("nmo", "nocc", "active"):
+            if hasattr(self, attr):
+                delattr(self, attr)
 
     @property
     def mo_coeff(self):
@@ -266,7 +270,9 @@ class Base:
         """Set the molecular orbital coefficients."""
         if value is not None:
             self._mo_coeff = mpi_helper.bcast(np.asarray(value))
-        del self.nmo, self.nocc, self.active
+        for attr in ("nmo", "nocc", "active"):
+            if hasattr(self, attr):
+                delattr(self, attr)
 
     @property
     def mo_occ(self):
@@ -290,7 +296,9 @@ class Base:
         """Set the molecular orbital occupation numbers."""
         if value is not None:
             self._mo_occ = mpi_helper.bcast(np.asarray(value))
-        del self.nmo, self.nocc, self.active
+        for attr in ("nmo", "nocc", "active"):
+            if hasattr(self, attr):
+                delattr(self, attr)
 
     def __getattr__(self, key):
         """

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -2,6 +2,7 @@
 Base classes for moment-constrained GW solvers.
 """
 
+import functools
 from collections import OrderedDict
 
 import numpy as np
@@ -41,7 +42,7 @@ class Base:
         self._mo_energy = mo_energy
         self._mo_coeff = mo_coeff
         self._mo_occ = mo_occ
-        self.frozen = frozen
+        self._frozen = frozen
 
         # Logging
         init_logging()
@@ -178,7 +179,7 @@ class Base:
         """Get the number of atomic orbitals."""
         return self._scf.mol.nao
 
-    @property
+    @functools.cached_property
     def nmo(self):
         """Get the number of molecular orbitals."""
         frozen = self.frozen if self.frozen is not None else []
@@ -191,7 +192,7 @@ class Base:
             nmo = np.asarray(nmo).item()
         return nmo
 
-    @property
+    @functools.cached_property
     def nocc(self):
         """Get the number of occupied molecular orbitals."""
         frozen = self.frozen if self.frozen is not None else []
@@ -202,7 +203,7 @@ class Base:
         nocc -= sum(occ[..., i] > 0 for i in frozen)
         return nocc
 
-    @property
+    @functools.cached_property
     def active(self):
         """Get the mask to remove frozen orbitals."""
         frozen = self.frozen if self.frozen is not None else []
@@ -212,6 +213,18 @@ class Base:
         mask = np.ones((nmo,), dtype=bool)
         mask[frozen] = False
         return mask
+
+    @property
+    def frozen(self):
+        """Get the frozen orbitals."""
+        return self._frozen
+
+    @frozen.setter
+    def frozen(self, value):
+        """Set the frozen orbitals."""
+        if value is not None:
+            self._frozen = np.asarray(value)
+        del self.nmo, self.nocc, self.active
 
     @property
     def mo_energy(self):
@@ -232,6 +245,7 @@ class Base:
         """Set the molecular orbital energies."""
         if value is not None:
             self._mo_energy = mpi_helper.bcast(np.asarray(value))
+        del self.nmo, self.nocc, self.active
 
     @property
     def mo_coeff(self):
@@ -252,6 +266,7 @@ class Base:
         """Set the molecular orbital coefficients."""
         if value is not None:
             self._mo_coeff = mpi_helper.bcast(np.asarray(value))
+        del self.nmo, self.nocc, self.active
 
     @property
     def mo_occ(self):
@@ -275,6 +290,7 @@ class Base:
         """Set the molecular orbital occupation numbers."""
         if value is not None:
             self._mo_occ = mpi_helper.bcast(np.asarray(value))
+        del self.nmo, self.nocc, self.active
 
     def __getattr__(self, key):
         """
@@ -863,7 +879,7 @@ class BaseSE:
         """Get the number of auxiliaries."""
         return self.integrals.naux
 
-    @property
+    @functools.cached_property
     def nov(self):
         """
         Get the number of ov states in the screened Coulomb interaction.

--- a/momentGW/base.py
+++ b/momentGW/base.py
@@ -309,7 +309,7 @@ class Base:
         """
         if key in self._defaults:
             return self._opts[key]
-        raise AttributeError
+        return self.__getattribute__(key)
 
     def __setattr__(self, key, val):
         """

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -2,6 +2,7 @@
 Fock matrix self-consistent loop.
 """
 
+import functools
 from collections import OrderedDict
 
 import numpy as np
@@ -170,7 +171,6 @@ class BaseFockLoop:
             self._opts[key] = val
 
         # Attributes
-        self._h1e = None
         self.converged = None
         self.gf = gf if gf is not None else gw.init_gf()
         self.se = se
@@ -330,18 +330,17 @@ class BaseFockLoop:
 
         return converged, gf, None
 
-    @property
+    @functools.cached_property
     def h1e(self):
         """Get the core Hamiltonian."""
-        if self._h1e is None:
-            with util.SilentSCF(self.gw._scf):
-                self._h1e = util.einsum(
-                    "...pq,...pi,...qj->...ij",
-                    self.gw._scf.get_hcore(),
-                    np.conj(self.mo_coeff),
-                    self.mo_coeff,
-                )
-        return self._h1e
+        with util.SilentSCF(self.gw._scf):
+            h1e = util.einsum(
+                "...pq,...pi,...qj->...ij",
+                self.gw._scf.get_hcore(),
+                np.conj(self.mo_coeff),
+                self.mo_coeff,
+            )
+        return h1e
 
     def make_rdm1(self, gf=None):
         """Get the first-order reduced density matrix.

--- a/momentGW/fock.py
+++ b/momentGW/fock.py
@@ -414,7 +414,7 @@ class BaseFockLoop:
         """
         if key in self._defaults:
             return self._opts[key]
-        raise AttributeError
+        return self.__getattribute__(key)
 
     def __setattr__(self, key, val):
         """

--- a/momentGW/ints.py
+++ b/momentGW/ints.py
@@ -100,9 +100,9 @@ class Integrals(BaseIntegrals):
         store_full=False,
     ):
         # Parameters
-        self.with_df = with_df
-        self.mo_coeff = mo_coeff
-        self.mo_occ = mo_occ
+        self._with_df = with_df
+        self._mo_coeff = mo_coeff
+        self._mo_occ = mo_occ
 
         # Options
         self.compression = compression
@@ -583,6 +583,11 @@ class Integrals(BaseIntegrals):
         return h1e + veff
 
     @property
+    def with_df(self):
+        """Get the density fitting object."""
+        return self._with_df
+
+    @property
     def Lpq(self):
         """Get the full uncompressed ``(aux, MO, MO)`` integrals."""
         return self._blocks["Lpq"]
@@ -598,6 +603,11 @@ class Integrals(BaseIntegrals):
         return self._blocks["Lia"]
 
     @property
+    def mo_coeff(self):
+        """Get the MO coefficients."""
+        return self._mo_coeff
+
+    @property
     def mo_coeff_g(self):
         """Get the MO coefficients for the Green's function."""
         return self._mo_coeff_g if self._mo_coeff_g is not None else self.mo_coeff
@@ -606,6 +616,11 @@ class Integrals(BaseIntegrals):
     def mo_coeff_w(self):
         """Get the MO coefficients for the screened Coulomb interaction."""
         return self._mo_coeff_w if self._mo_coeff_w is not None else self.mo_coeff
+
+    @property
+    def mo_occ(self):
+        """Get the MO occupation numbers."""
+        return self._mo_occ
 
     @property
     def mo_occ_w(self):
@@ -674,7 +689,7 @@ class Integrals(BaseIntegrals):
                 return self.naux_full
         return self._rot.shape[1]
 
-    @property
+    @functools.cached_property
     def naux_full(self):
         """
         Get the number of auxiliary basis functions, before the

--- a/momentGW/pbc/base.py
+++ b/momentGW/pbc/base.py
@@ -3,6 +3,7 @@ Base class for moment-constrained GW solvers with periodic boundary
 conditions.
 """
 
+import functools
 from collections import OrderedDict
 
 import numpy as np
@@ -85,7 +86,7 @@ class BaseKGW(BaseGW):
         """Alias for `self.cell`."""
         return self._scf.cell
 
-    @property
+    @functools.cached_property
     def nmo(self):
         """Get the number of molecular orbitals."""
         return super().nmo[..., 0]

--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -338,13 +338,6 @@ class KIntegrals(Integrals):
         It must contain a 'collocation_matrix' and a 'coulomb_matrix'.
         """
 
-        # Initialise the sizes
-        naux = self.naux
-        nmo = self.nmo
-        nmo_g = self.nmo_g
-        nocc_w = self.nocc_w
-        nvir_w = self.nvir_w
-
         if self.input_path is None:
             raise ValueError(
                 "A file path containing the THC integrals is needed for the THC implementation"
@@ -358,10 +351,17 @@ class KIntegrals(Integrals):
         if self.kpts != kpts_imp:
             raise ValueError("Different kpts imported to those from PySCF")
 
+        # Initialise the sizes
+        self._naux = [np.array(thc_eri["coulomb_matrix"])[0, ..., 0].shape[0]] * len(self.kpts)
+        naux = self.naux
+        nmo = self.nmo
+        nmo_g = self.nmo_g
+        nocc_w = self.nocc_w
+        nvir_w = self.nvir_w
+
         Lpx = {}
         Lia = {}
         Lai = {}
-        self._naux = [np.array(thc_eri["coulomb_matrix"])[0, ..., 0].shape[0]] * len(self.kpts)
         for q in self.kpts.loop(1):
             for ki in self.kpts.loop(1):
                 kj = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[ki]))

--- a/momentGW/pbc/kpts.py
+++ b/momentGW/pbc/kpts.py
@@ -2,6 +2,7 @@
 k-points helper utilities.
 """
 
+import functools
 import itertools
 
 import numpy as np
@@ -291,7 +292,7 @@ class KPoints:
         """
         return np.max(np.abs(kpts)) < self.tol
 
-    @property
+    @functools.cached_property
     def kmesh(self):
         """Guess the k-mesh.
 

--- a/momentGW/pbc/rpa.py
+++ b/momentGW/pbc/rpa.py
@@ -189,6 +189,7 @@ class dRPA(dTDA, MoldRPA):
             integral = self.integrate()
 
         kpts = self.kpts
+        naux = self.naux
         Lia = self.integrals.Lia
         moments = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
 
@@ -201,7 +202,7 @@ class dRPA(dTDA, MoldRPA):
 
         for q in kpts.loop(1):
             # Get the zeroth order moment
-            tmp = np.zeros((self.naux[q], self.naux[q]), dtype=complex)
+            tmp = np.zeros((naux[q], naux[q]), dtype=complex)
             inter = 0.0
             for kj in kpts.loop(1, mpi=True):
                 kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[kj]))
@@ -503,6 +504,7 @@ class dRPA(dTDA, MoldRPA):
 
         # Calculate the integral for each point
         kpts = self.kpts
+        naux = self.naux
         for i, (point, weight) in enumerate(zip(*quad)):
             contrib = np.zeros_like(d, dtype=object)
 
@@ -516,7 +518,7 @@ class dRPA(dTDA, MoldRPA):
                     qz += np.dot(pre, Liad[q, kj].T.conj())
                 qz = mpi_helper.allreduce(qz)
 
-                tmp = np.linalg.inv(np.eye(self.naux[q]) + qz) - np.eye(self.naux[q])
+                tmp = np.linalg.inv(np.eye(naux[q]) + qz) - np.eye(naux[q])
                 inner = np.dot(qz, tmp)
 
                 for ka in kpts.loop(1, mpi=True):

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -49,6 +49,7 @@ class dTDA(MoldTDA):
 
         # Initialise the moments
         kpts = self.kpts
+        naux = self.naux
         moments = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
 
         # Get the zeroth order moment
@@ -69,7 +70,7 @@ class dTDA(MoldTDA):
                     )
                     moments[q, kb, i] += moments[q, kb, i - 1] * d.ravel()[None]
 
-                tmp = np.zeros((self.naux[q], self.naux[q]), dtype=complex)
+                tmp = np.zeros((naux[q], naux[q]), dtype=complex)
                 for ki in kpts.loop(1, mpi=True):
                     ka = kpts.member(kpts.wrap_around(kpts[q] + kpts[ki]))
 

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -2,6 +2,8 @@
 Construct TDA moments with periodic boundary conditions.
 """
 
+import functools
+
 import numpy as np
 import scipy.special
 
@@ -248,7 +250,7 @@ class dTDA(MoldTDA):
 
         return moments_occ, moments_vir
 
-    @property
+    @functools.cached_property
     def nov(self):
         """Get the number of ov states in W."""
         return np.multiply.outer(

--- a/momentGW/pbc/thc.py
+++ b/momentGW/pbc/thc.py
@@ -55,9 +55,6 @@ class KIntegrals(Integrals, DFKIntegrals):
         # Options
         self.compression = None
 
-        # Attributes
-        self._madelung = None
-
     def import_thc_components(self):
         """
         Import a HDF5 file containing a dictionary. The keys

--- a/momentGW/pbc/thc.py
+++ b/momentGW/pbc/thc.py
@@ -303,6 +303,7 @@ class dTDA(MoldTDA, DFdTDA):
         zeta = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
 
         kpts = self.kpts
+        naux = self.naux
         cou_occ = np.zeros((self.nkpts, 1), dtype=object)
         cou_vir = np.zeros((self.nkpts, 1), dtype=object)
 
@@ -318,19 +319,19 @@ class dTDA(MoldTDA, DFdTDA):
                 zeta[q, kb, 0] = cou_occ[kj, 0] * cou_vir[kb, 0]
         zeta[..., 0] /= self.nkpts
 
-        cou_square = np.zeros((self.nkpts, self.naux, self.naux), dtype=complex)
+        cou_square = np.zeros((self.nkpts, naux, naux), dtype=complex)
         for q in kpts.loop(1):
             for kj in kpts.loop(1):
                 kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[kj]))
-                cou_left[q, kb, 0] = np.eye(self.naux)
+                cou_left[q, kb, 0] = np.eye(naux)
                 cou_square[q] += np.dot(self.cou[q], (cou_occ[kj, 0] * cou_vir[kb, 0]))
 
         for i in range(1, self.nmom_max + 1):
-            cou_it_add = np.zeros((self.nkpts, self.naux, self.naux), dtype=complex)
+            cou_it_add = np.zeros((self.nkpts, naux, naux), dtype=complex)
             for q in kpts.loop(1):
                 for kj in kpts.loop(1):
                     kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[kj]))
-                    zeta[q, kb, i] = np.zeros((self.naux, self.naux), dtype=complex)
+                    zeta[q, kb, i] = np.zeros((naux, naux), dtype=complex)
                     cou_d_left[q, kb, 0] = cou_left[q, kb, 0]
                     cou_d_left[q, kb] = np.roll(cou_d_left[q, kb], 1)
                     cou_left[q, kb, 0] = np.dot(cou_square[q], cou_left[q, kb, 0]) * 2 / self.nkpts

--- a/momentGW/pbc/uhf/ints.py
+++ b/momentGW/pbc/uhf/ints.py
@@ -77,9 +77,9 @@ class KUIntegrals(UIntegrals, KIntegrals):
         store_full=False,
     ):
         # Parameters
-        self.with_df = with_df
-        self.mo_coeff = mo_coeff
-        self.mo_occ = mo_occ
+        self._with_df = with_df
+        self._mo_coeff = mo_coeff
+        self._mo_occ = mo_occ
 
         # Options
         self.compression = compression
@@ -108,7 +108,6 @@ class KUIntegrals(UIntegrals, KIntegrals):
                 store_full=self.store_full,
             ),
         }
-        self._madelung = None
 
     @logging.with_status("Computing compression metric")
     def get_compression_metric(self):

--- a/momentGW/pbc/uhf/ints.py
+++ b/momentGW/pbc/uhf/ints.py
@@ -120,13 +120,16 @@ class KUIntegrals(UIntegrals, KIntegrals):
             Rotation matrix into the compressed auxiliary space.
         """
 
+        # Initialise the sizes
+        naux_full = self.naux_full
+
         # Get the compression sectors
         compression = self._parse_compression()
         if not compression:
             return None
 
         # Initialise the inner product matrix
-        prod = np.zeros((len(self.kpts), self.naux_full, self.naux_full), dtype=complex)
+        prod = np.zeros((len(self.kpts), naux_full, naux_full), dtype=complex)
 
         # Loop over required blocks
         for key in sorted(compression):
@@ -153,16 +156,16 @@ class KUIntegrals(UIntegrals, KIntegrals):
                         kj = self.kpts.member(self.kpts.wrap_around(self.kpts[ki] - self.kpts[q]))
 
                         # Build the (L|xy) array
-                        Lxy = np.zeros((self.naux_full, ni[ki] * nj[kj]), dtype=complex)
+                        Lxy = np.zeros((naux_full, ni[ki] * nj[kj]), dtype=complex)
                         b1 = 0
                         for block in self.with_df.sr_loop((ki, kj), compact=False):
                             if block[2] == -1:
                                 raise NotImplementedError("Low dimensional integrals")
                             block = block[0] + block[1] * 1.0j
-                            block = block.reshape(self.naux_full, self.nao, self.nao)
+                            block = block.reshape(naux_full, self.nao, self.nao)
                             b0, b1 = b1, b1 + block.shape[0]
                             progress = ki * len(self.kpts) ** 2 + kj * len(self.kpts) + b0
-                            progress /= len(self.kpts) ** 2 + self.naux_full
+                            progress /= len(self.kpts) ** 2 + naux_full
 
                             with logging.with_status(
                                 f"block [{ki}, {kj}, {b0}:{b1}] ({progress:.1%})"
@@ -191,7 +194,7 @@ class KUIntegrals(UIntegrals, KIntegrals):
 
         # Print the compression status
         naux_total = sum(r.shape[-1] for r in rot)
-        naux_full_total = self.naux_full * len(self.kpts)
+        naux_full_total = naux_full * len(self.kpts)
         if naux_total == naux_full_total:
             logging.write("No compression found for auxiliary space")
             rot = None

--- a/momentGW/pbc/uhf/tda.py
+++ b/momentGW/pbc/uhf/tda.py
@@ -52,6 +52,7 @@ class dTDA(KdTDA, MolUdTDA):
 
         # Initialise the moments
         kpts = self.kpts
+        naux = self.naux
         moments = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
 
         # Get the zeroth order moment
@@ -89,7 +90,7 @@ class dTDA(KdTDA, MolUdTDA):
                     )
                     moments[q, kb, i] += moments[q, kb, i - 1] * d[None]
 
-                tmp = np.zeros((self.naux[q], self.naux[q]), dtype=complex)
+                tmp = np.zeros((naux[q], naux[q]), dtype=complex)
                 for ki in kpts.loop(1, mpi=True):
                     ka = kpts.member(kpts.wrap_around(kpts[q] + kpts[ki]))
 

--- a/momentGW/pbc/uhf/tda.py
+++ b/momentGW/pbc/uhf/tda.py
@@ -3,6 +3,8 @@ Construct TDA moments with periodic boundary conditions and unrestricted
 references.
 """
 
+import functools
+
 import numpy as np
 
 from momentGW import logging, mpi_helper, util
@@ -256,7 +258,7 @@ class dTDA(KdTDA, MolUdTDA):
 
         return tuple(moments_occ), tuple(moments_vir)
 
-    @property
+    @functools.cached_property
     def nov(self):
         """Number of ov states in the screened Coulomb interaction."""
         return (

--- a/momentGW/thc.py
+++ b/momentGW/thc.py
@@ -37,12 +37,12 @@ class Integrals(ints.Integrals):
         file_path=None,
     ):
         # Parameters
-        self.with_df = with_df
-        self.mo_coeff = mo_coeff
-        self.mo_occ = mo_occ
-        self.file_path = file_path
+        self._with_df = with_df
+        self._mo_coeff = mo_coeff
+        self._mo_occ = mo_occ
 
         # Options
+        self.file_path = file_path
         self.compression = None
 
         # Logging

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -2,6 +2,8 @@
 Integral helpers with unrestricted reference.
 """
 
+import functools
+
 import numpy as np
 from pyscf.ao2mo import _ao2mo
 
@@ -72,9 +74,9 @@ class UIntegrals(Integrals):
         store_full=False,
     ):
         # Parameters
-        self.with_df = with_df
-        self.mo_coeff = mo_coeff
-        self.mo_occ = mo_occ
+        self._with_df = with_df
+        self._mo_coeff = mo_coeff
+        self._mo_occ = mo_occ
 
         # Options
         self.compression = compression
@@ -486,7 +488,7 @@ class UIntegrals(Integrals):
         assert np.all(self._spins[0].naux == self._spins[1].naux)
         return self._spins[0].naux
 
-    @property
+    @functools.cached_property
     def naux_full(self):
         """
         Get the number of auxiliary basis functions, before the

--- a/momentGW/uhf/ints.py
+++ b/momentGW/uhf/ints.py
@@ -114,13 +114,16 @@ class UIntegrals(Integrals):
             Rotation matrix into the compressed auxiliary space.
         """
 
+        # Initialise the sizes
+        naux_full = self.naux_full
+
         # Get the compression sectors
         compression = self._parse_compression()
         if not compression:
             return None
 
         # Initialise the inner product matrix
-        prod = np.zeros((self.naux_full, self.naux_full))
+        prod = np.zeros((naux_full, naux_full))
 
         # Loop over required blocks
         for key in sorted(compression):
@@ -145,11 +148,11 @@ class UIntegrals(Integrals):
                         i1, j1 = divmod(p1, nj)
 
                         # Build the (L|xy) array
-                        Lxy = np.zeros((self.naux_full, p1 - p0))
+                        Lxy = np.zeros((naux_full, p1 - p0))
                         b1 = 0
                         for block in self.with_df.loop():
                             b0, b1 = b1, b1 + block.shape[0]
-                            progress = (p0 * self.naux_full + b0) / (ni * nj * self.naux_full)
+                            progress = (p0 * naux_full + b0) / (ni * nj * naux_full)
                             with logging.with_status(
                                 f"block [{p0}:{p1}, {b0}:{b1}] ({progress:.1%})"
                             ):
@@ -184,14 +187,14 @@ class UIntegrals(Integrals):
         rot = mpi_helper.bcast(rot, root=0)
 
         # Print the compression status
-        if rot.shape[-1] == self.naux_full:
+        if rot.shape[-1] == naux_full:
             logging.write("No compression found for auxiliary space")
             rot = None
         else:
-            percent = 100 * rot.shape[-1] / self.naux_full
+            percent = 100 * rot.shape[-1] / naux_full
             style = logging.rate(percent, 80, 95)
             logging.write(
-                f"Compressed auxiliary space from {self.naux_full} to {rot.shape[1]} "
+                f"Compressed auxiliary space from {naux_full} to {rot.shape[1]} "
                 f"([{style}]{percent:.1f}%)[/]"
             )
 

--- a/momentGW/uhf/tda.py
+++ b/momentGW/uhf/tda.py
@@ -2,6 +2,8 @@
 Construct TDA moments with unrestricted references.
 """
 
+import functools
+
 import numpy as np
 
 from momentGW import logging, mpi_helper, util
@@ -235,7 +237,7 @@ class dTDA(RdTDA):
         """
         raise NotImplementedError
 
-    @property
+    @functools.cached_property
     def nov(self):
         """
         Get the number of ov states in the screened Coulomb interaction.

--- a/tests/test_kthcgw.py
+++ b/tests/test_kthcgw.py
@@ -22,7 +22,7 @@ class Test_KGW(unittest.TestCase):
         cell.atom = "He 0 0 0; He 1 1 1"
         cell.basis = "6-31g"
         cell.a = np.eye(3) * 3
-        cell.verbose = 3
+        cell.verbose = 0
         cell.build()
 
         kmesh = [2, 2, 2]
@@ -146,7 +146,7 @@ class Test_KGW(unittest.TestCase):
         cell.atom = "He 0 0 0; He 1 1 1"
         cell.basis = "6-31g"
         cell.a = np.eye(3) * 3
-        cell.verbose = 3
+        cell.verbose = 0
         cell.build()
 
         kmesh = [2, 2, 2]


### PR DESCRIPTION
Caches some properties that don't have O(1) overhead using `functools.cached_property`. Also ensures that properties like this that are not elegantly cacheable are instantiated outside of rate-limiting loops.

Some of the integrals code is getting a bit messy now... maybe a refactor in the future would be nice