### PR TITLE
New RPA integral and memory savings

### DIFF
--- a/examples/20-store_calculation.py
+++ b/examples/20-store_calculation.py
@@ -1,0 +1,67 @@
+"""Example of how to store a `momentGW` calculations."""
+
+import numpy as np
+
+from pyscf import dft, gto
+
+from momentGW import GW
+from momentGW.rpa import dRPA
+
+# Define a molecule
+mol = gto.Mole()
+mol.atom = "Li 0 0 0; H 0 0 1.64"
+mol.basis = "cc-pvdz"
+mol.verbose = 5
+mol.build()
+
+# Run a DFT calculation
+mf = dft.RKS(mol)
+mf = mf.density_fit()
+mf.xc = "hf"
+mf.kernel()
+
+# When running large calculations you may wish to store the key elements of the calculation.
+# The key and most expensive terms are the density-density (dd) response moments and the
+# self-energy (SE) moments.
+
+
+nmom_max = 3
+
+# Construct your GW inputs and integrals
+gw = GW(mf)
+gw.polarizability = "dRPA"
+gw.npoints = 24
+gw.compression = None
+integrals = gw.ao2mo()
+
+# Build the static term
+static = gw.build_se_static(integrals)
+
+# If you wish to store the minimum essential information regarding the calculation, the SE-moments
+# can just be stored. These moments (or a subset) can then be used to solve Dyson's equation
+# Memory cost to store - O(2 * nmom_max * N^2_orb)
+# Maximum memory - O(N^3_orb) + O(2 * nmom_max * N^2_orb)
+
+# Build the SE-moments
+se_moments = gw.build_se_moments(nmom_max, integrals)
+
+# Solve dyson's equation
+gw.kernel(nmom_max, integrals=integrals, moments=se_moments)
+
+
+# If you also wish to be able to build higher moments to improve the accuracy of your calculation
+# in the future, you can also store the dd-moments
+# Memory cost to store - O(nmom_max * N^3_orb) + O(2 * nmom_max * N^2_orb)
+# Maximum memory - O(nmom_max * N^3_orb) + O(2 * nmom_max * N^2_orb)
+
+# Initialise the screened Coulomb object
+rpa = dRPA(gw, nmom_max, integrals)
+
+# Build the DD-moments
+moments_dd = rpa.build_dd_moments()
+
+# Build the SE-moments
+moments = rpa.build_se_moments(moments_dd)
+
+# Solve dyson's equation
+gw.kernel(nmom_max, integrals=integrals, moments=moments)

--- a/examples/20-store_calculation.py
+++ b/examples/20-store_calculation.py
@@ -1,7 +1,5 @@
 """Example of how to store a `momentGW` calculations."""
 
-import numpy as np
-
 from pyscf import dft, gto
 
 from momentGW import GW

--- a/examples/20-store_calculation.py
+++ b/examples/20-store_calculation.py
@@ -1,14 +1,23 @@
 """Example of how to store a `momentGW` calculations."""
 
+import os
+
+import h5py
+import numpy as np
 from pyscf import dft, gto
 
 from momentGW import GW
 from momentGW.rpa import dRPA
 
+# Key calculation and file variables for storage
+path = os.path.dirname(os.path.realpath(__file__))
+basis = "cc-pvdz"
+polarizability = "dRPA"
+
 # Define a molecule
 mol = gto.Mole()
 mol.atom = "Li 0 0 0; H 0 0 1.64"
-mol.basis = "cc-pvdz"
+mol.basis = basis
 mol.verbose = 5
 mol.build()
 
@@ -27,7 +36,7 @@ nmom_max = 3
 
 # Construct your GW inputs and integrals
 gw = GW(mf)
-gw.polarizability = "dRPA"
+gw.polarizability = polarizability
 gw.npoints = 24
 gw.compression = None
 integrals = gw.ao2mo()
@@ -46,9 +55,17 @@ se_moments = gw.build_se_moments(nmom_max, integrals)
 # Solve dyson's equation
 gw.kernel(nmom_max, integrals=integrals, moments=se_moments)
 
+with h5py.File("%s/data_min_%s_%s.h5" % (path, basis, polarizability), "w") as f:
+    f.create_dataset("e_tot", data=np.array([mf.e_tot]))
+    f.create_dataset("mo_occ", data=np.asarray(mf.mo_occ))
+    f.create_dataset("mo_coeff", data=np.asarray(mf.mo_coeff))
+    f.create_dataset("mo_energy", data=np.asarray(mf.mo_energy))
+    f.create_dataset("static", data=np.asarray(static))
+    f.create_dataset("se_moments", data=np.asarray(se_moments))
 
-# If you also wish to be able to build higher moments to improve the accuracy of your calculation
-# in the future, you can also store the dd-moments
+
+# If you also wish to store all the information required to build the se-moments you can also
+# store the dd-moments. This requires more memory for the calculation.
 # Memory cost to store - O(nmom_max * N^3_orb) + O(2 * nmom_max * N^2_orb)
 # Maximum memory - O(nmom_max * N^3_orb) + O(2 * nmom_max * N^2_orb)
 
@@ -63,3 +80,12 @@ moments = rpa.build_se_moments(moments_dd)
 
 # Solve dyson's equation
 gw.kernel(nmom_max, integrals=integrals, moments=moments)
+
+with h5py.File("%s/data_large_%s_%s.h5" % (path, basis, polarizability), "w") as f:
+    f.create_dataset("e_tot", data=np.array([mf.e_tot]))
+    f.create_dataset("mo_occ", data=np.asarray(mf.mo_occ))
+    f.create_dataset("mo_coeff", data=np.asarray(mf.mo_coeff))
+    f.create_dataset("mo_energy", data=np.asarray(mf.mo_energy))
+    f.create_dataset("static", data=np.asarray(static))
+    f.create_dataset("moments_dd", data=np.asarray(moments_dd))
+    f.create_dataset("se_moments", data=np.asarray(moments))

--- a/momentGW/pbc/rpa.py
+++ b/momentGW/pbc/rpa.py
@@ -34,27 +34,6 @@ class dRPA(dTDA, MoldRPA):
     `momentGW.tda.dTDA.kernel` for calculation run details.
     """
 
-    def _build_d(self):
-        """Construct the energy differences matrix.
-
-        Returns
-        -------
-        d : numpy.ndarray
-            Orbital energy differences at each k-point.
-        """
-
-        d = np.zeros((self.nkpts, self.nkpts), dtype=object)
-
-        for q in self.kpts.loop(1):
-            for ki in self.kpts.loop(1, mpi=True):
-                ka = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[ki]))
-                d[q, ka] = util.build_1h1p_energies(
-                    (self.mo_energy_w[ki], self.mo_energy_w[ka]),
-                    (self.mo_occ_w[ki], self.mo_occ_w[ka]),
-                ).ravel()
-
-        return d
-
     def _build_diag_eri(self):
         """Construct the diagonal of the ERIs at each k-point.
 
@@ -75,47 +54,9 @@ class dRPA(dTDA, MoldRPA):
 
         return diag_eri
 
-    def _build_Liad(self, Lia, d):
-        """Construct the ``Liad`` array.
-
-        Returns
-        -------
-        Liad : numpy.ndarray
-           Product of Lia and the orbital energy differences at each
-           k-point.
-        """
-
-        Liad = np.zeros((self.nkpts, self.nkpts), dtype=object)
-
-        for q in self.kpts.loop(1):
-            for ki in self.kpts.loop(1, mpi=True):
-                kb = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[ki]))
-                Liad[q, kb] = Lia[ki, kb] * d[q, kb]
-
-        return Liad
-
-    def _build_Liadinv(self, Lia, d):
-        """Construct the ``Liadinv`` array.
-
-        Returns
-        -------
-        Liadinv : numpy.ndarray
-           Division of Lia and the orbital energy differences at each
-           k-point.
-        """
-
-        Liadinv = np.zeros((self.nkpts, self.nkpts), dtype=object)
-
-        for q in self.kpts.loop(1):
-            for ki in self.kpts.loop(1, mpi=True):
-                kb = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[ki]))
-                Liadinv[q, kb] = Lia[ki, kb] / d[q, kb]
-
-        return Liadinv
-
     @logging.with_timer("Numerical integration")
     @logging.with_status("Performing numerical integration")
-    def integrate(self):
+    def build_zeroth_moment(self):
         """Optimise the quadrature and perform the integration for a given set of k-points for the
         zeroth moment.
 
@@ -125,23 +66,14 @@ class dRPA(dTDA, MoldRPA):
             Integral array, including the offset part.
         """
 
-        # Construct the energy differences
-        d = self._build_d()
-
         # Calculate diagonal part of ERIs
         diag_eri = self._build_diag_eri()
 
-        # Get the offset integral quadrature
-        quad = self.optimise_offset_quad(d, diag_eri)
-
-        # Perform the offset integral
-        offset = self.eval_offset_integral(quad, d)
-
         # Get the main integral quadrature
-        quad = self.optimise_main_quad(d, diag_eri)
+        quad = self.optimise_main_quad(self.d, diag_eri)
 
         # Perform the main integral
-        integral = self.eval_main_integral(quad, d)
+        integral = self.eval_main_integral(quad, self.d)
 
         # Report quadrature error
         if self.report_quadrature_error:
@@ -161,8 +93,82 @@ class dRPA(dTDA, MoldRPA):
                 f"Error in integral:  [{style_full}]{err:.3e}[/] "
                 f"(half = [{style_half}]{a:.3e}[/], quarter = [{style_quar}]{b:.3e}[/])",
             )
+            integral = np.delete(integral, [1, 2], 0)
 
-        return integral[0] + offset
+        return integral[0]
+
+    @logging.with_timer("Nth density-density moments")
+    @logging.with_status("Constructing nth density-density moment")
+    def build_nth_dd_moment(self, n, q, recursion_term=None, zeroth_mom=None):
+        """Build the nth moment of the density-density response for a given set of k-points.
+
+        Parameters
+        ----------
+        n : int
+            Moment order to be built.
+        q : int
+            Index associated with a difference in k-points
+        recursion_term : numpy.ndarray, optional
+            Previous recursion term required to build the next moment. In the case of RPA this is
+            the appropriate [(A+B)(A-B)]^(n-2/2) for the nth moment. These are only calculated on
+            even moments, odd moments use the previous even moment value.
+        zeroth moment : numpy.ndarray, optional
+            Zeroth moment of the density-density response.
+
+        Returns
+        -------
+        recursion_term : numpy.ndarray
+            Term required for the next moment. In the case of RPA this is [(A+B)(A-B)]^(n/2)
+        eta_aux : numpy.ndarray
+            The nth density-density response moment in (N_aux,N_aux) form
+        """
+        kpts = self.kpts
+        eta_aux = 0
+        if n % 2 == 0:
+            if zeroth_mom is None:
+                raise AttributeError(
+                    "0th moment must be provided by build_zeroth_moment for k-point calculations."
+                )
+            if n != 0:
+                tmp = 0.0
+                for ka in kpts.loop(1, mpi=True):
+                    kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[ka]))
+                    tmp += np.dot(self.integrals.Lia[ka, kb] * self.d[q, kb], recursion_term[q, kb])
+                tmp = mpi_helper.allreduce(tmp)
+                tmp *= 4 / self.nkpts
+                for ka in kpts.loop(1, mpi=True):
+                    kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[ka]))
+                    recursion_term[q, kb] = util.einsum(
+                        "i, iP->iP", self.d[q, kb] ** 2, recursion_term[q, kb]
+                    )
+                    recursion_term[q, kb] += util.einsum(
+                        "Pi,PQ->iQ", self.integrals.Lia[ka, kb].conj(), tmp
+                    )
+                    eta_aux += np.dot(zeroth_mom[q, kb], recursion_term[q, kb])
+            else:
+                if recursion_term is None:
+                    recursion_term = np.zeros_like(zeroth_mom)
+                for ka in kpts.loop(1, mpi=True):
+                    kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[ka]))
+                    recursion_term[q, kb] += self.integrals.Lia[ka, kb].T.conj()
+                    eta_aux += np.dot(zeroth_mom[q, kb], recursion_term[q, kb])
+
+        else:
+            if recursion_term is None:
+                raise AttributeError(
+                    f"To build the {n}th dd-moment, a recursion_term must be provided"
+                )
+            for ka in kpts.loop(1, mpi=True):
+                kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[ka]))
+                eta_aux += (
+                    np.dot(self.integrals.Lia[ka, kb] * self.d[q, kb][None], recursion_term[q, kb])
+                    / self.nkpts
+                )
+
+        eta_aux = mpi_helper.allreduce(eta_aux)
+        eta_aux *= 2.0 / self.nkpts
+
+        return recursion_term, eta_aux
 
     @logging.with_timer("Density-density moments")
     @logging.with_status("Constructing density-density moments")
@@ -181,42 +187,23 @@ class dRPA(dTDA, MoldRPA):
             Moments of the density-density response.
         """
 
+        if self.d is None:
+            self._build_d()
+
         if integral is None:
-            integral = self.integrate()
+            integral = self.build_zeroth_moment()
 
         kpts = self.kpts
-        naux = self.naux
         Lia = self.integrals.Lia
         moments = np.zeros((self.nkpts, self.nkpts, self.nmom_max + 1), dtype=object)
 
-        # Construct the energy differences
-        d = self._build_d()
-
-        # Calculate (L|ia) D_{ia} and (L|ia) D_{ia}^{-1} intermediates
-        Liad = self._build_Liad(Lia, d)
-        Liadinv = self._build_Liadinv(Lia, d)
-
-        for q in kpts.loop(1):
-            # Get the zeroth order moment
-            tmp = np.zeros((naux[q], naux[q]), dtype=complex)
-            inter = 0.0
-            for kj in kpts.loop(1, mpi=True):
-                kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[kj]))
-                tmp += np.dot(Liadinv[q, kb], self.integrals.Lia[kj, kb].conj().T)
-                inter += np.dot(integral[q, kb], Liadinv[q, kb].T.conj())
-            tmp = mpi_helper.allreduce(tmp)
-            inter = mpi_helper.allreduce(inter)
-            tmp *= 2.0
-            u = np.linalg.inv(np.eye(tmp.shape[0]) * self.nkpts / 2 + tmp)
-
-            rest = np.dot(inter, u) * self.nkpts / 2
-            for ki in kpts.loop(1, mpi=True):
-                ka = kpts.member(kpts.wrap_around(kpts[q] + kpts[ki]))
-                moments[q, ka, 0] = integral[q, ka] / d[q, ka] * self.nkpts / 2
-                moments[q, ka, 0] -= np.dot(rest, Liadinv[q, ka]) * 2
+        moments[:, :, 0] = integral
 
         # Get the first order moment
-        moments[:, :, 1] = Liad / self.nkpts
+        for q in kpts.loop(1):
+            for ki in self.kpts.loop(1, mpi=True):
+                kb = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[ki]))
+                moments[q, kb, 1] = Lia[ki, kb] * self.d[q, kb]
 
         # Get the higher order moments
         for i in range(2, self.nmom_max + 1):
@@ -224,141 +211,17 @@ class dRPA(dTDA, MoldRPA):
                 tmp = 0.0
                 for ka in kpts.loop(1, mpi=True):
                     kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[ka]))
-                    moments[q, kb, i] = moments[q, kb, i - 2] * d[q, kb] ** 2
+                    moments[q, kb, i] = moments[q, kb, i - 2] * self.d[q, kb] ** 2
                     tmp += np.dot(moments[q, kb, i - 2], self.integrals.Lia[ka, kb].conj().T)
                 tmp = mpi_helper.allreduce(tmp)
-                tmp /= self.nkpts
-                tmp *= 2
+                tmp *= 2 / self.nkpts
                 for ki in kpts.loop(1, mpi=True):
                     ka = kpts.member(kpts.wrap_around(kpts[q] + kpts[ki]))
-                    moments[q, ka, i] += np.dot(tmp, Liad[q, ka]) * 2
+                    moments[q, ka, i] += np.dot(tmp, moments[q, ka, 1]) * 2
+
+        moments[:, :, 1] /= self.nkpts  # Moment 1 used as Lia*d, needed to correct it for mom 1
 
         return moments
-
-    def optimise_offset_quad(self, d, diag_eri, name="main"):
-        """Optimise the grid spacing of Gauss-Laguerre quadrature for the offset integral.
-
-        Parameters
-        ----------
-        d : numpy.ndarray
-            Orbital energy differences at each k-point.
-        diag_eri : numpy.ndarray
-            Diagonal of the ERIs at each k-point.
-        name : str, optional
-            Name of the integral. Default value is `"main"`.
-
-        Returns
-        -------
-        points : numpy.ndarray
-            The quadrature points.
-        weights : numpy.ndarray
-            The quadrature weights.
-        """
-
-        # Generate the bare quadrature
-        bare_quad = self.gen_gausslag_quad_semiinf()
-
-        # Calculate the exact value of the integral for the diagonal
-        exact = 0.0
-        for q in self.kpts.loop(1):
-            for ki in self.kpts.loop(1, mpi=True):
-                ka = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[ki]))
-                exact += np.dot(1.0 / d[q, ka], d[q, ka] * diag_eri[q, ka])
-        exact = mpi_helper.allreduce(exact)
-
-        # Define the integrand
-        integrand = lambda quad: self.eval_diag_offset_integral(quad, d, diag_eri)
-
-        # Get the optimal quadrature
-        quad = self.get_optimal_quad(bare_quad, integrand, exact, name=name)
-
-        return quad
-
-    def eval_diag_offset_integral(self, quad, d, diag_eri):
-        """Evaluate the diagonal of the offset integral.
-
-        Parameters
-        ----------
-        quad : tuple
-            The quadrature points and weights.
-        d : numpy.ndarray
-            Orbital energy differences at each k-point.
-        diag_eri : numpy.ndarray
-            Diagonal of the ERIs at each k-point.
-
-        Returns
-        -------
-        integral : numpy.ndarray
-            Offset integral.
-        """
-
-        # Calculate the integral for each point
-        integral = 0.0
-        for point, weight in zip(*quad):
-            for q in self.kpts.loop(1):
-                for ki in self.kpts.loop(1, mpi=True):
-                    ka = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[ki]))
-                    tmp = d[q, ka] * diag_eri[q, ka]
-                    expval = np.exp(-2 * point * d[q, ka])
-                    res = np.dot(expval, tmp)
-                    integral += 2 * res * weight
-        integral = mpi_helper.allreduce(integral)
-
-        return integral
-
-    def eval_offset_integral(self, quad, d, Lia=None):
-        """Evaluate the offset integral.
-
-        Parameters
-        ----------
-        quad : tuple
-            The quadrature points and weights.
-        d : numpy.ndarray
-            Orbital energy differences at each k-point.
-        Lia : dict of numpy.ndarray
-            Dict. with keys that are pairs of k-point indices (Nkpt, Nkpt)
-            with an array of form (aux, W occ, W vir) at this k-point pair.
-            The 1st Nkpt is defined by the difference between k-points and
-            the second index's kpoint. If `None`, use `self.integrals.Lia`.
-        Liad : dict of numpy.ndarray
-            Product of Lia and the orbital energy differences at each
-            k-point.
-
-
-        Returns
-        -------
-        integral : numpy.ndarray
-            Offset integral.
-        """
-
-        # Get the integral intermediates
-        if Lia is None:
-            Lia = self.integrals.Lia
-        Liad = self._build_Liad(Lia, d)
-        integrals = 2 * Liad / (self.nkpts**2)
-
-        kpts = self.kpts
-
-        # Calculate the integral for each point
-        for point, weight in zip(*quad):
-            for q in kpts.loop(1):
-                lhs = 0.0
-                for ka in kpts.loop(1, mpi=True):
-                    kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[ka]))
-                    expval = np.exp(-point * d[q, kb])
-                    lhs += np.dot(Liad[q, kb] * expval[None], Lia[ka, kb].T.conj())
-                lhs = mpi_helper.allreduce(lhs)
-                lhs /= self.nkpts
-                lhs *= 2
-
-                for ka in kpts.loop(1, mpi=True):
-                    kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[ka]))
-                    rhs = self.integrals.Lia[ka, kb] * np.exp(-point * d[q, kb])
-                    rhs /= self.nkpts**2
-                    res = np.dot(lhs, rhs)
-                    integrals[q, kb] += res * weight * 4
-
-        return integrals
 
     def optimise_main_quad(self, d, diag_eri, name="main"):
         """Optimise the grid spacing of Clenshaw-Curtis quadrature for the main integral.
@@ -379,33 +242,25 @@ class dRPA(dTDA, MoldRPA):
         """
 
         # Generate the bare quadrature
-        bare_quad = self.gen_clencur_quad_inf(even=True)
+        bare_quad = self.gen_ClenCur_quad_semiinf()
 
         # Calculate the exact value of the integral for the diagonal
         exact = 0.0
-        d_sq = np.zeros((self.nkpts, self.nkpts), dtype=object)
-        d_eri = np.zeros((self.nkpts, self.nkpts), dtype=object)
-        d_sq_eri = np.zeros((self.nkpts, self.nkpts), dtype=object)
         for q in self.kpts.loop(1):
             for kj in self.kpts.loop(1, mpi=True):
                 kb = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[kj]))
-                exact += np.sum((d[q, kb] * (d[q, kb] + diag_eri[q, kb])) ** 0.5)
-                exact -= 0.5 * np.dot(1.0 / d[q, kb], d[q, kb] * diag_eri[q, kb])
-                exact -= np.sum(d[q, kb])
-                d_sq[q, kb] = d[q, kb] ** 2
-                d_eri[q, kb] = d[q, kb] * diag_eri[q, kb]
-                d_sq_eri[q, kb] = d[q, kb] * (d[q, kb] + diag_eri[q, kb])
+                exact += np.sum(d[q, kb] * ((d[q, kb] * (d[q, kb] + diag_eri[q, kb])) ** -0.5))
         exact = mpi_helper.allreduce(exact)
 
         # Define the integrand
-        integrand = lambda quad: self.eval_diag_main_integral(quad, d, d_sq, d_eri, d_sq_eri)
+        integrand = lambda quad: self.eval_diag_main_integral(quad, d, diag_eri)
 
         # Get the optimal quadrature
         quad = self.get_optimal_quad(bare_quad, integrand, exact, name=name)
 
         return quad
 
-    def eval_diag_main_integral(self, quad, d, d_sq, d_eri, d_sq_eri):
+    def eval_diag_main_integral(self, quad, d, diag_eri):
         """Evaluate the diagonal of the main integral.
 
         Parameters
@@ -434,24 +289,14 @@ class dRPA(dTDA, MoldRPA):
 
         integral = 0.0
 
-        def diag_contrib(x, freq):
-            integral = x / (x + freq**2)
-            integral /= np.pi
-            return integral
-
         # Calculate the integral for each point
         for point, weight in zip(*quad):
             contrib = 0.0
             for q in self.kpts.loop(1):
                 for kj in self.kpts.loop(1, mpi=True):
                     kb = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[kj]))
-                    contrib_int = diag_contrib(d_sq_eri[q, kb], point)
-                    contrib_int -= diag_contrib(d_sq[q, kb], point)
-                    contrib += np.abs(np.sum(contrib_int))
-
-                    f_sq = 1.0 / (d[q, kb] ** 2 + point**2) ** 2
-                    contrib -= np.abs(point**2 * np.dot(f_sq, d_eri[q, kb]) / np.pi)
-
+                    val = (d[q, kb] + diag_eri[q, kb]) * d[q, kb] + point**2
+                    contrib += np.sum(d[q, kb] * val ** (-1)) * 2 / np.pi
             integral += weight * contrib
 
         integral = mpi_helper.allreduce(integral)
@@ -488,7 +333,6 @@ class dRPA(dTDA, MoldRPA):
         # Get the integral intermediates
         if Lia is None:
             Lia = self.integrals.Lia
-        Liad = self._build_Liad(Lia, d)
 
         # Initialise the integral
         dim = 3 if self.report_quadrature_error else 1
@@ -498,25 +342,27 @@ class dRPA(dTDA, MoldRPA):
         kpts = self.kpts
         naux = self.naux
         for i, (point, weight) in enumerate(zip(*quad)):
-            contrib = np.zeros_like(d, dtype=object)
-
             for q in kpts.loop(1):
                 f = np.zeros((self.nkpts), dtype=object)
                 qz = 0.0
                 for ki in kpts.loop(1, mpi=True):
                     kj = kpts.member(kpts.wrap_around(kpts[q] + kpts[ki]))
-                    f[kj] = 1.0 / (d[q, kj] ** 2 + point**2)
+                    f[kj] = d[q, kj] / (d[q, kj] ** 2 + point**2)
                     pre = (Lia[ki, kj] * f[kj]) * (4 / self.nkpts)
-                    qz += np.dot(pre, Liad[q, kj].T.conj())
+                    qz += np.dot(pre, Lia[ki, kj].T.conj())
                 qz = mpi_helper.allreduce(qz)
 
                 tmp = np.linalg.inv(np.eye(naux[q]) + qz) - np.eye(naux[q])
-                inner = np.dot(qz, tmp)
 
                 for ka in kpts.loop(1, mpi=True):
                     kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[ka]))
-                    contrib[q, kb] = 2 * np.dot(inner, Lia[ka, kb]) / (self.nkpts**2)
-                    value = weight * (contrib[q, kb] * f[kb] * (point**2 / np.pi))
+                    if i == 0:
+                        for v in range(dim):
+                            integral[v, q, kb] += Lia[ka, kb] / self.nkpts
+
+                    value = (
+                        weight * np.dot(tmp, Lia[ka, kb] * f[kb]) * (2 / (np.pi * self.nkpts))
+                    )
 
                     integral[0, q, kb] += value
                     if i % 2 == 0 and self.report_quadrature_error:

--- a/momentGW/pbc/rpa.py
+++ b/momentGW/pbc/rpa.py
@@ -360,9 +360,7 @@ class dRPA(dTDA, MoldRPA):
                         for v in range(dim):
                             integral[v, q, kb] += Lia[ka, kb] / self.nkpts
 
-                    value = (
-                        weight * np.dot(tmp, Lia[ka, kb] * f[kb]) * (2 / (np.pi * self.nkpts))
-                    )
+                    value = weight * np.dot(tmp, Lia[ka, kb] * f[kb]) * (2 / (np.pi * self.nkpts))
 
                     integral[0, q, kb] += value
                     if i % 2 == 0 and self.report_quadrature_error:

--- a/momentGW/pbc/rpa.py
+++ b/momentGW/pbc/rpa.py
@@ -56,7 +56,7 @@ class dRPA(dTDA, MoldRPA):
 
     @logging.with_timer("Numerical integration")
     @logging.with_status("Performing numerical integration")
-    def build_zeroth_moment(self):
+    def build_zeroth_dd_moment(self):
         """Optimise the quadrature and perform the integration for a given set of k-points for the
         zeroth moment.
 
@@ -127,7 +127,7 @@ class dRPA(dTDA, MoldRPA):
         if n % 2 == 0:
             if zeroth_mom is None:
                 raise AttributeError(
-                    "0th moment must be provided by build_zeroth_moment for k-point calculations."
+                    "0th moment must be provided by build_zeroth_dd_moment for pbc calculations."
                 )
             if n != 0:
                 tmp = 0.0
@@ -191,7 +191,7 @@ class dRPA(dTDA, MoldRPA):
             self._build_d()
 
         if integral is None:
-            integral = self.build_zeroth_moment()
+            integral = self.build_zeroth_dd_moment()
 
         kpts = self.kpts
         Lia = self.integrals.Lia

--- a/momentGW/pbc/rpa.py
+++ b/momentGW/pbc/rpa.py
@@ -242,7 +242,7 @@ class dRPA(dTDA, MoldRPA):
         """
 
         # Generate the bare quadrature
-        bare_quad = self.gen_ClenCur_quad_semiinf()
+        bare_quad = self.gen_clencur_quad_semiinf()
 
         # Calculate the exact value of the integral for the diagonal
         exact = 0.0

--- a/momentGW/pbc/rpa.py
+++ b/momentGW/pbc/rpa.py
@@ -112,7 +112,7 @@ class dRPA(dTDA, MoldRPA):
             Previous recursion term required to build the next moment. In the case of RPA this is
             the appropriate [(A+B)(A-B)]^(n-2/2) for the nth moment. These are only calculated on
             even moments, odd moments use the previous even moment value.
-        zeroth moment : numpy.ndarray, optional
+        zeroth_mom : numpy.ndarray, optional
             Zeroth moment of the density-density response.
 
         Returns

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -83,7 +83,7 @@ class dTDA(MoldTDA):
         recursion_term : numpy.ndarray, optional
             Previous recursion term required to build the next moment. In the case of TDA this is
             the previous density-density response.
-        zeroth moment : numpy.ndarray, optional
+        zeroth_mom : numpy.ndarray, optional
             Zeroth moment of the density-density response.
 
         Returns

--- a/momentGW/pbc/tda.py
+++ b/momentGW/pbc/tda.py
@@ -53,7 +53,7 @@ class dTDA(MoldTDA):
 
     @logging.with_timer("Zeroth density-density moments")
     @logging.with_status("Constructing zeroth density-density moment")
-    def build_zeroth_moment(self):
+    def build_zeroth_dd_moment(self):
         """Build the zeroth moment of the density-density response for a given set of k-points.
 
         Returns
@@ -100,7 +100,7 @@ class dTDA(MoldTDA):
                 raise AttributeError("Zeroth moment should not have a recursion term")
             if zeroth_mom is None:
                 raise AttributeError(
-                    "0th moment must be provided by build_zeroth_moment for k-point calculations."
+                    "0th moment must be provided by build_zeroth_dd_moment for pbc calculations."
                 )
             else:
                 for kj in self.kpts.loop(1, mpi=True):
@@ -319,7 +319,7 @@ class dTDA(MoldTDA):
             self._build_d()
 
         if moments_dd is None:
-            zeroth_mom = self.build_zeroth_moment()
+            zeroth_mom = self.build_zeroth_dd_moment()
             recursion_term = np.zeros_like(zeroth_mom)
 
         # Get the moments in (aux|aux) and rotate to (mo|mo)

--- a/momentGW/pbc/uhf/tda.py
+++ b/momentGW/pbc/uhf/tda.py
@@ -366,6 +366,7 @@ class dTDA(KdTDA, MolUdTDA):
         return tuple(moments_occ), tuple(moments_vir)
 
     def Lia(self, kj, kb):
+        """Concatenated spin channels for Lia."""
         return np.concatenate(
             [
                 self.integrals[0].Lia[kj, kb],
@@ -375,6 +376,7 @@ class dTDA(KdTDA, MolUdTDA):
         )
 
     def Lai(self, kj, kb):
+        """Concatenated spin channels for Lai."""
         return np.concatenate(
             [
                 self.integrals[0].Lai[kj, kb],

--- a/momentGW/pbc/uhf/tda.py
+++ b/momentGW/pbc/uhf/tda.py
@@ -74,7 +74,7 @@ class dTDA(KdTDA, MolUdTDA):
         for q in self.kpts.loop(1):
             for kj in self.kpts.loop(1, mpi=True):
                 kb = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[kj]))
-                zeroth_moment[q, kb] += self.Lia(kj, kb) / self.nkpts
+                zeroth_moment[q, kb] += self._Lia(kj, kb) / self.nkpts
 
         return zeroth_moment
 
@@ -115,7 +115,7 @@ class dTDA(KdTDA, MolUdTDA):
                 for kj in self.kpts.loop(1, mpi=True):
                     kb = self.kpts.member(self.kpts.wrap_around(self.kpts[q] + self.kpts[kj]))
                     recursion_term[q, kb] = zeroth_mom[q, kb]
-                    eta_aux += np.dot(recursion_term[q, kb], self.Lia(kj, kb).T.conj())
+                    eta_aux += np.dot(recursion_term[q, kb], self._Lia(kj, kb).T.conj())
         else:
             if recursion_term is None:
                 raise AttributeError(
@@ -126,16 +126,16 @@ class dTDA(KdTDA, MolUdTDA):
             for ki in kpts.loop(1, mpi=True):
                 ka = kpts.member(kpts.wrap_around(kpts[q] + kpts[ki]))
 
-                tmp += np.dot(recursion_term[q, ka], self.Lia(ki, ka).T.conj())
+                tmp += np.dot(recursion_term[q, ka], self._Lia(ki, ka).T.conj())
 
             tmp = mpi_helper.allreduce(tmp)
             tmp /= self.nkpts
             for kj in kpts.loop(1, mpi=True):
                 kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[kj]))
                 recursion_term[q, kb] = recursion_term[q, kb] * self.d[q, kb].ravel()[None]
-                recursion_term[q, kb] += np.dot(tmp, self.Lai(kj, kb).conj())
+                recursion_term[q, kb] += np.dot(tmp, self._Lai(kj, kb).conj())
 
-                eta_aux += np.dot(recursion_term[q, kb], self.Lia(kj, kb).T.conj())
+                eta_aux += np.dot(recursion_term[q, kb], self._Lia(kj, kb).T.conj())
             del tmp
 
         eta_aux = mpi_helper.allreduce(eta_aux)
@@ -336,7 +336,7 @@ class dTDA(KdTDA, MolUdTDA):
                     eta_aux = 0
                     for kj in kpts.loop(1, mpi=True):
                         kb = kpts.member(kpts.wrap_around(kpts[q] + kpts[kj]))
-                        eta_aux += np.dot(moments_dd[q, kb, n], self.Lia(kj, kb).T.conj())
+                        eta_aux += np.dot(moments_dd[q, kb, n], self._Lia(kj, kb).T.conj())
 
                     eta_aux = mpi_helper.allreduce(eta_aux)
                     eta_aux /= self.nkpts
@@ -365,7 +365,7 @@ class dTDA(KdTDA, MolUdTDA):
 
         return tuple(moments_occ), tuple(moments_vir)
 
-    def Lia(self, kj, kb):
+    def _Lia(self, kj, kb):
         """Concatenated spin channels for Lia."""
         return np.concatenate(
             [
@@ -375,7 +375,7 @@ class dTDA(KdTDA, MolUdTDA):
             axis=1,
         )
 
-    def Lai(self, kj, kb):
+    def _Lai(self, kj, kb):
         """Concatenated spin channels for Lai."""
         return np.concatenate(
             [

--- a/momentGW/pbc/uhf/tda.py
+++ b/momentGW/pbc/uhf/tda.py
@@ -62,7 +62,7 @@ class dTDA(KdTDA, MolUdTDA):
 
     @logging.with_timer("Zeroth density-density moments")
     @logging.with_status("Constructing zeroth density-density moment")
-    def build_zeroth_moment(self):
+    def build_zeroth_dd_moment(self):
         """Build the zeroth moment of the density-density response for a given set of k-points.
 
         Returns
@@ -109,7 +109,7 @@ class dTDA(KdTDA, MolUdTDA):
                 raise AttributeError("Zeroth moment should not have a recursion term")
             if zeroth_mom is None:
                 raise AttributeError(
-                    "0th moment must be provided by build_zeroth_moment for k-point calculations."
+                    "0th moment must be provided by build_zeroth_dd_moment for pbc calculations."
                 )
             else:
                 for kj in self.kpts.loop(1, mpi=True):
@@ -322,7 +322,7 @@ class dTDA(KdTDA, MolUdTDA):
             self._build_d()
 
         if moments_dd is None:
-            zeroth_mom = self.build_zeroth_moment()
+            zeroth_mom = self.build_zeroth_dd_moment()
             recursion_term = np.zeros_like(zeroth_mom)
 
         # Get the moments in (aux|aux) and rotate to (mo|mo)

--- a/momentGW/pbc/uhf/tda.py
+++ b/momentGW/pbc/uhf/tda.py
@@ -92,7 +92,7 @@ class dTDA(KdTDA, MolUdTDA):
         recursion_term : numpy.ndarray, optional
             Previous recursion term required to build the next moment. In the case of TDA this is
             the previous density-density response.
-        zeroth moment : numpy.ndarray, optional
+        zeroth_mom : numpy.ndarray, optional
             Zeroth moment of the density-density response.
 
         Returns

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -326,7 +326,7 @@ class dRPA(dTDA):
 
         return integral
 
-    def eval_main_integral(self, quad, d=None, Lia=None):
+    def eval_main_integral(self, quad, d=None, Lia=None, spin=False):
         """Evaluate the main integral.
 
         Parameters
@@ -337,6 +337,9 @@ class dRPA(dTDA):
             The (aux, W occ, W vir) integral array. If `None`, use
             `self.integrals.Lia`. Keyword argument allows for the use of
             this function with `uhf` and `pbc` modules.
+        spin : bool
+            A boolean operator to control whether an extra factor of 2
+            is included to account for the two spin states.
 
         Returns
         -------
@@ -347,6 +350,10 @@ class dRPA(dTDA):
         # Get the integral intermediates
         if d is None:
             d = self.d
+        if spin:
+            spin_factor = 2
+        else:
+            spin_factor = 4
 
         if Lia is None:
             Lia = self.integrals.Lia
@@ -360,7 +367,7 @@ class dRPA(dTDA):
         # Calculate the integral for each point
         for i, (point, weight) in enumerate(zip(*quad)):
             f = d / (d**2 + point**2)
-            q = np.dot(Lia * f[None], Lia.T) * 4.0  # aux^2 o v
+            q = np.dot(Lia * f[None], Lia.T) * spin_factor  # aux^2 o v
             q = mpi_helper.allreduce(q)
             tmp = np.linalg.inv(np.eye(naux) + q) - np.eye(naux)
             del q

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -326,7 +326,7 @@ class dRPA(dTDA):
 
         return integral
 
-    def eval_main_integral(self, quad, Lia=None):
+    def eval_main_integral(self, quad, d=None, Lia=None):
         """Evaluate the main integral.
 
         Parameters
@@ -345,6 +345,9 @@ class dRPA(dTDA):
         """
 
         # Get the integral intermediates
+        if d is None:
+            d = self.d
+
         if Lia is None:
             Lia = self.integrals.Lia
         naux, nov = Lia.shape  # This `nov` is actually self.mpi_size(nov)
@@ -356,7 +359,7 @@ class dRPA(dTDA):
 
         # Calculate the integral for each point
         for i, (point, weight) in enumerate(zip(*quad)):
-            f = self.d / (self.d**2 + point**2)
+            f = d / (d**2 + point**2)
             q = np.dot(Lia * f[None], Lia.T) * 4.0  # aux^2 o v
             q = mpi_helper.allreduce(q)
             tmp = np.linalg.inv(np.eye(naux) + q) - np.eye(naux)

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -326,7 +326,7 @@ class dRPA(dTDA):
 
         return integral
 
-    def eval_main_integral(self, quad, d=None, Lia=None, spin=False):
+    def eval_main_integral(self, quad, d=None, Lia=None):
         """Evaluate the main integral.
 
         Parameters
@@ -337,9 +337,6 @@ class dRPA(dTDA):
             The (aux, W occ, W vir) integral array. If `None`, use
             `self.integrals.Lia`. Keyword argument allows for the use of
             this function with `uhf` and `pbc` modules.
-        spin : bool
-            A boolean operator to control whether an extra factor of 2
-            is included to account for the two spin states.
 
         Returns
         -------
@@ -350,10 +347,6 @@ class dRPA(dTDA):
         # Get the integral intermediates
         if d is None:
             d = self.d
-        if spin:
-            spin_factor = 2
-        else:
-            spin_factor = 4
 
         if Lia is None:
             Lia = self.integrals.Lia
@@ -367,7 +360,7 @@ class dRPA(dTDA):
         # Calculate the integral for each point
         for i, (point, weight) in enumerate(zip(*quad)):
             f = d / (d**2 + point**2)
-            q = np.dot(Lia * f[None], Lia.T) * spin_factor  # aux^2 o v
+            q = np.dot(Lia * f[None], Lia.T) * 4.0  # aux^2 o v
             q = mpi_helper.allreduce(q)
             tmp = np.linalg.inv(np.eye(naux) + q) - np.eye(naux)
             del q

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -326,7 +326,7 @@ class dRPA(dTDA):
 
         return integral
 
-    def eval_main_integral(self, quad, d=None, Lia=None):
+    def eval_main_integral(self, quad, d=None, Lia=None, spin=False):
         """Evaluate the main integral.
 
         Parameters
@@ -337,6 +337,9 @@ class dRPA(dTDA):
             The (aux, W occ, W vir) integral array. If `None`, use
             `self.integrals.Lia`. Keyword argument allows for the use of
             this function with `uhf` and `pbc` modules.
+        spin : bool
+            A boolean operator to control whether an extra factor of 2
+            is included to account for the two spin states.
 
         Returns
         -------
@@ -347,6 +350,11 @@ class dRPA(dTDA):
         # Get the integral intermediates
         if d is None:
             d = self.d
+
+        if spin:
+            spin_factor = 2.0
+        else:
+            spin_factor = 4.0
 
         if Lia is None:
             Lia = self.integrals.Lia
@@ -360,7 +368,7 @@ class dRPA(dTDA):
         # Calculate the integral for each point
         for i, (point, weight) in enumerate(zip(*quad)):
             f = d / (d**2 + point**2)
-            q = np.dot(Lia * f[None], Lia.T) * 4.0  # aux^2 o v
+            q = np.dot(Lia * f[None], Lia.T) * spin_factor  # aux^2 o v
             q = mpi_helper.allreduce(q)
             tmp = np.linalg.inv(np.eye(naux) + q) - np.eye(naux)
             del q

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -394,13 +394,10 @@ class dRPA(dTDA):
         j = np.arange(1, self.gw.npoints + 1)
         tvals = np.pi * j / (self.gw.npoints + 1)
         points = 1.0 / np.tan(tvals / 2) ** 2
-        
         # Vectorize the inner sum computation
         j_mesh, t_mesh = np.meshgrid(j, tvals, indexing='ij')
         jsums = np.sum(np.sin(j_mesh * t_mesh) * (1 - np.cos(j_mesh * np.pi)) / j_mesh, axis=0)
-        
         weights = (4 * np.sin(tvals) / ((self.gw.npoints + 1) * (1 - np.cos(tvals)) ** 2)) * jsums
-        
         return points, weights
 
     def gen_gausslag_quad_semiinf(self):

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -35,7 +35,7 @@ class dRPA(dTDA):
 
     @logging.with_timer("Numerical integration")
     @logging.with_status("Performing numerical integration")
-    def build_zeroth_moment(self, m0=None):
+    def build_zeroth_dd_moment(self, m0=None):
         """Build the zeroth moment by optimising the quadrature and perform the integration for
         the zeroth moment.
 
@@ -103,7 +103,7 @@ class dRPA(dTDA):
         """
         if n % 2 == 0:
             if zeroth_mom is None:
-                zeroth_mom = self.build_zeroth_moment()
+                zeroth_mom = self.build_zeroth_dd_moment()
             if n != 0:
                 tmp = np.dot(self.integrals.Lia * self.d[None], recursion_term) * 4.0
                 tmp = mpi_helper.allreduce(tmp)
@@ -140,7 +140,7 @@ class dRPA(dTDA):
             self._build_d()
 
         if integral is None:
-            integral = self.build_zeroth_moment()
+            integral = self.build_zeroth_dd_moment()
 
         p0, p1 = self.mpi_slice(self.nov)
         moments = np.zeros((self.nmom_max + 1, self.naux, p1 - p0))

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -395,7 +395,7 @@ class dRPA(dTDA):
         tvals = np.pi * j / (self.gw.npoints + 1)
         points = 1.0 / np.tan(tvals / 2) ** 2
         # Vectorize the inner sum computation
-        j_mesh, t_mesh = np.meshgrid(j, tvals, indexing='ij')
+        j_mesh, t_mesh = np.meshgrid(j, tvals, indexing="ij")
         jsums = np.sum(np.sin(j_mesh * t_mesh) * (1 - np.cos(j_mesh * np.pi)) / j_mesh, axis=0)
         weights = (4 * np.sin(tvals) / ((self.gw.npoints + 1) * (1 - np.cos(tvals)) ** 2)) * jsums
         return points, weights

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -244,7 +244,7 @@ class dRPA(dTDA):
         """
 
         # Generate the bare quadrature
-        bare_quad = self.gen_ClenCur_quad_semiinf()
+        bare_quad = self.gen_clencur_quad_semiinf()
 
         # Calculate the exact value of the integral for the diagonal
         exact = np.sum(d * (d * (d + diag_eri)) ** -0.5)
@@ -326,20 +326,24 @@ class dRPA(dTDA):
 
         return integral
 
-    def eval_main_integral(self, quad, d=None, Lia=None, spin=False):
+    def eval_main_integral(self, quad, d=None, Lia=None, include_spin_factor=False):
         """Evaluate the main integral.
 
         Parameters
         ----------
         quad : tuple
             The quadrature points and weights.
-        Lia : numpy.ndarray
+        d : numpy.ndarray, optional
+            Orbital energy differences. If `None`, use `self.d`.
+            Default value is `None`.
+        Lia : numpy.ndarray, optional
             The (aux, W occ, W vir) integral array. If `None`, use
             `self.integrals.Lia`. Keyword argument allows for the use of
             this function with `uhf` and `pbc` modules.
-        spin : bool
-            A boolean operator to control whether an extra factor of 2
-            is included to account for the two spin states.
+        include_spin_factor : bool, optional
+            If `True`, use spin factor of 2 (for unrestricted with combined
+            spin channels). If `False`, use spin factor of 4 (for restricted).
+            Default value is `False`.
 
         Returns
         -------
@@ -351,7 +355,7 @@ class dRPA(dTDA):
         if d is None:
             d = self.d
 
-        if spin:
+        if include_spin_factor:
             spin_factor = 2.0
         else:
             spin_factor = 4.0
@@ -383,24 +387,20 @@ class dRPA(dTDA):
 
         return integral
 
-    def gen_ClenCur_quad_semiinf(self):
+    def gen_clencur_quad_semiinf(self):
         """Generate quadrature points and weights for Clenshaw-Curtis quadrature over semiinfinite
         range (0 to +inf)
         """
-        tvals = [(np.pi * j / (self.gw.npoints + 1)) for j in range(1, self.gw.npoints + 1)]
-        points = np.asarray([1.0 / (np.tan(t / 2) ** 2) for t in tvals])
-        jsums = [
-            sum(
-                [np.sin(j * t) * (1 - np.cos(j * np.pi)) / j for j in range(1, self.gw.npoints + 1)]
-            )
-            for t in tvals
-        ]
-        weights = np.asarray(
-            [
-                1.0 * (4 * np.sin(t) / ((self.gw.npoints + 1) * (1 - np.cos(t)) ** 2)) * s
-                for (t, s) in zip(tvals, jsums)
-            ]
-        )
+        j = np.arange(1, self.gw.npoints + 1)
+        tvals = np.pi * j / (self.gw.npoints + 1)
+        points = 1.0 / np.tan(tvals / 2) ** 2
+        
+        # Vectorize the inner sum computation
+        j_mesh, t_mesh = np.meshgrid(j, tvals, indexing='ij')
+        jsums = np.sum(np.sin(j_mesh * t_mesh) * (1 - np.cos(j_mesh * np.pi)) / j_mesh, axis=0)
+        
+        weights = (4 * np.sin(tvals) / ((self.gw.npoints + 1) * (1 - np.cos(tvals)) ** 2)) * jsums
+        
         return points, weights
 
     def gen_gausslag_quad_semiinf(self):

--- a/momentGW/rpa.py
+++ b/momentGW/rpa.py
@@ -91,7 +91,7 @@ class dRPA(dTDA):
             Previous recursion term required to build the next moment. In the case of RPA this is
             the appropriate [(A+B)(A-B)]^(n-2/2) for the nth moment. These are only calculated on
             even moments, odd moments use the previous even moment value.
-        zeroth moment : numpy.ndarray, optional
+        zeroth_mom : numpy.ndarray, optional
             Zeroth moment of the density-density response.
 
         Returns

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -160,8 +160,8 @@ class dTDA(BaseSE):
         for i in range(1, self.nmom_max + 1):
             moments[i] = moments[i - 1] * self.d[None]
             tmp = np.dot(moments[i - 1], self.integrals.Lia.T)
-            tmp = mpi_helper.allreduce(tmp)
-            moments[i] += np.dot(tmp, self.integrals.Lia) * 2.0
+            tmp = mpi_helper.allreduce(tmp) * 2.0
+            moments[i] += np.dot(tmp, self.integrals.Lia)
             del tmp
 
         return moments
@@ -304,12 +304,11 @@ class dTDA(BaseSE):
 
         if moments_dd is None:
             zeroth_mom = self.build_zeroth_moment(m0=m0)
+            recursion_term = None
 
         # Initialise output moments
         moments_occ = np.zeros((self.nmom_max + 1, self.nmo, self.nmo))
         moments_vir = np.zeros((self.nmom_max + 1, self.nmo, self.nmo))
-
-        recursion_term = None
 
         # Get the moments in (aux|aux) and rotate to (mo|mo)
         for n in range(self.nmom_max + 1):

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -60,6 +60,73 @@ class dTDA(BaseSE):
         else:
             self.compression_tol = None
 
+        self.d = None
+
+    def _build_d(self):
+        """Build the orbital energy differences matrix."""
+        p0, p1 = self.mpi_slice(self.nov)
+        self.d = util.build_1h1p_energies(self.mo_energy_w, self.mo_occ_w).ravel()[p0:p1]
+
+    @logging.with_timer("Zeroth density-density moments")
+    @logging.with_status("Constructing zeroth density-density moment")
+    def build_zeroth_moment(self, m0=None):
+        """Build the zeroth moment of the density-density response.
+
+        Parameters
+        ----------
+        m0 : numpy.ndarray, optional
+            The zeroth moment of the density-density response. If
+            `None`, use `self.integrals.Lia`. This argument allows for
+            custom starting points in the recursion i.e. in optical
+            spectra calculations. Default value is `None`.
+
+        Returns
+        -------
+        zeroth moment : numpy.ndarray
+            Zeroth moment of the density-density response.
+        """
+        return m0 if m0 is not None else self.integrals.Lia
+
+    @logging.with_timer("Nth density-density moments")
+    @logging.with_status("Constructing nth density-density moment")
+    def build_nth_dd_moment(self, n, recursion_term=None, zeroth_mom=None):
+        """Build the nth moment of the density-density response.
+
+        Parameters
+        ----------
+        n : int
+            Moment order to be built.
+        recursion_term : numpy.ndarray, optional
+            Previous recursion term required to build the next moment. In the case of TDA this is
+            the previous density-density response.
+        zeroth moment : numpy.ndarray, optional
+            Zeroth moment of the density-density response.
+
+        Returns
+        -------
+        recursion_term : numpy.ndarray
+            Term required for the next moment. In the case of TDA this is the current
+            density-density response moment.
+        eta_aux : numpy.ndarray
+            The nth density-density response moment in (N_aux,N_aux) form
+        """
+        if recursion_term is None:
+            if n != 0:
+                raise AttributeError(
+                    f"To build the {n}th dd-moment, a recursion_term must be provided"
+                )
+            if zeroth_mom is None:
+                recursion_term = self.build_zeroth_moment()
+            else:
+                recursion_term = zeroth_mom
+        else:
+            tmp = np.dot(recursion_term, self.integrals.Lia.T)  # aux^2 o v
+            tmp = mpi_helper.allreduce(tmp)
+            recursion_term = recursion_term * self.d[None]
+            recursion_term += np.dot(tmp, self.integrals.Lia) * 2.0
+            del tmp
+        return recursion_term, np.dot(recursion_term, self.integrals.Lia.T)  # aux^2 o v
+
     @logging.with_timer("Density-density moments")
     @logging.with_status("Constructing density-density moments")
     def build_dd_moments(self, m0=None):
@@ -78,21 +145,20 @@ class dTDA(BaseSE):
         moments : numpy.ndarray
             Moments of the density-density response.
         """
+        if self.d is None:
+            self._build_d()
 
         # Initialise the moments
         naux = self.naux if m0 is None else m0.shape[0]
         p0, p1 = self.mpi_slice(self.nov)
         moments = np.zeros((self.nmom_max + 1, naux, p1 - p0))
 
-        # Construct energy differences
-        d = util.build_1h1p_energies(self.mo_energy_w, self.mo_occ_w).ravel()[p0:p1]
-
         # Get the zeroth order moment
-        moments[0] = m0 if m0 is not None else self.integrals.Lia
+        moments[0] = self.build_zeroth_moment(m0=m0)
 
         # Get the higher order moments
         for i in range(1, self.nmom_max + 1):
-            moments[i] = moments[i - 1] * d[None]
+            moments[i] = moments[i - 1] * self.d[None]
             tmp = np.dot(moments[i - 1], self.integrals.Lia.T)
             tmp = mpi_helper.allreduce(tmp)
             moments[i] += np.dot(tmp, self.integrals.Lia) * 2.0
@@ -117,12 +183,8 @@ class dTDA(BaseSE):
             Moments of the virtual self-energy.
         """
 
-        # Build the density-density response moments
-        moments_dd = self.build_dd_moments()
-
         # Build the self-energy moments
-        moments_occ, moments_vir = self.build_se_moments(moments_dd)
-
+        moments_occ, moments_vir = self.build_se_moments()
         return moments_occ, moments_vir
 
     @logging.with_timer("Moment convolution")
@@ -181,21 +243,24 @@ class dTDA(BaseSE):
         eta_orders = np.asarray(eta_orders)
 
         for n in range(self.nmom_max + 1):
-            # Get the binomial coefficients
-            fp = scipy.special.binom(n, eta_orders)
-            fh = fp * (-1) ** eta_orders
+            if eta_orders.shape[0] == 1 and eta_orders[0] > n:
+                pass
+            else:
+                # Get the binomial coefficients
+                fp = scipy.special.binom(n, eta_orders)
+                fh = fp * (-1) ** eta_orders
 
-            # Construct the occupied moments for this order
-            if np.any(mo_occ_g[q0:q1] > 0):
-                eo = np.power.outer(mo_energy_g[q0:q1][mo_occ_g[q0:q1] > 0], n - eta_orders)
-                to = util.einsum(f"t,kt,kt{pq}->{pq}", fh, eo, eta[mo_occ_g[q0:q1] > 0])
-                moments_occ[n] += fproc(to)
+                # Construct the occupied moments for this order
+                if np.any(mo_occ_g[q0:q1] > 0):
+                    eo = np.power.outer(mo_energy_g[q0:q1][mo_occ_g[q0:q1] > 0], n - eta_orders)
+                    to = util.einsum(f"t,kt,kt{pq}->{pq}", fh, eo, eta[mo_occ_g[q0:q1] > 0])
+                    moments_occ[n] += fproc(to)
 
-            # Construct the virtual moments for this order
-            if np.any(mo_occ_g[q0:q1] == 0):
-                ev = np.power.outer(mo_energy_g[q0:q1][mo_occ_g[q0:q1] == 0], n - eta_orders)
-                tv = util.einsum(f"t,ct,ct{pq}->{pq}", fp, ev, eta[mo_occ_g[q0:q1] == 0])
-                moments_vir[n] += fproc(tv)
+                # Construct the virtual moments for this order
+                if np.any(mo_occ_g[q0:q1] == 0):
+                    ev = np.power.outer(mo_energy_g[q0:q1][mo_occ_g[q0:q1] == 0], n - eta_orders)
+                    tv = util.einsum(f"t,ct,ct{pq}->{pq}", fp, ev, eta[mo_occ_g[q0:q1] == 0])
+                    moments_vir[n] += fproc(tv)
 
         # Sum over all processes
         moments_occ = mpi_helper.allreduce(moments_occ)
@@ -209,12 +274,12 @@ class dTDA(BaseSE):
 
     @logging.with_timer("Self-energy moments")
     @logging.with_status("Constructing self-energy moments")
-    def build_se_moments(self, moments_dd):
+    def build_se_moments(self, moments_dd=None, m0=None):
         """Build the moments of the self-energy via convolution.
 
         Parameters
         ----------
-        moments_dd : numpy.ndarray
+        moments_dd : numpy.ndarray, optional
             Moments of the density-density response.
 
         Returns
@@ -234,13 +299,24 @@ class dTDA(BaseSE):
             eta = np.zeros((q1 - q0, self.nmo, self.nmo))
             pq, p, q = "pq", "p", "q"
 
+        if self.d is None:
+            self._build_d()
+
+        if moments_dd is None:
+            zeroth_mom = self.build_zeroth_moment(m0=m0)
+
         # Initialise output moments
         moments_occ = np.zeros((self.nmom_max + 1, self.nmo, self.nmo))
         moments_vir = np.zeros((self.nmom_max + 1, self.nmo, self.nmo))
 
+        recursion_term = None
+
         # Get the moments in (aux|aux) and rotate to (mo|mo)
         for n in range(self.nmom_max + 1):
-            eta_aux = np.dot(moments_dd[n], self.integrals.Lia.T)  # aux^2 o v
+            if moments_dd is None:
+                recursion_term, eta_aux = self.build_nth_dd_moment(n, recursion_term, zeroth_mom)
+            else:
+                eta_aux = np.dot(moments_dd[n], self.integrals.Lia.T)  # aux^2 o v
             eta_aux = mpi_helper.allreduce(eta_aux)
             for x in range(q1 - q0):
                 Lp = self.integrals.Lpx[:, :, x]

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -99,7 +99,7 @@ class dTDA(BaseSE):
         recursion_term : numpy.ndarray, optional
             Previous recursion term required to build the next moment. In the case of TDA this is
             the previous density-density response.
-        zeroth moment : numpy.ndarray, optional
+        zeroth_mom : numpy.ndarray, optional
             Zeroth moment of the density-density response.
 
         Returns

--- a/momentGW/tda.py
+++ b/momentGW/tda.py
@@ -69,7 +69,7 @@ class dTDA(BaseSE):
 
     @logging.with_timer("Zeroth density-density moments")
     @logging.with_status("Constructing zeroth density-density moment")
-    def build_zeroth_moment(self, m0=None):
+    def build_zeroth_dd_moment(self, m0=None):
         """Build the zeroth moment of the density-density response.
 
         Parameters
@@ -116,7 +116,7 @@ class dTDA(BaseSE):
                     f"To build the {n}th dd-moment, a recursion_term must be provided"
                 )
             if zeroth_mom is None:
-                recursion_term = self.build_zeroth_moment()
+                recursion_term = self.build_zeroth_dd_moment()
             else:
                 recursion_term = zeroth_mom
         else:
@@ -154,7 +154,7 @@ class dTDA(BaseSE):
         moments = np.zeros((self.nmom_max + 1, naux, p1 - p0))
 
         # Get the zeroth order moment
-        moments[0] = self.build_zeroth_moment(m0=m0)
+        moments[0] = self.build_zeroth_dd_moment(m0=m0)
 
         # Get the higher order moments
         for i in range(1, self.nmom_max + 1):
@@ -303,7 +303,7 @@ class dTDA(BaseSE):
             self._build_d()
 
         if moments_dd is None:
-            zeroth_mom = self.build_zeroth_moment(m0=m0)
+            zeroth_mom = self.build_zeroth_dd_moment(m0=m0)
             recursion_term = None
 
         # Initialise output moments

--- a/momentGW/thc.py
+++ b/momentGW/thc.py
@@ -266,6 +266,30 @@ class dTDA(DFdTDA):
         `gw.mo_occ`.
     """
 
+    def kernel(self, exact=False):
+        """Run the polarizability calculation to compute moments of the self-energy.
+
+        Parameters
+        ----------
+        exact : bool, optional
+            Has no effect and is only present for compatibility with
+            `dRPA`. Default value is `False`.
+
+        Returns
+        -------
+        moments_occ : numpy.ndarray
+            Moments of the occupied self-energy for each spin channel.
+        moments_vir : numpy.ndarray
+            Moments of the virtual self-energy for each spin channel.
+        """
+        # Build the density-density response moments
+        moments_dd = self.build_dd_moments()
+
+        # Build the self-energy moments
+        moments_occ, moments_vir = self.build_se_moments(moments_dd)
+
+        return moments_occ, moments_vir
+
     @logging.with_timer("Density-density moments")
     @logging.with_status("Constructing density-density moments")
     def build_dd_moments(self):

--- a/momentGW/uhf/rpa.py
+++ b/momentGW/uhf/rpa.py
@@ -70,8 +70,8 @@ class dRPA(dTDA, RdRPA):
 
         # Perform the main integral
         integral = (
-            self.eval_main_integral(quad[0], d[0], Lia=self.integrals[0].Lia, spin=True),
-            self.eval_main_integral(quad[1], d[1], Lia=self.integrals[1].Lia, spin=True),
+            self.eval_main_integral(quad[0], d[0], Lia=self.integrals[0].Lia),
+            self.eval_main_integral(quad[1], d[1], Lia=self.integrals[1].Lia),
         )
 
         # Report quadrature errors

--- a/momentGW/uhf/rpa.py
+++ b/momentGW/uhf/rpa.py
@@ -70,8 +70,8 @@ class dRPA(dTDA, RdRPA):
 
         # Perform the main integral
         integral = (
-            self.eval_main_integral(quad[0], d[0], Lia=self.integrals[0].Lia),
-            self.eval_main_integral(quad[1], d[1], Lia=self.integrals[1].Lia),
+            self.eval_main_integral(quad[0], d[0], Lia=self.integrals[0].Lia, spin=True),
+            self.eval_main_integral(quad[1], d[1], Lia=self.integrals[1].Lia, spin=True),
         )
 
         # Report quadrature errors

--- a/momentGW/uhf/rpa.py
+++ b/momentGW/uhf/rpa.py
@@ -112,8 +112,12 @@ class dRPA(dTDA, RdRPA):
             Previous recursion term required to build the next moment. In the case of RPA this is
             the appropriate [(A+B)(A-B)]^(n-2/2) for the nth moment. These are only calculated on
             even moments, odd moments use the previous even moment value.
-        zeroth moment : numpy.ndarray, optional
+        zeroth_mom : numpy.ndarray, optional
             Zeroth moment of the density-density response.
+        Lia : numpy.ndarray, optional
+            Combined (aux, occ, vir) integral array for both spin channels.
+            If `None`, concatenate `self.integrals[0].Lia` and `self.integrals[1].Lia`.
+            Default value is `None`.
 
         Returns
         -------
@@ -152,15 +156,14 @@ class dRPA(dTDA, RdRPA):
 
         Parameters
         ----------
-        integral : tuple of numpy.ndarray, optional
-            Integral array, include the offset part, for each spin
-            channel. If `None`, calculate from scratch. Default value is
-            `None`.
+        integral : numpy.ndarray, optional
+            Zeroth moment integral array combining both spin channels.
+            If `None`, calculate from scratch. Default value is `None`.
 
         Returns
         -------
-        moments : tuple of numpy.ndarray
-            Moments of the density-density response.
+        moments : numpy.ndarray
+            Moments of the density-density response combining both spin channels.
         """
 
         # Construct energy differences

--- a/momentGW/uhf/rpa.py
+++ b/momentGW/uhf/rpa.py
@@ -33,7 +33,7 @@ class dRPA(dTDA, RdRPA):
 
     @logging.with_timer("Numerical integration")
     @logging.with_status("Performing numerical integration")
-    def build_zeroth_moment(self):
+    def build_zeroth_dd_moment(self):
         """Optimise the quadrature and perform the integration.
 
         Returns
@@ -132,7 +132,7 @@ class dRPA(dTDA, RdRPA):
 
         if n % 2 == 0:
             if zeroth_mom is None:
-                zeroth_mom = self.build_zeroth_moment()
+                zeroth_mom = self.build_zeroth_dd_moment()
             if n != 0:
                 tmp = np.dot(Lia * self.d[None], recursion_term) * 2.0
                 tmp = mpi_helper.allreduce(tmp)
@@ -172,7 +172,7 @@ class dRPA(dTDA, RdRPA):
             self._build_d()
 
         if integral is None:
-            integral = self.build_zeroth_moment()
+            integral = self.build_zeroth_dd_moment()
 
         a0, a1 = self.mpi_slice(self.nov[0])
         b0, b1 = self.mpi_slice(self.nov[1])

--- a/momentGW/uhf/rpa.py
+++ b/momentGW/uhf/rpa.py
@@ -73,7 +73,7 @@ class dRPA(dTDA, RdRPA):
         )
 
         quad = self.optimise_main_quad(d, diag_eri, name="Combined ERI")
-        integral = self.eval_main_integral(quad, d, Lia=Lia, spin=True)
+        integral = self.eval_main_integral(quad, d, Lia=Lia, include_spin_factor=True)
 
         # Report quadrature errors
         if self.report_quadrature_error:

--- a/momentGW/uhf/rpa.py
+++ b/momentGW/uhf/rpa.py
@@ -116,6 +116,7 @@ class dRPA(dTDA, RdRPA):
             Zeroth moment of the density-density response.
         Lia : numpy.ndarray, optional
             Combined (aux, occ, vir) integral array for both spin channels.
+            Expected shape is `(naux, nocc_α * nvir_α + nocc_β * nvir_β)`.
             If `None`, concatenate `self.integrals[0].Lia` and `self.integrals[1].Lia`.
             Default value is `None`.
 

--- a/momentGW/uhf/tda.py
+++ b/momentGW/uhf/tda.py
@@ -85,7 +85,13 @@ class dTDA(RdTDA):
         moments_vir : numpy.ndarray
             Moments of the virtual self-energy for each spin channel.
         """
-        return super().kernel(exact=exact)
+        # Build the density-density response moments
+        moments_dd = self.build_dd_moments()
+
+        # Build the self-energy moments
+        moments_occ, moments_vir = self.build_se_moments(moments_dd)
+
+        return moments_occ, moments_vir
 
     @logging.with_timer("Moment convolution")
     @logging.with_status("Convoluting moments")

--- a/momentGW/uhf/tda.py
+++ b/momentGW/uhf/tda.py
@@ -73,8 +73,12 @@ class dTDA(RdTDA):
         recursion_term : numpy.ndarray, optional
             Previous recursion term required to build the next moment. In the case of TDA this is
             the previous density-density response.
-        zeroth moment : numpy.ndarray, optional
+        zeroth_mom : numpy.ndarray, optional
             Zeroth moment of the density-density response.
+        Lia : numpy.ndarray, optional
+            Combined (aux, occ, vir) integral array for both spin channels.
+            If `None`, concatenate `self.integrals[0].Lia` and `self.integrals[1].Lia`.
+            Default value is `None`.
 
         Returns
         -------
@@ -111,9 +115,8 @@ class dTDA(RdTDA):
 
         Returns
         -------
-        moments : tuple of numpy.ndarray
-            Moments of the density-density response for each spin
-            channel.
+        moments : numpy.ndarray
+            Moments of the density-density response combining both spin channels.
         """
         # Construct energy differences
         if self.d is None:

--- a/momentGW/uhf/tda.py
+++ b/momentGW/uhf/tda.py
@@ -43,7 +43,7 @@ class dTDA(RdTDA):
 
     @logging.with_timer("Zeroth density-density moments")
     @logging.with_status("Constructing zeroth density-density moment")
-    def build_zeroth_moment(self):
+    def build_zeroth_dd_moment(self):
         """Build the zeroth moment of the density-density response.
 
         Parameters
@@ -98,7 +98,7 @@ class dTDA(RdTDA):
                     f"To build the {n}th dd-moment, a recursion_term must be provided"
                 )
             if zeroth_mom is None:
-                recursion_term = self.build_zeroth_moment()
+                recursion_term = self.build_zeroth_dd_moment()
             else:
                 recursion_term = zeroth_mom
         else:
@@ -129,7 +129,7 @@ class dTDA(RdTDA):
         moments = np.zeros((self.nmom_max + 1, self.naux, (a1 - a0) + (b1 - b0)))
 
         # Get the zeroth order moment
-        moments[0] = self.build_zeroth_moment()
+        moments[0] = self.build_zeroth_dd_moment()
 
         # Get the higher order moments
         for i in range(1, self.nmom_max + 1):
@@ -249,7 +249,7 @@ class dTDA(RdTDA):
         ]
 
         if moments_dd is None:
-            zeroth_mom = self.build_zeroth_moment()
+            zeroth_mom = self.build_zeroth_dd_moment()
             recursion_term = None
 
         # Get the moments in (aux|aux) and rotate to (mo|mo)

--- a/momentGW/uhf/tda.py
+++ b/momentGW/uhf/tda.py
@@ -77,6 +77,7 @@ class dTDA(RdTDA):
             Zeroth moment of the density-density response.
         Lia : numpy.ndarray, optional
             Combined (aux, occ, vir) integral array for both spin channels.
+            Expected shape is `(naux, nocc_α * nvir_α + nocc_β * nvir_β)`.
             If `None`, concatenate `self.integrals[0].Lia` and `self.integrals[1].Lia`.
             Default value is `None`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
         "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
-    "numpy>=1.19.0 <2.4.0",
+    "numpy>=1.19.0,<2.4.0",
     "scipy>=1.9.0",
     "pyscf>2.0.0",
     "rich>=13.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
         "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
-    "numpy>=1.19.0",
+    "numpy>=1.19.0 <2.4.0",
     "scipy>=1.9.0",
     "pyscf>2.0.0",
     "rich>=13.0.0",

--- a/tests/test_evugw.py
+++ b/tests/test_evugw.py
@@ -189,10 +189,10 @@ class Test_evUGW(unittest.TestCase):
         ugw.conv_tol = 1e-8
         conv, gf, se, _ = ugw.kernel(nmom_max=1)
         self.assertTrue(conv)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2825828082, 6)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4759100883, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1897440202, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1920596382, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2830128915, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4759225587, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1899085847, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1913022094, 6)
 
     def test_dtda_regression(self):
         ugw = evUGW(self.mf)
@@ -287,8 +287,8 @@ class Test_evUGW_no_beta(unittest.TestCase):
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2053697398)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5019828956)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2066056869)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5130984694)
 
 
 if __name__ == "__main__":

--- a/tests/test_evugw.py
+++ b/tests/test_evugw.py
@@ -189,10 +189,10 @@ class Test_evUGW(unittest.TestCase):
         ugw.conv_tol = 1e-8
         conv, gf, se, _ = ugw.kernel(nmom_max=1)
         self.assertTrue(conv)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2835255704, 6)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4759355383, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1900941468, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1904171777, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2825828082, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4759100883, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1897440202, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1920596382, 6)
 
     def test_dtda_regression(self):
         ugw = evUGW(self.mf)
@@ -287,8 +287,8 @@ class Test_evUGW_no_beta(unittest.TestCase):
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2015330104)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5130472630)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2053697398)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5019828956)
 
 
 if __name__ == "__main__":

--- a/tests/test_fsugw.py
+++ b/tests/test_fsugw.py
@@ -159,10 +159,10 @@ class Test_fsUGW(unittest.TestCase):
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=3)
         self.assertTrue(conv)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2757015698, 6)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4761722709, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1862852956, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.2014835291, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2764876796, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4765158837, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1865688788, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.2017089856, 6)
 
     def test_dtda_regression(self):
         ugw = fsUGW(self.mf)
@@ -218,6 +218,14 @@ class Test_fsUGW_no_beta(unittest.TestCase):
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
         self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.1978538038)
         self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.4667283798)
+
+    def test_drpa_regression(self):
+        ugw = fsUGW(self.mf)
+        ugw.compression = None
+        ugw.npoints = 128
+        conv, gf, se, _ = ugw.kernel(nmom_max=9)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.1984487509)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.4667656921)
 
 
 if __name__ == "__main__":

--- a/tests/test_fsugw.py
+++ b/tests/test_fsugw.py
@@ -159,10 +159,10 @@ class Test_fsUGW(unittest.TestCase):
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=3)
         self.assertTrue(conv)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2764876796, 6)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4765158837, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1865688788, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.2017089856, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2761532510, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4763582474, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1864490166, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.2016074364, 6)
 
     def test_dtda_regression(self):
         ugw = fsUGW(self.mf)
@@ -224,8 +224,8 @@ class Test_fsUGW_no_beta(unittest.TestCase):
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.1984487509)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.4667656921)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.1981015220)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.4667439156)
 
 
 if __name__ == "__main__":

--- a/tests/test_qsugw.py
+++ b/tests/test_qsugw.py
@@ -117,10 +117,10 @@ class Test_qsUGW(unittest.TestCase):
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=3)
         self.assertTrue(conv)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2818994392, 6)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4757294661, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1916730746, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1841548976, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2807282643, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4769159715, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1913015936, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1880456631, 6)
 
     def test_dtda_regression(self):
         ugw = qsUGW(self.mf)
@@ -182,8 +182,8 @@ class Test_qsUGW_no_beta(unittest.TestCase):
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2028363871)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5121796398)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2053587263)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5016536345)
 
 
 if __name__ == "__main__":

--- a/tests/test_qsugw.py
+++ b/tests/test_qsugw.py
@@ -117,10 +117,10 @@ class Test_qsUGW(unittest.TestCase):
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=3)
         self.assertTrue(conv)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2807282643, 6)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4769159715, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1913015936, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1880456631, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2811686092, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4764955941, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1914878484, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1865863150, 6)
 
     def test_dtda_regression(self):
         ugw = qsUGW(self.mf)
@@ -182,8 +182,8 @@ class Test_qsUGW_no_beta(unittest.TestCase):
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2053587263)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5016536345)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2065905891)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5124750845)
 
 
 if __name__ == "__main__":

--- a/tests/test_scugw.py
+++ b/tests/test_scugw.py
@@ -221,10 +221,10 @@ class Test_scUGW(unittest.TestCase):
         ugw.conv_tol = 1e-8
         conv, gf, se, _ = ugw.kernel(nmom_max=1)
         self.assertTrue(conv)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2810356047, 6)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4752868829, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1880140506, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1909862940, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2813086336, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4752633492, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1880747399, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1901918672, 6)
 
     def test_dtda_regression(self):
         ugw = scUGW(self.mf)
@@ -322,8 +322,8 @@ class Test_scUGW_no_beta(unittest.TestCase):
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2044836061)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5014548428)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2053645500)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5161248341)
 
 
 if __name__ == "__main__":

--- a/tests/test_scugw.py
+++ b/tests/test_scugw.py
@@ -221,10 +221,10 @@ class Test_scUGW(unittest.TestCase):
         ugw.conv_tol = 1e-8
         conv, gf, se, _ = ugw.kernel(nmom_max=1)
         self.assertTrue(conv)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2816255364, 6)
-        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4752488345, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1881409112, 6)
-        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1892747093, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[0][self.mf.mo_occ[0] > 0]), -0.2810356047, 6)
+        self.assertAlmostEqual(np.max(ugw.qp_energy[1][self.mf.mo_occ[1] > 0]), -0.4752868829, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[0][self.mf.mo_occ[0] == 0]), 0.1880140506, 6)
+        self.assertAlmostEqual(np.min(ugw.qp_energy[1][self.mf.mo_occ[1] == 0]), 0.1909862940, 6)
 
     def test_dtda_regression(self):
         ugw = scUGW(self.mf)
@@ -322,8 +322,8 @@ class Test_scUGW_no_beta(unittest.TestCase):
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.1998418470)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5138875709)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2044836061)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5014548428)
 
 
 if __name__ == "__main__":

--- a/tests/test_ugw.py
+++ b/tests/test_ugw.py
@@ -230,22 +230,22 @@ class Test_UGW(unittest.TestCase):
         self.assertAlmostEqual(
             ugw.qp_energy[0][ugw_exact.mo_occ[0] > 0].max(),
             ugw_exact.mo_energy[0][ugw_exact.mo_occ[0] > 0].max(),
-            2,
+            3,
         )
         self.assertAlmostEqual(
             ugw.qp_energy[0][ugw_exact.mo_occ[0] == 0].min(),
             ugw_exact.mo_energy[0][ugw_exact.mo_occ[0] == 0].min(),
-            2,
+            3,
         )
         self.assertAlmostEqual(
             ugw.qp_energy[1][ugw_exact.mo_occ[1] > 0].max(),
             ugw_exact.mo_energy[1][ugw_exact.mo_occ[1] > 0].max(),
-            2,
+            3,
         )
         self.assertAlmostEqual(
             ugw.qp_energy[1][ugw_exact.mo_occ[1] == 0].min(),
             ugw_exact.mo_energy[1][ugw_exact.mo_occ[1] == 0].min(),
-            2,
+            3,
         )
 
 
@@ -297,8 +297,8 @@ class Test_UGW_no_beta(unittest.TestCase):
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2054355461)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5019402315)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2067280266)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5131022208)
 
 
 if __name__ == "__main__":

--- a/tests/test_ugw.py
+++ b/tests/test_ugw.py
@@ -297,8 +297,9 @@ class Test_UGW_no_beta(unittest.TestCase):
         ugw.compression = None
         ugw.npoints = 128
         conv, gf, se, _ = ugw.kernel(nmom_max=9)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2014130154)
-        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5116967415)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[0]), -1.2054355461)
+        self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5019402315)
+
 
 
 if __name__ == "__main__":

--- a/tests/test_ugw.py
+++ b/tests/test_ugw.py
@@ -301,7 +301,6 @@ class Test_UGW_no_beta(unittest.TestCase):
         self.assertAlmostEqual(lib.fp(ugw.qp_energy[1]), -0.5019402315)
 
 
-
 if __name__ == "__main__":
     print("Running tests for UGW")
     unittest.main()


### PR DESCRIPTION
Updated integral for the zeroth moment of RPA calculations.

Changes to the manner in which se_moments are build so that only the required information for the current dd-moment and for future moments is stored. This significantly reduces the memory overhead of mGW calculations.