### PR TITLE
Freeze `dyson` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "scipy<=1.10.0",
     "pyscf>=2.0.0",
     "rich>=13.0.0",
-    "dyson @ git+https://github.com/BoothGroup/dyson@master",
+    "dyson @ git+https://github.com/BoothGroup/dyson@old",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
Freezes the version of `dyson` ahead of the incoming refactor, which will need API changes