### PR TITLE
Fix failing CI lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ ignore = [
     "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-arguments
     "PLR0915",  # too-many-statements
+    "PLR0917",  # too-many-positional-arguments
     "PLR2004",  # magic-value-comparison
     "PLR5501",  # collapsible-else-if
     "PLW2901",  # redefined-loop-name


### PR DESCRIPTION
CI has failed on every run since 24/07/26. `ruff check` reports 20 errors, all `PLR0917` (too-many-positional-arguments), across 13 library files and 7 test files. Nothing in the repository changed — ruff stabilised the rule, and the dev extra tracks `ruff>=0.10.0`, so CI picks up the new release.

`PLR0913` (too-many-arguments) is already ignored, and `PLR0917` is the same check restricted to positional arguments, so ignoring one but not the other was not intentional. This adds it to the ignore list alongside it.

The alternative, making the 20 signatures keyword-only, changes the public API of `FockLoop`, the integral classes and several kernels, which seems disproportionate to a lint rule the project has already opted out of in its keyword-inclusive form.

`ruff check` and `ruff format --check` both pass with ruff 0.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)