### PR TITLE
Take rot[-q] as conj(rot[q]) in the k-point compression metric

### DIFF
--- a/momentGW/pbc/ints.py
+++ b/momentGW/pbc/ints.py
@@ -135,13 +135,26 @@ class KIntegrals(Integrals):
                     # Update the inner product matrix
                     prod[q] += np.dot(Lxy, Lxy.T.conj()) / len(self.kpts)
 
-        # Diagonalise the inner product matrix
+        # Diagonalise the inner product matrix. The metric at -q is the complex
+        # conjugate of the one at q, and `transform` compresses the (L|ia) block
+        # with rot[q] and the (L|ai) block with rot[-q], which `build_dd_moments`
+        # then contracts against each other. That contraction is only correct
+        # when rot[-q] is exactly conj(rot[q]). Diagonalising the two
+        # independently does not give that: the eigenvector sign is arbitrary,
+        # the two matrices agree only to rounding, and LAPACK occasionally
+        # returns opposite signs for a column. Take the conjugate instead.
         rot = np.empty((len(self.kpts),), dtype=object)
         if mpi_helper.rank == 0:
+            done = set()
             for q in self.kpts.loop(1):
+                if q in done:
+                    continue
                 e, v = np.linalg.eigh(prod[q])
                 mask = np.abs(e) > self.compression_tol
                 rot[q] = v[:, mask]
+                invq = self.kpts.member(self.kpts.wrap_around(-self.kpts[q]))
+                rot[invq] = rot[q].conj()
+                done.update((q, invq))
         else:
             for q in self.kpts.loop(1):
                 rot[q] = np.zeros((0,), dtype=complex)

--- a/momentGW/pbc/uhf/ints.py
+++ b/momentGW/pbc/uhf/ints.py
@@ -174,13 +174,23 @@ class KUIntegrals(UIntegrals, KIntegrals):
 
         prod *= 0.5
 
-        # Diagonalise the inner product matrix
+        # Diagonalise the inner product matrix. As in the restricted case, the
+        # metric at -q is the conjugate of the one at q and the two rotations are
+        # contracted against each other via Lia and Lai, so rot[-q] must be
+        # exactly conj(rot[q]) rather than a second, independently signed
+        # decomposition. See `KIntegrals.get_compression_metric`.
         rot = np.empty((len(self.kpts),), dtype=object)
         if mpi_helper.rank == 0:
+            done = set()
             for q in self.kpts.loop(1):
+                if q in done:
+                    continue
                 e, v = np.linalg.eigh(prod[q])
                 mask = np.abs(e) > self.compression_tol
                 rot[q] = v[:, mask]
+                invq = self.kpts.member(self.kpts.wrap_around(-self.kpts[q]))
+                rot[invq] = rot[q].conj()
+                done.update((q, invq))
         else:
             for q in self.kpts.loop(1):
                 rot[q] = np.zeros((0,), dtype=complex)

--- a/tests/test_kgw.py
+++ b/tests/test_kgw.py
@@ -204,6 +204,28 @@ class Test_KGW(unittest.TestCase):
 
         self._test_vs_supercell(gw, kgw)
 
+    def test_compression_metric_conjugate_pairs(self):
+        # `transform` compresses (L|ia) with rot[q] and (L|ai) with rot[-q], and
+        # the density-density recursion contracts the two against each other.
+        # That is only correct if rot[-q] is exactly conj(rot[q]). The metrics at
+        # q and -q are complex conjugates, but they are built by different sums
+        # and so agree only to rounding, and the sign of an eigenvector is
+        # arbitrary -- diagonalising both independently lets LAPACK return
+        # opposite signs for a column, which silently shifts the quasiparticle
+        # energies by ~1e-5 on some runs and not others.
+        kgw = KGW(self.mf)
+        kgw.compression = "ov,oo,vv"
+        kgw.compression_tol = 1e-7
+        integrals = kgw.ao2mo()
+        kpts = kgw.kpts
+
+        rot = integrals._rot
+        self.assertIsNotNone(rot)
+        for q in kpts.loop(1):
+            invq = kpts.member(kpts.wrap_around(-kpts[q]))
+            self.assertEqual(rot[q].shape, rot[invq].shape)
+            np.testing.assert_allclose(rot[invq], rot[q].conj(), atol=1e-12, rtol=0)
+
     def test_dtda_vs_supercell_compression(self):
         nmom_max = 5
 


### PR DESCRIPTION
### Summary

The k-point auxiliary compression diagonalises the metric at `q` and at `-q` independently. It should not: the two matrices are complex conjugates of each other, and the rest of the code assumes their eigenvectors are too.

`transform` compresses the `(L|ia)` block with `rot[q]` and the `(L|ai)` block with `rot[-q]`, and `build_dd_moments` then contracts those two against each other:

```python
tmp += np.dot(moments[q, ka, i - 1], self.integrals.Lia[ki, ka].T.conj())   # rot[q] basis
...
moments[q, kb, i] += np.dot(tmp, self.integrals.Lai[kj, kb].conj())         # rot[-q] basis
```

That contraction is only correct when `rot[-q]` is exactly `conj(rot[q])`. Two independent `eigh` calls do not give that. `prod[q]` and `prod[-q]` are accumulated over different k-point pairs, so they agree only to rounding (measured: 2.1e-15 on a scale of 2.03), and the sign of an eigenvector is arbitrary — LAPACK occasionally returns opposite signs for a column. Those auxiliary directions then enter the density-density recursion with the wrong sign.

This PR diagonalises one of each ±q pair and conjugates for the other. As a side effect the two rotations are now guaranteed to retain the same rank, which independent masking did not.

### How it shows up

As flakiness in `test_dtda_vs_supercell_compression` and `test_drpa_vs_supercell_compression`, which compare KGW against an equivalent supercell GW at `nmom_max=5` with `compression="ov,oo,vv"`, `compression_tol=1e-7`, `atol=1e-5`.

On master, running each test in a fresh process 25 times (macOS, Apple Accelerate, PySCF 2.14.0):

| | agrees with supercell | disagrees |
|---|---|---|
| dTDA | 1.7414e-07 ×22 | **3.1661e-05 ×3** |
| dRPA | 1.4273e-07 ×22 | **2.0666e-05 ×3** |

With this PR, 25/25 processes give 1.7414e-07 and 1.4273e-07 respectively, bit for bit.

The outcome is fixed at process start — deterministic within a process, identical for both polarizabilities in a given process — which is why the tests pass in isolation and fail intermittently in a full run.

The columns that flip are the weakly weighted ones near the compression cutoff, so the error is small rather than obvious. That is what makes it read as a tolerance problem rather than a bug.

### Why it isn't a tolerance problem, rounding, or MO gauge

Worth stating explicitly, since all three are plausible and all three are wrong here:

- **Not the tolerance.** The correct branch agrees with the supercell to 1.4e-7, 70× inside the 1e-5 tolerance. Loosening it would hide a real error.
- **Not rounding.** Perturbing the MO coefficients by a relative 1e-16 through 1e-12 moves the quasiparticle energies by only ~2e-14 — amplification ≤ 1, with and without compression. Nothing here can amplify rounding to 1e-5. Thread count does not decide it either; the branch flips within a fixed `OMP_NUM_THREADS`.
- **Not MO gauge.** The k-point path is invariant to a sign flip or a general complex phase on any MO, at any k, to 7e-14. The supercell side is likewise invariant to rotations within its degenerate blocks to 4e-14, and reproduces across processes to 6.5e-14 — only the k-point side moves.

### Evidence

Bisecting the pipeline across 40 instrumented runs, everything up to the compressed integrals is stable across processes — the density-fitted 3-centre integrals bit-for-bit, and `|rot|`, `rot @ rot†`, `|Lia|`, `|Lai|` and the static self-energy to ~1e-15. The first quantity to fork is the density-density moments (7.6e-3), then the self-energy moments (1.2e-3 relative).

The branch tracked the relative sign of `rot[q]` and `conj(rot[-q])` exactly, 40/40: every agreeing run had all 13 retained columns in phase; every disagreeing run had exactly two columns inverted. Those columns were not degenerate (eigenvalues 3.22e-4 and 4.81e-4, gap 1.6e-4), so this is LAPACK's arbitrary sign convention rather than an arbitrary basis within a degenerate subspace.

### Also fixed

`KUIntegrals.get_compression_metric` carries the same defect — it shares `KIntegrals.transform`, and `pbc/uhf/tda.py` contracts `Lai` the same way — so it gets the same fix.

### Tests

Adds `test_compression_metric_conjugate_pairs`, asserting `rot[-q] == conj(rot[q])`. Note this pins the contract rather than reproducing the flake: on master it would fail only on the ~12% of runs where LAPACK diverges.

Full suite passes (124 tests). `ruff check` reports the same 20 pre-existing errors before and after; `ruff format --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
