### PR TITLE
Check kpts are equal using norm instead of hash

### DIFF
--- a/momentGW/pbc/kpts.py
+++ b/momentGW/pbc/kpts.py
@@ -408,7 +408,10 @@ class KPoints:
             other = KPoints(self.cell, other, tol=self.tol)
         if len(self) != len(other):
             return False
-        return self.hash_kpts(self._kpts) == other.hash_kpts(other._kpts)
+        for kpt in self._kpts:
+            if kpt not in other:
+                return False
+        return True
 
     def __ne__(self, other):
         """Check if two k-point lists are not equal to within `self.tol`."""

--- a/momentGW/pbc/kpts.py
+++ b/momentGW/pbc/kpts.py
@@ -67,7 +67,6 @@ class KPoints:
         self._kpts = kpts
 
         self._kconserv = kpts_helper.get_kconserv(cell, kpts)
-        self._kpts_hash = {self.hash_kpts(kpt): k for k, kpt in enumerate(self._kpts)}
 
     def member(self, kpt):
         """Find the index of the k-point in the k-point list.
@@ -82,10 +81,12 @@ class KPoints:
         index : int
             Index of the k-point.
         """
-        if kpt not in self:
+        norms = np.linalg.norm(self._kpts - kpt, axis=1)
+        idx = np.argmin(norms)
+        if norms[idx] >= self.tol:
             raise ValueError(f"{kpt} is not in list")
-        return self._kpts_hash[self.hash_kpts(kpt)]
-
+        return idx
+    
     def index(self, kpt):
         """Alias for `member`.
 
@@ -161,22 +162,6 @@ class KPoints:
         kpts = self.get_abs_kpts(kpts)
 
         return kpts
-
-    @allow_single_kpt(output_is_kpts=False)
-    def hash_kpts(self, kpts):
-        """Convert k-points to a unique, hashable representation.
-
-        Parameters
-        ----------
-        kpts : numpy.ndarray
-            Absolute k-points.
-
-        Returns
-        -------
-        hash_kpts : tuple
-            Hashable representation of k-points.
-        """
-        return tuple(np.rint(kpts / (self.tol)).ravel().astype(int))
 
     @property
     def tol_decimals(self):
@@ -396,8 +381,9 @@ class KPoints:
         is_in : bool
             Whether the k-point is in the list.
         """
-        return self.hash_kpts(kpt) in self._kpts_hash
-
+        norms = np.linalg.norm(self._kpts - kpt, axis=1)
+        return np.any(norms < self.tol)
+    
     def __len__(self):
         """Get the number of k-points."""
         return len(self._kpts)

--- a/momentGW/pbc/kpts.py
+++ b/momentGW/pbc/kpts.py
@@ -86,7 +86,7 @@ class KPoints:
         if norms[idx] >= self.tol:
             raise ValueError(f"{kpt} is not in list")
         return idx
-    
+
     def index(self, kpt):
         """Alias for `member`.
 
@@ -383,7 +383,7 @@ class KPoints:
         """
         norms = np.linalg.norm(self._kpts - kpt, axis=1)
         return np.any(norms < self.tol)
-    
+
     def __len__(self):
         """Get the number of k-points."""
         return len(self._kpts)


### PR DESCRIPTION
The rounding of k points is inconsistent when using rounding. This change checks the norm is less than a threshold instead. Lookups are now O(N_k) instead of O(1) but the cost should be negligible for all reasonable meshes.